### PR TITLE
refactor(state): drop duplicate get(key, callback) overload

### DIFF
--- a/packages/solid/src/state.ts
+++ b/packages/solid/src/state.ts
@@ -29,7 +29,6 @@ declare namespace SolidState {
   export import Value = State.Value;
   export import Setter = State.Setter;
   export import OnEvent = State.OnEvent;
-  export import OnUpdate = State.OnUpdate;
   export import Values = State.Values;
   export import Partial = State.Partial;
   export import Ref = State.Ref;

--- a/packages/state/src/state.test.ts
+++ b/packages/state/src/state.test.ts
@@ -745,46 +745,6 @@ describe('get method', () => {
     });
   });
 
-  describe('callback', () => {
-    class Test extends State {
-      foo = 'foo';
-    }
-
-    it('will call callback on update', async () => {
-      const test = Test.new();
-      const done = mock();
-      const cb = mock(() => done);
-
-      test.get('foo', cb);
-
-      expect(cb).toBeCalledTimes(0);
-
-      test.foo = 'bar';
-      test.foo = 'baz';
-
-      expect(cb).toBeCalledTimes(2);
-      expect(cb).toBeCalledWith('foo', test);
-
-      await expect(test).toHaveUpdated('foo');
-
-      expect(done).toBeCalledTimes(1);
-    });
-
-    it('will call on event', async () => {
-      const test = Test.new();
-      const cb = mock();
-
-      test.get('baz', cb);
-
-      expect(cb).not.toBeCalled();
-
-      // dispatch explicit event
-      test.set('baz');
-
-      expect(cb).toBeCalledWith('baz', test);
-    });
-  });
-
   describe('null', () => {
     class Test extends State {}
 
@@ -1857,6 +1817,48 @@ describe('set method', () => {
 
       test.bar = 'baz';
       expect(didUpdateFoo).toBeCalledTimes(2);
+    });
+
+    it('will run returned function once on settle', async () => {
+      class Test extends State {
+        foo = 'foo';
+      }
+
+      const test = Test.new();
+      const done = mock();
+      const cb = mock(() => done);
+
+      test.set('foo', cb);
+
+      expect(cb).toBeCalledTimes(0);
+
+      test.foo = 'bar';
+      test.foo = 'baz';
+
+      expect(cb).toBeCalledTimes(2);
+      expect(cb).toBeCalledWith('foo', test);
+
+      await expect(test).toHaveUpdated('foo');
+
+      expect(done).toBeCalledTimes(1);
+    });
+
+    it('will call on explicit event', async () => {
+      class Test extends State {
+        foo = 'foo';
+      }
+
+      const test = Test.new();
+      const cb = mock();
+
+      test.set('baz', cb);
+
+      expect(cb).not.toBeCalled();
+
+      // dispatch explicit event
+      test.set('baz');
+
+      expect(cb).toBeCalledWith('baz', test);
     });
 
     it('will unsubscribe if returns null', async () => {

--- a/packages/state/src/state.ts
+++ b/packages/state/src/state.ts
@@ -114,12 +114,6 @@ declare namespace State {
     source: T
   ) => void | (() => void) | null;
 
-  type OnUpdate<T extends State, K extends State.Event<T>> = (
-    this: T,
-    key: K,
-    thisArg: K
-  ) => void;
-
   /** Exotic value, where actual value is contained within. */
   type Ref<T = any> = {
     (next: T): void;
@@ -209,21 +203,6 @@ abstract class State {
   ): State.Value<this, T>;
 
   /**
-   * Run a function when a property is updated and has settled.
-   *
-   * Not to be confused with `set(event, callback)`, which runs on every update,
-   * even if value is the same, and before updates are settled.
-   *
-   * @param key - Property to watch for updates.
-   * @param callback - Function to call when property is updated.
-   * @returns Function to cancel listener.
-   */
-  get<T extends State.Event<this>>(
-    key: T,
-    callback: State.OnUpdate<this, T>
-  ): () => void;
-
-  /**
    * Check if state is destroyed.
    *
    * @param status - `null` to check if state is destroyed.
@@ -266,7 +245,7 @@ abstract class State {
 
   get(
     arg1?: State.Effect<this> | State.Type | string | null,
-    arg2?: boolean | Context.Expect | State.OnUpdate<this, any>,
+    arg2?: boolean | Context.Expect | (() => void),
     arg3?: boolean
   ) {
     const self = this.is;
@@ -450,7 +429,7 @@ define(State, 'toString', {
   }
 });
 
-/** Register a user OnEvent/OnUpdate callback, preserving `this` and `source`. */
+/** Register a user OnEvent callback, preserving `this` and `source`. */
 function callback<T extends State>(
   self: T,
   cb: Function,

--- a/skills/state/get.md
+++ b/skills/state/get.md
@@ -75,27 +75,7 @@ If the effect throws a Promise (e.g., accessing an unset `set<T>()` property), t
 **Before ready:**
 Effects registered in constructors wait for activation before first run.
 
-### Watch single property
-
-```ts
-get<T extends State.Event<this>>(key: T, callback: State.OnUpdate<this, T>): () => void
-```
-
-Callback fires on every assignment to `key` that changes the value, and on explicit `set(key)` dispatches. Fires synchronously on each assignment (before flush). If callback returns a function, that function is called once when the batch settles.
-
-```ts
-const stop = state.get('count', (key, source) => {
-  console.log('count changed:', source.count);
-});
-```
-
-Also works for custom events:
-
-```ts
-state.get('myEvent', (key, source) => {
-  console.log('custom event fired');
-});
-```
+To watch a specific property or event, use [`set(event, callback)`](set.md).
 
 ### Check destroyed
 
@@ -165,6 +145,4 @@ type Effect<T> = (
 ) => EffectCallback | Promise<void> | null | void;
 
 type EffectCallback = (update: boolean | null) => void;
-
-type OnUpdate<T, K> = (this: T, key: K, thisArg: K) => void;
 ```


### PR DESCRIPTION
## Summary

`State.get(key, callback)` and `State.set(event, callback)` had **identical implementations** - both route to the same internal `callback()` helper. The source doc claimed `get(key, callback)` ran "when settled" while `set` ran "on every update," but the implementations were the same, so the distinction was fictional (the docs in `skills/state/get.md` even described `get(key, callback)` as firing on every assignment, before flush).

This consolidates event listening under `set()`, which is the natural home:
- `set` is the dispatch/event side of the API, where `set(callback)` (listen-all) already lives; `set(event, callback)` is its natural narrowing.
- `set` can target arbitrary events (symbols, `"!event"`, `"my-event"`) that aren't real properties - listening via `get` is incoherent since there's no value to "get". (The removed `get('baz', cb)` test relied on exactly this.)
- The "run on settle" use case is already expressible via `set` returning a function from its callback.

## Changes

- **`packages/state/src/state.ts`** - removed the `get(key, callback)` overload signature and the orphaned `State.OnUpdate` type; narrowed the `get` impl `arg2` type to `(() => void)` (still serves the `get(null, callback)` destroy listener, which shares the same impl branch).
- **`packages/solid/src/state.ts`** - removed the dead `OnUpdate` re-export.
- **`packages/state/src/state.test.ts`** - migrated the two `get(key, callback)` tests (returns-function-settles, custom event) into `set`'s `listener` describe.
- **`skills/state/get.md`** - removed the "Watch single property" section and `OnUpdate` type signature; points to `set(event, callback)`.

## Verification

- `tsc --noEmit` clean for state, react, preact.
- Tests pass: state 443, react 170.
- solid's only `tsc` error is a pre-existing, unrelated `use` export issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)