### PR TITLE
fix: restore reactive accessors clobbered by subclass class fields under strict mode

### DIFF
--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -653,10 +653,7 @@ describe('error boundary', () => {
     screen.getByText('Recovered');
   });
 
-  // SKIP: React 19 Suspense fallback never paints under bun + happy-dom even
-  // when running this file alone. The library's `catch()` flow triggers a
-  // Suspense throw that doesn't render the fallback under happy-dom scheduling.
-  it.skip('will restore fallback after catch resolves', async () => {
+  it('will restore fallback after catch resolves', async () => {
     let throwing: any = new Error('boom');
     let resolve!: () => void;
     let instance!: Boundary;
@@ -786,8 +783,7 @@ describe('error boundary', () => {
     expect(parentCatch).toBeCalledWith('recovery failed');
   });
 
-  // SKIP: React 19 Suspense fallback never paints under bun + happy-dom.
-  it.skip('will catch new error after successful recovery', async () => {
+  it('will catch new error after successful recovery', async () => {
     let catchCount = 0;
     let shouldThrow = true;
     let resolve!: () => void;
@@ -893,8 +889,7 @@ describe('error boundary', () => {
     screen.getByText('Recovered');
   });
 
-  // SKIP: React 19 Suspense fallback never paints under bun + happy-dom.
-  it.skip('will restore fallback after sync catch', async () => {
+  it('will restore fallback after sync catch', async () => {
     let throwing: any = new Error('boom');
     let instance!: Boundary;
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -5,6 +5,7 @@ import { useHook } from './runtime';
 import { State } from './state';
 
 const PENDING = new WeakMap<object, Component>();
+const SNAPSHOT = new WeakMap<Component, PropertyDescriptorMap>();
 const INTERNAL = [
   'updater',
   'refs',
@@ -87,7 +88,15 @@ export class Component extends State {
     );
 
     const existing = PENDING.get(nextProps);
-    if (existing) return existing;
+    if (existing) {
+      const snap: PropertyDescriptorMap = {};
+      for (const [key] of existing) {
+        const desc = Object.getOwnPropertyDescriptor(existing, key);
+        if (desc && 'get' in desc) snap[key] = desc;
+      }
+      SNAPSHOT.set(existing, snap);
+      return existing;
+    }
     PENDING.set(nextProps, this);
 
     for (const key of INTERNAL)
@@ -199,7 +208,13 @@ function bootstrap(this: Component, context: Context) {
   Object.defineProperties(self, {
     context: {
       get: () => context,
-      set() { }
+      set(this: Component) {
+        const snap = SNAPSHOT.get(this);
+        if (snap) {
+          SNAPSHOT.delete(this);
+          Object.defineProperties(this, snap);
+        }
+      }
     },
     render: {
       value: () => createElement(AsComponent)


### PR DESCRIPTION
## Summary

Fixes #92.

Under React StrictMode's double-construction, subclass class-field initializers replay against the same `Component` instance (via the `PENDING` cache hit) and overwrite the reactive accessor descriptors installed during the first mount's bootstrap. Subsequent mutations bypass the setter, fire no events, and never trigger re-renders.

Hidden under Vitest/esbuild (which emits `this.x = v` plain assignments). Surfaced after migrating to `bun:test`, since bun honors ES2022 class-field spec semantics and emits `Object.defineProperty` regardless of `useDefineForClassFields`.

## Mechanism

```
[component-ctor #1]                       <- first new, class fields applied
[apply -> fallback] INSTALLING accessor   <- bootstrap fires event(state) on first context assignment
[component-ctor #2] existing:true         <- second new, PENDING returns existing
                                          <- subclass class fields replay on existing -> CLOBBER
```

After clobber: `Object.getOwnPropertyDescriptor(existing, 'fallback')` is `{ value, writable, enumerable, configurable }` - the setter is gone.

## Fix

Two synchronous hooks bracket the destruction window:

1. **Capture** ([component.ts:91-99](../blob/fix/strict-mode-class-field-clobber/packages/react/src/component.ts#L91-L99)) - on `PENDING` cache hit, snapshot every own descriptor whose key is in `STORE` (via `State[Symbol.iterator]`) and that's still an accessor. Stored in a `WeakMap<Component, PropertyDescriptorMap>`. At this point the replay hasn't happened yet, so the original accessors are intact.

2. **Repair** ([component.ts:211-217](../blob/fix/strict-mode-class-field-clobber/packages/react/src/component.ts#L211-L217)) - the instance-level `context` setter (previously a no-op) now reads the snapshot and re-applies the descriptors verbatim via `Object.defineProperties`. React fires this setter synchronously after the second construction completes - before `render` is called. Verified empirically.

Why descriptors verbatim rather than re-calling `apply()`: preserves the exact original configuration including `set: false` from read-only `set()` instructions, custom setter functions from `set(value, onUpdate)` callbacks, original `enumerable`, etc.

## Why not a microtask?

Considered and rejected - reactivity must be in place synchronously before React calls `render`, which happens in the same task as the constructor. The `context` reassignment turns out to be the right hook: it fires after class-field replay, before render.

## Test changes

- Unskipped three previously-failing tests in `packages/react/src/component.test.tsx`:
  - `error boundary > will restore fallback after catch resolves`
  - `error boundary > will catch new error after successful recovery`
  - `error boundary > will restore fallback after sync catch`
- Removed misattributed skip comments blaming happy-dom Suspense scheduling.

## Test plan

- [x] Three previously-skipped error-boundary tests pass.
- [x] `bun test packages/react/src/component.test.tsx` - 59 pass, 0 fail.
- [x] `bun test packages/react` - 168 pass, 0 fail.
- [x] `bun test packages/state` - 443 pass, 0 fail.
- [x] `bun test` (entire repo) - 643 pass, 0 fail.
- [ ] Manual: nested subclass hierarchy with mixed class-field overrides under StrictMode.