### PR TITLE
Fix self lookup in State.get

### DIFF
--- a/packages/state/src/context.ts
+++ b/packages/state/src/context.ts
@@ -33,7 +33,7 @@ class Context {
   public scope = new Set<Context>();
   public consume = new Map<
     State.Extends,
-    Set<[Expect, boolean | undefined]> | null
+    Set<[Expect, boolean | undefined, State | undefined]> | null
   >();
   public provide = new Map<State.Extends, Set<[State, boolean]> | null>();
 
@@ -58,7 +58,7 @@ class Context {
 
   private register<T extends State>(
     type: State.Extends<T>,
-    value: [Expect<T>, boolean | undefined],
+    value: [Expect<T>, boolean | undefined, State | undefined],
     asConsumer: true,
   ): () => void;
 
@@ -102,6 +102,7 @@ class Context {
     Type: State.Extends<T>,
     arg?: boolean | Expect<T>,
     downstream?: boolean,
+    exclude?: State,
   ) {
     let found: T | null | undefined;
     let priority = false;
@@ -111,6 +112,7 @@ class Context {
       if (!entries) continue;
 
       for (const [state, explicit] of entries) {
+        if (state === exclude) continue;
         if (found === state) continue;
         if (!found || (explicit && !priority)) {
           found = state as T;
@@ -126,7 +128,7 @@ class Context {
             `Did find ${Type} in context, but multiple were defined.`,
           );
       }
-      break;
+      if (found !== undefined) break;
     }
 
     if (typeof arg === "function") {
@@ -135,12 +137,14 @@ class Context {
       if (downstream !== false) {
         this.traverse((ctx) => {
           const has = ctx.provide.get(Type);
-          if (has) for (const x of has) arg(x[0] as T, true);
+          if (has)
+            for (const x of has)
+              if (x[0] !== exclude) arg(x[0] as T, true);
           return has !== undefined;
         });
       }
 
-      return this.register(Type, [arg as Expect, downstream], true);
+      return this.register(Type, [arg as Expect, downstream, exclude], true);
     }
 
     if (found) return found;
@@ -238,8 +242,8 @@ class Context {
         const list = ctx.consume.get(T);
         if (list !== undefined) found = true;
         if (list)
-          for (const [cb, filter] of list)
-            if (filter === downstream || filter == null)
+          for (const [cb, filter, exclude] of list)
+            if (I !== exclude && (filter === downstream || filter == null))
               expects.set(cb, () => {
                 const r = cb(I, downstream);
                 if (r) onDone.add(r);

--- a/packages/state/src/state.test.ts
+++ b/packages/state/src/state.test.ts
@@ -686,6 +686,67 @@ describe('get method', () => {
       expect(child.get(Foo, false)).toBeUndefined();
     });
 
+    it('will not resolve as own instance', () => {
+      const foo = new Foo();
+
+      new Context(foo);
+
+      expect(foo.get(Foo, false)).toBeUndefined();
+      expect(() => foo.get(Foo)).toThrow('Could not find Foo in context.');
+    });
+
+    it('will get same type from parent context', () => {
+      const parent = new Foo();
+      const child = new Foo();
+
+      new Context(parent).push(child);
+
+      expect(child.get(Foo)).toBe(parent);
+    });
+
+    it('will get same type peer without resolving self', () => {
+      const foo = new Foo();
+      const peer = new Foo();
+
+      new Context({ foo, peer });
+
+      expect(foo.get(Foo)).toBe(peer);
+    });
+
+    it('will not call callback with own instance', () => {
+      const foo = new Foo();
+      const callback = vi.fn();
+
+      new Context(foo);
+      foo.get(Foo, callback);
+
+      expect(callback).not.toBeCalled();
+    });
+
+    it('will call callback for downstream same type child', () => {
+      const parent = new Foo();
+      const callback = vi.fn();
+      const context = new Context(parent);
+
+      parent.get(Foo, callback);
+
+      const child = new Foo();
+      context.push(child);
+
+      expect(callback).toBeCalledWith(child, true);
+    });
+
+    it('will not call callback for own instance downstream', () => {
+      const foo = new Foo();
+      const callback = vi.fn();
+      const context = new Context(foo);
+
+      context.push(foo);
+      foo.get(Foo, callback);
+
+      expect(callback).not.toBeCalled();
+    });
+
     it('will subscribe with callback', () => {
       const parent = new Foo();
       const ctx = new Context(parent);

--- a/packages/state/src/state.ts
+++ b/packages/state/src/state.ts
@@ -268,7 +268,8 @@ abstract class State {
     const self = this.is;
 
     if (arg1 === undefined) return values(self);
-    if (State.is(arg1)) return Context.get(self).get(arg1, arg2 as any, arg3);
+    if (State.is(arg1))
+      return (Context.get(self).get as any)(arg1, arg2, arg3, self);
     if (typeof arg1 == 'function') return watch(self, unbind(arg1));
     if (typeof arg2 == 'function') return callback(self, arg2, arg1);
     if (arg1 === null) return observer(self) === null;


### PR DESCRIPTION
## Summary

- Make `State#get(Type)` skip the calling instance when resolving context candidates
- Preserve direct `Context#get(Type)` behavior by keeping the skip-self value internal to the State instance method
- Cover same-type self, parent, peer, and callback lookup cases

Resolves #84.

## Tests

- `pnpm --filter @expressive/state test -- --runInBand`
- `pnpm test`