### PR TITLE
fix(react): preserve optional render props

### DIFF
--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -344,6 +344,23 @@ describe('render method', () => {
     expect(screen.queryByText('Hello')).toBe(null);
   });
 
+  it('will accept all-optional render props', () => {
+    type ControlProps = {
+      base?: string;
+      children?: React.ReactNode;
+    };
+
+    class Control extends Component {
+      render(props: ControlProps = {}) {
+        return <>{props.base || props.children}</>;
+      }
+    }
+
+    const screen = render(<Control base="home" />);
+
+    screen.getByText('home');
+  });
+
   it('will handle children if managed by this', () => {
     class Control extends Component {
       children = set<React.ReactNode>();

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -16,10 +16,10 @@ export type StateProps<T extends State> = {
   [K in Exclude<keyof T, keyof Component>]?: T[K];
 };
 
-type RenderProps<T> = T extends { render(props: infer P): any }
-  ? {} extends P
-  ? { children?: React.ReactNode }
-  : P
+type RenderProps<T> = [T] extends [(props: infer P) => any]
+  ? [keyof NonNullable<P>] extends [never]
+    ? { children?: React.ReactNode }
+    : NonNullable<P>
   : { children?: React.ReactNode };
 
 interface ComponentProps<T extends Component> {
@@ -32,7 +32,7 @@ interface ComponentProps<T extends Component> {
 
 export type Props<T extends Component> = StateProps<T> &
   ComponentProps<T> &
-  RenderProps<T>;
+  RenderProps<T['render']>;
 
 declare module '@expressive/state' {
   namespace State {


### PR DESCRIPTION
## Summary

- infer Component render props from the render function type directly
- treat only truly empty render prop objects as the default children-only fallback
- add regression coverage for all-optional render props

Fixes #82.

## Test

- `pnpm --dir packages/react test`