### PR TITLE
fix(context): clear consume and provide maps on pop

### DIFF
--- a/packages/state/src/context.test.ts
+++ b/packages/state/src/context.test.ts
@@ -238,7 +238,7 @@ it('will clear consume and provide on pop', () => {
   const parent = new Context();
   const child = parent.push();
 
-  // register() seeds null placeholders up the parent chain — these survive
+  // register() seeds null placeholders up the parent chain - these survive
   // child cleanup callbacks and accumulate on long-lived roots without this.
   child.get(Foo, mock());
   child.add(Foo.new());


### PR DESCRIPTION
## Summary

`Context.pop()` now clears the `consume` and `provide` Maps in addition to scope and cleanup. Without this, `register()`'s parent-chain `null` placeholders persist after children pop — accumulating on long-lived contexts (notably `Context.root`) and causing cross-test pollution in single-process test runners.

Closes #93. With this primitive in place, `feature/bun` can add `afterEach(() => Context.root.pop())` to its test setup and unskip the 6 polluted react tests.

## Notes on the issue's other suggestion

The issue also proposed adding `remove()` to the listener at `context.ts:265-269`. Investigation showed that listener is a one-shot init dispatcher (fires on first emit, self-removes via `return null`), not a destroy listener. Root-context destruction cleanup already happens via [state.ts:498](packages/state/src/state.ts#L498) registering `Context.root.add()`'s returned `remove` against the `null` signal.

Adding a separate destroy-filtered listener that calls `remove()` is tempting but breaks two existing tests because `remove()` flushes `onDone`, which contains the unlisten callbacks for consumer destroy listeners (e.g. the cleanup registered by `get(Foo, true, false)`'s callback). Running those on destruction cancels the listeners that should fire to clear consumer-side slots. Left out for now.

## Test plan

- [x] `bun test packages/state packages/react` — 602 pass, 0 fail
- [x] New regression test verifies pop() clears both maps when child consumer/provider seeded null placeholders in parent
- [ ] Manual: rebase `feature/bun`, add `afterEach(() => Context.root.pop())`, unskip the 6 tests, confirm green