### PR TITLE
docs(react): document ref prop support on Component

### DIFF
--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -71,6 +71,37 @@ it('will call is method on creation', () => {
   act(screen.unmount);
 });
 
+describe('ref prop', () => {
+  it('will populate ref object with instance', () => {
+    class Control extends Component {
+      foo = 'bar';
+    }
+
+    const ref = React.createRef<Control>();
+    const screen = render(<Control ref={ref} />);
+
+    expect(ref.current).toBeInstanceOf(Control);
+    expect(ref.current!.foo).toBe('bar');
+
+    act(screen.unmount);
+    expect(ref.current).toBe(null);
+  });
+
+  it('will invoke callback ref with instance', () => {
+    class Control extends Component {}
+
+    const cb = vi.fn();
+    const screen = render(<Control ref={cb} />);
+
+    expect(cb).toBeCalledTimes(1);
+    expect(cb.mock.calls[0][0]).toBeInstanceOf(Control);
+
+    act(screen.unmount);
+    expect(cb).toBeCalledTimes(2);
+    expect(cb.mock.calls[1][0]).toBe(null);
+  });
+});
+
 describe('new method', () => {
   it('will call if exists', () => {
     const didCreate = vi.fn();

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -129,7 +129,9 @@ class ChatRoom extends Component {
 }
 ```
 
-External code can hold a reference via `is` prop: `<ChatRoom is={c => controller = c} />`.
+External code can hold a reference via `is` prop (construction-time, fires once): `<ChatRoom is={c => controller = c} />`.
+
+Standard React `ref` also works - Component is a real class component, so `ref` receives the instance after mount and clears to `null` on unmount: `<ChatRoom ref={chatRef} />`. Use `is` when you need the instance during construction; use `ref` for post-mount imperative access following React conventions.
 
 ## Props
 
@@ -168,6 +170,7 @@ All props (state + render + special) available on `this.props`.
 ### Special Props
 
 - `is` - callback receiving instance on creation: `<Counter is={c => ref = c} />`
+- `ref` - standard React ref (object or callback), attached after mount, cleared on unmount
 - `fallback` - ReactNode for suspense/error UI, overrides instance property
 
 ## Children and Context


### PR DESCRIPTION
## Summary
- Component already works with the standard React `ref` prop since it's a real class component (`isReactComponent: true`); no implementation changes needed.
- Add tests covering both `React.createRef()` objects and callback refs, including the `null` clear on unmount.
- Update the component skill doc to mention `ref` as a special prop alongside `is`, with a note on when to prefer each (`is` for construction-time, `ref` for post-mount).

## Test plan
- [x] \`pnpm vitest run src/component.test.tsx\` - all 61 tests pass