### PR TITLE
docs: fix invalid code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ class Greetings extends Model {
       const res = await fetch("http://my.api/hello");
       this.response = await res.text();
     }
-    catch(){
+    catch(e) {
       this.error = true;
     }
   }
@@ -255,10 +255,12 @@ const Parent = () => {
   const state = State.use();
 
   // Instance `state` is now available as its own class `State`
-  <Provider of={state}>
-    <AboutFoo />
-    <AboutBar />
-  </Provider>
+  return (
+    <Provider for={state}>
+      <AboutFoo />
+      <AboutBar />
+    </Provider>
+  )
 }
 
 const AboutFoo = () => {


### PR DESCRIPTION
Fix these issues when running the examples on CodeSandbox:

<img width="1054" alt="Screen Shot 2023-03-28 at 15 27 44" src="https://user-images.githubusercontent.com/24610813/228336659-6b026260-8715-4d06-bf07-568b157b8b0f.png">
<img width="998" alt="Screen Shot 2023-03-28 at 15 28 01" src="https://user-images.githubusercontent.com/24610813/228336666-86f7a727-f601-4d61-805f-8cbc82ee9ffa.png">
<img width="1039" alt="Screen Shot 2023-03-28 at 15 34 27" src="https://user-images.githubusercontent.com/24610813/228336672-47c554c3-df42-4910-8abe-5575ab32ea39.png">
