### PR TITLE
Restore 100% test coverage enforcement

### DIFF
--- a/packages/mvc/bunfig.toml
+++ b/packages/mvc/bunfig.toml
@@ -1,2 +1,6 @@
 [test]
 preload = ["./test.setup.ts"]
+coverage = true
+coverageSkipTestFiles = true
+coverageThreshold = 1.0
+coveragePathIgnorePatterns = ["**/test.setup.ts", "**/src/component.ts"]

--- a/packages/mvc/bunfig.toml
+++ b/packages/mvc/bunfig.toml
@@ -3,4 +3,4 @@ preload = ["./test.setup.ts"]
 coverage = true
 coverageSkipTestFiles = true
 coverageThreshold = 1.0
-coveragePathIgnorePatterns = ["**/test.setup.ts", "**/src/component.ts"]
+coveragePathIgnorePatterns = ["**/test.setup.ts"]

--- a/packages/mvc/package.json
+++ b/packages/mvc/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "test": "tsc --noEmit && bun test --coverage",
+    "test": "tsc --noEmit && bun test --coverage --only-failures",
     "preversion": "npm run test && npm run build"
   },
   "devDependencies": {

--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -1,0 +1,96 @@
+import { expect, it, mock } from 'bun:test';
+import { Component } from './component';
+import { Context } from './context';
+
+it('will default fallback to null', () => {
+  const foo = Component.new({});
+
+  expect(foo.fallback).toBe(null);
+});
+
+it('will accept fallback as prop', () => {
+  const foo = Component.new({ fallback: 'Loading' });
+
+  expect(foo.fallback).toBe('Loading');
+});
+
+it('will render children by default', () => {
+  const foo = Component.new({ children: 'hello' });
+
+  expect(foo.render()).toBe('hello');
+});
+
+it('will render null without children', () => {
+  const foo = Component.new({});
+
+  expect(foo.render()).toBe(null);
+});
+
+it('will call is callback once with instance', () => {
+  const is = mock();
+  const foo = Component.new({ is });
+
+  expect(is).toBeCalledWith(foo);
+  expect(is).toHaveBeenCalledTimes(1);
+
+  // ressigning props from another render.
+  (foo as any).props = { is };
+
+  expect(is).toHaveBeenCalledTimes(1);
+});
+
+it('will merge state when props reassigned', async () => {
+  class Foo extends Component {
+    value?: number = 10;
+    other?: number = 1;
+  }
+
+  const foo = Foo.new({ value: 5, other: 2 });
+
+  expect(foo.value).toBe(5);
+  expect(foo.other).toBe(2);
+
+  (foo as any).props = { value: 7 };
+  await foo.set();
+
+  expect(foo.value).toBe(7);
+});
+
+it('will reset omitted props on reassignment', async () => {
+  class Foo extends Component {
+    value?: number = 10;
+    other?: number = 1;
+  }
+
+  const foo = Foo.new({ value: 5, other: 2 });
+
+  (foo as any).props = { value: 7 };
+  await foo.set();
+
+  expect(foo.other).toBeUndefined();
+});
+
+// Seam: React may instantiate the class twice with the same props object
+// (e.g. StrictMode / reconciliation) before init completes. The second
+// construction must return the first instance, not a duplicate.
+it('will dedupe construction by props object', () => {
+  const props = { value: 1 };
+
+  const a = new Component(props);
+  const b = new Component(props);
+
+  expect(b).toBe(a);
+});
+
+// Seam: React passes context as a constructor argument alongside props.
+// Context instances must be filtered so they never apply as state overlays.
+it('will ignore Context passed as constructor argument', () => {
+  class Foo extends Component {
+    value?: number = 10;
+  }
+
+  const foo = Foo.new({ value: 5 }, new Context() as any);
+
+  expect(foo.value).toBe(5);
+  expect(Object.keys(foo.get())).not.toContain('0');
+});

--- a/packages/react/bunfig.toml
+++ b/packages/react/bunfig.toml
@@ -1,2 +1,6 @@
 [test]
 preload = ["./test.dom.ts", "./test.setup.ts"]
+coverage = true
+coverageSkipTestFiles = true
+coverageThreshold = 1.0
+coveragePathIgnorePatterns = ["**/mvc/**", "**/test.setup.ts", "**/test.dom.ts"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "test": "tsc --noEmit && bun test --coverage",
+    "test": "tsc --noEmit && bun test --coverage --only-failures",
     "preversion": "npm run test && npm run build"
   },
   "dependencies": {

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -152,6 +152,10 @@ class ErrorBoundary extends React.Component<{
   state = {} as { error?: Error };
   recovering = false;
 
+  constructor(props: ErrorBoundary['props']) {
+    super(props);
+  }
+
   static getDerivedStateFromError(error: Error) {
     return { error };
   }


### PR DESCRIPTION
Enforces 100% test coverage on the `mvc` and `react` packages, scoped to each package's own source.

## Changes
- **Enforce 100% coverage** (`7c410a94`): each package's `bunfig.toml` enables `coverage`, sets `coverageThreshold = 1.0`, skips test files, and ignores cross-package (`../mvc`) and setup files so the report and gate cover only the package's own `src`.
- **ErrorBoundary constructor** (`28a9d3ea`): react's `ErrorBoundary` used only class-field initializers, so its synthesized constructor was counted-but-uncovered by bun. Added an explicit `super(props)` so bun tracks it. Behavior unchanged; already exercised by existing tests.
- **Quieter output** (`eed717a4`): `test` scripts use `--only-failures` to drop the passing-test list (coverage table + summary still shown).
- **mvc Component tests** (`aba9e316`): new agnostic tests covering built-in Component behavior (props→state, fallback, render/children defaults, `is` callback, props re-merge) and the seams React leverages (same-props construction dedupe, Context arg filtering). Removes the temporary `component.ts` coverage exclusion now that it's tested natively.

## Result
Both packages pass `tsc --noEmit && bun test` at 100%/100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)