### PR TITLE
fix(state): skip self when looking up own type

### DIFF
--- a/packages/state/src/context.ts
+++ b/packages/state/src/context.ts
@@ -98,10 +98,19 @@ class Context {
     downstream?: boolean,
   ): () => void;
 
+  /** Lookup excluding a specific instance (used by State.prototype.get for upstream-of-self semantics). */
+  public get<T extends State>(
+    Type: State.Extends<T>,
+    arg: boolean | Expect<T> | undefined,
+    downstream: boolean | undefined,
+    skip: State,
+  ): T | undefined | (() => void);
+
   public get<T extends State>(
     Type: State.Extends<T>,
     arg?: boolean | Expect<T>,
     downstream?: boolean,
+    skip?: State,
   ) {
     let found: T | null | undefined;
     let priority = false;
@@ -111,7 +120,7 @@ class Context {
       if (!entries) continue;
 
       for (const [state, explicit] of entries) {
-        if (found === state) continue;
+        if (state === skip || found === state) continue;
         if (!found || (explicit && !priority)) {
           found = state as T;
           priority = explicit;
@@ -126,7 +135,7 @@ class Context {
             `Did find ${Type} in context, but multiple were defined.`,
           );
       }
-      break;
+      if (found !== undefined) break;
     }
 
     if (typeof arg === "function") {
@@ -135,7 +144,7 @@ class Context {
       if (downstream !== false) {
         this.traverse((ctx) => {
           const has = ctx.provide.get(Type);
-          if (has) for (const x of has) arg(x[0] as T, true);
+          if (has) for (const x of has) if (x[0] !== skip) arg(x[0] as T, true);
           return has !== undefined;
         });
       }

--- a/packages/state/src/state.test.ts
+++ b/packages/state/src/state.test.ts
@@ -686,6 +686,38 @@ describe('get method', () => {
       expect(child.get(Foo, false)).toBeUndefined();
     });
 
+    it('will skip self when looking up own type', () => {
+      const outer = new Foo();
+      const inner = new Foo();
+
+      new Context(outer).push(inner);
+
+      expect(inner.get(Foo)).toBe(outer);
+      expect(inner.get(Foo, false)).toBe(outer);
+    });
+
+    it('will return undefined when no upstream of own type', () => {
+      const foo = new Foo();
+
+      new Context(foo);
+
+      expect(foo.get(Foo, false)).toBeUndefined();
+      expect(() => foo.get(Foo)).toThrow('Could not find Foo in context.');
+    });
+
+    it('will skip self in callback subscription for own type', () => {
+      const outer = new Foo();
+      const inner = new Foo();
+
+      new Context(outer).push(inner);
+
+      const callback = vi.fn();
+      inner.get(Foo, callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(outer, false);
+    });
+
     it('will subscribe with callback', () => {
       const parent = new Foo();
       const ctx = new Context(parent);

--- a/packages/state/src/state.ts
+++ b/packages/state/src/state.ts
@@ -268,7 +268,7 @@ abstract class State {
     const self = this.is;
 
     if (arg1 === undefined) return values(self);
-    if (State.is(arg1)) return Context.get(self).get(arg1, arg2 as any, arg3);
+    if (State.is(arg1)) return Context.get(self).get(arg1, arg2, arg3, self);
     if (typeof arg1 == 'function') return watch(self, unbind(arg1));
     if (typeof arg2 == 'function') return callback(self, arg2, arg1);
     if (arg1 === null) return observer(self) === null;


### PR DESCRIPTION
## Summary

- `State.prototype.get(Type)` now walks past self's own provide entry instead of returning self, restoring upstream-lookup semantics when the subject is itself an instance of the queried Type.
- Implemented as an internal `skip` argument on `Context.prototype.get` (4th param overload); passed from `state.ts` so the public 3-arg shapes are unchanged.

Closes #84.

## Test plan

- [x] `inner.get(Foo)` returns outer when both are `Foo`
- [x] `inner.get(Foo, false)` returns outer (not undefined, not inner)
- [x] callback form skips self
- [x] root-only case still throws / returns undefined as appropriate
- [x] peer lookup (`foo.get(Bar)` in `new Context({ foo, bar })`) still works