### PR TITLE
Fix omitted component prop clearing

### DIFF
--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -536,6 +536,24 @@ describe('state props on rerender', () => {
 
     screen.getByText('second');
   });
+
+  it('will clear omitted instance value', () => {
+    class Control extends Component {
+      value?: string = 'initial';
+
+      render() {
+        return <span>{this.value || 'empty'}</span>;
+      }
+    }
+
+    const element = render(<Control value="first" />);
+
+    screen.getByText('first');
+
+    element.rerender(<Control />);
+
+    screen.getByText('empty');
+  });
 });
 
 describe('default render', () => {

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -71,8 +71,14 @@ export class Component extends State {
 
   constructor(nextProps: any, ...rest: any[]) {
     const { is, ...props } = nextProps;
+    const seen = {} as Record<string, undefined>;
+    const merge = (props: {}) => {
+      for (const key in props) seen[key] = undefined;
+      return { ...seen, ...props };
+    };
+
     rest = rest.filter((x) => !(x instanceof Context));
-    super(props, rest, is && ((x) => void is(x)), () => {
+    super(merge(props), rest, is && ((x) => void is(x)), () => {
       Object.defineProperty(this, 'props', { enumerable: false });
     });
 
@@ -85,7 +91,7 @@ export class Component extends State {
 
     this.props = nextProps;
     this.set('props', () => {
-      this.set(this.props as {});
+      this.set(merge(this.props) as {});
     });
   }
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -73,14 +73,18 @@ export class Component extends State {
     const { is, ...props } = nextProps;
     const seen = {} as Record<string, undefined>;
     const merge = (props: {}) => {
-      for (const key in props) seen[key] = undefined;
+      for (const k in props) seen[k] = undefined;
       return { ...seen, ...props };
     };
 
-    rest = rest.filter((x) => !(x instanceof Context));
-    super(merge(props), rest, is && ((x) => void is(x)), () => {
-      Object.defineProperty(this, 'props', { enumerable: false });
-    });
+    super(
+      merge(props),
+      rest.filter((x) => !(x instanceof Context)),
+      is && ((x) => void is(x)),
+      () => {
+        Object.defineProperty(this, 'props', { enumerable: false });
+      }
+    );
 
     const existing = PENDING.get(nextProps);
     if (existing) return existing;
@@ -91,7 +95,7 @@ export class Component extends State {
 
     this.props = nextProps;
     this.set('props', () => {
-      this.set(merge(this.props) as {});
+      this.set(merge(this.props));
     });
   }
 


### PR DESCRIPTION
## Summary

- Track component prop keys seen across renders
- Assign omitted previously-seen props as `undefined` before applying incoming props
- Add regression coverage for rerendering from a provided prop to an omitted prop

Fixes #85.

## Tests

- `pnpm --filter @expressive/react test -- component.test.tsx`