### PR TITLE
Add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Mirrors the .devcontainer setup (postCreateCommand: bun install) so that
+# tests, type-checks, and builds work in remote cloud sessions.
+set -euo pipefail
+
+# Only run in the remote (web) environment; local sessions use the devcontainer.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Bun workspaces + lerna monorepo. A single root install hydrates every package.
+# `bun install` (not `--frozen-lockfile`/ci) plays nicely with the cached
+# container state and stays idempotent across re-runs.
+bun install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Mirror the .devcontainer setup (bun install) so dependencies are
installed in remote cloud sessions, enabling tests, type-checks, and
builds to run. Guarded to the remote environment via CLAUDE_CODE_REMOTE.

https://claude.ai/code/session_01TVMMdstpXqu5dFde5LUU5T