### PR TITLE
fix(state): make Context.root lazy to avoid module-init cycle crash

### DIFF
--- a/packages/state/src/context.test.ts
+++ b/packages/state/src/context.test.ts
@@ -12,6 +12,11 @@ it('will add instance to context', () => {
   expect(context.get(Example)).toBe(example);
 });
 
+it('will lazily initialize root', () => {
+  expect(Context.root).toBeInstanceOf(Context);
+  expect(typeof Context.root.id).toBe('string');
+});
+
 it('will UID context', () => {
   const contextA = new Context();
   const contextB = new Context();

--- a/packages/state/src/context.ts
+++ b/packages/state/src/context.ts
@@ -2,6 +2,7 @@ import { listener } from "./observable";
 import { event, State, uid } from "./state";
 
 const LOOKUP = new WeakMap<State, Context>();
+let ROOT: Context;
 
 type Accept<T extends State = State> =
   | T
@@ -18,7 +19,9 @@ declare namespace Context {
 }
 
 class Context {
-  static root = new Context();
+  static get root(): Context {
+    return ROOT ??= new Context();
+  }
 
   /** Get the context for a State. Adapters may override to provide framework context. */
   static get(state?: State): Context {
@@ -176,12 +179,12 @@ class Context {
 
       if (!V) continue;
 
-      if (!(State.is(V) || V instanceof State))
+      if (!(State.is(V) || V instanceof State)) {
+        const as = K == "0" || K == String(V) ? V : `${V} (as '${K}')`;
         throw new Error(
-          `Context can only include an instance or class of State but got ${
-            K == "0" || K == String(V) ? V : `${V} (as '${K}')`
-          }.`,
+          `Context can only include an instance or class of State but got ${as}.`,
         );
+      }
 
       const state = State.is(V) ? new (V as State.Type)() : V.is;
       const remove = this.add(state, true);


### PR DESCRIPTION
## Summary
- `Context.root` was eagerly constructed as a static field, which invoked `uid()` from `state.ts` during `context.ts` module evaluation. Under bundlers sensitive to ESM cycle load order (e.g. Bun.serve HTML imports), `uid` resolved to null/undefined and the package crashed at import with `TypeError: Cannot read properties of null (reading 'uid')`.
- Replaced the static field with a lazy getter backed by a module-local `ROOT` so no cross-cycle runtime work happens during module evaluation. `Context.root` is constructed on first access, after both modules have finished initializing.

## Test plan
- [x] `pnpm --filter @expressive/state test` (396 passed)
- [x] Added `will lazily initialize root` case in `context.test.ts` asserting `Context.root` is a `Context` with a defined `id`
- [x] Verify on the reproducing Bun + React consumer that `0.76.0` crash no longer occurs after publishing