### PR TITLE
fix(react): defer pre-commit subscription updates in useHook

### DIFF
--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, expect, it, mock } from 'bun:test';
+
+import { Runtime, useHook } from './runtime';
+
+// useHook calls useRef, useState, useEffect once each per render. Stub Runtime
+// with a hand-driven lifecycle so a subscription update can fire before vs.
+// after commit, and watch whether the React setter actually runs.
+function harness() {
+  const ref = { current: undefined as any };
+  let inited = false;
+  let state = 0;
+  let effect: () => (() => void) | void;
+  let refresh: (next?: any) => void;
+  const unmount = mock();
+
+  // Apply the updater like React would, so the `(x) => x + 1` path is exercised.
+  const update = mock((fn: (prev: number) => number) => void (state = fn(state)));
+
+  Runtime.useRef = ((value: any) => {
+    if (ref.current === undefined) ref.current = value;
+    return ref;
+  }) as typeof Runtime.useRef;
+
+  Runtime.useState = ((value: any) => {
+    if (!inited) {
+      inited = true;
+      if (typeof value === 'function') value(); // run initializer (subscribes)
+    }
+    return [state, update];
+  }) as typeof Runtime.useState;
+
+  Runtime.useEffect = ((fn: any) => void (effect = fn)) as typeof Runtime.useEffect;
+
+  let cleanup: (() => void) | void;
+
+  return {
+    update,
+    unmount,
+    render: () => useHook((r) => ((refresh = r), unmount)),
+    commit: () => void (cleanup = effect()),
+    unwind: () => cleanup && cleanup(),
+    refresh: (next?: any) => refresh(next)
+  };
+}
+
+let saved: Partial<typeof Runtime>;
+beforeEach(() => void (saved = { ...Runtime }));
+afterEach(() => void Object.assign(Runtime, saved));
+
+it('does not call the setter before commit', () => {
+  const { update, render, refresh } = harness();
+
+  render();
+  refresh('early'); // e.g. a sibling mutating shared state during render
+
+  expect(update).not.toHaveBeenCalled();
+});
+
+it('coalesces deferred refreshes into a single flush on commit', () => {
+  const { update, render, commit, refresh } = harness();
+
+  render();
+  refresh('a');
+  refresh('b');
+  expect(update).not.toHaveBeenCalled();
+
+  commit();
+  expect(update).toHaveBeenCalledTimes(1);
+});
+
+it('refreshes immediately for updates after commit', () => {
+  const { update, render, commit, refresh } = harness();
+
+  render();
+  commit();
+  update.mockClear();
+
+  refresh('later');
+  expect(update).toHaveBeenCalledTimes(1);
+});
+
+it('runs the callback cleanup on unmount', () => {
+  const { render, commit, unwind, unmount } = harness();
+
+  render();
+  commit();
+  expect(unmount).not.toHaveBeenCalled();
+
+  unwind();
+  expect(unmount).toHaveBeenCalledTimes(1);
+});

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -24,26 +24,36 @@ export function useHook<T = void>(
   callback: (refresh: (next: T) => void) => () => void
 ) {
   const { current } = Runtime.useRef(
-    { mounted: 0 } as {
-      mounted: number;
+    { rendered: 0 } as {
+      rendered: number;
+      mounted?: boolean;
+      pending?: boolean;
       unmount: () => void;
-      update: (next: (previous: number) => number) => void;
+      update?: (next: (previous: number) => number) => void;
       output: T;
     }
   );
 
   current.update = Runtime.useState(() => {
-    if (!current.mounted)
+    if (!current.rendered)
       current.unmount = callback((next) => {
         current.output = next;
-        current.update?.((x) => x + 1);
+        if (current.mounted) current.update?.((x) => x + 1);
+        else if (current.update) current.pending = true;
       });
 
-    return current.mounted++;
+    return current.rendered++;
   })[1];
 
-  Runtime.useEffect(() => () => {
-    if (--current.mounted < 1) current.unmount();
+  Runtime.useEffect(() => {
+    current.mounted = true;
+    if (current.pending) {
+      current.pending = false;
+      current.update!((x) => x + 1);
+    }
+    return () => {
+      if (--current.rendered < 1) current.unmount();
+    }
   }, []);
 
   return current.output;


### PR DESCRIPTION
## Summary

A subscription update that arrives **after a fiber has subscribed but before it has committed** was calling `setState` during the render phase, tripping React's dev warning:

> Can't perform a React state update on a component that hasn't mounted yet. This indicates that you have a side-effect in your render function that asynchronously tries to update the component.

`useHook` now defers such pre-commit updates to the commit effect instead of firing them mid-render.

## How it surfaced

Building a `Route.redirect` for the router: a matched redirect Route renders a `<Redirect>` whose `goto()` runs on mount. `goto()` mutates shared `Router.path` **during the render phase**, and an already-subscribed sibling (another Route reading `path` via its `match` computed) tried to refresh before React had committed it → the warning.

It's not redirect-specific. Any state mutated during one component's render, observed by a sibling that has subscribed in the same pass but not yet committed, hits it. The redirect was just the first trigger.

## Why it's subtle

- The window is narrow: subscribed (so a notify reaches it) but not committed (so `setState` is illegal). Outside that window everything is fine.
- It only manifests under `createRoot` in a real browser. In testing-library, `act()` batches the mid-render update so the warning never fires - which is why no existing unit test caught it, and why the regression test (below) drives the hook lifecycle directly instead of rendering.

## The fix

`useHook` distinguishes lifecycle phases via the ref it already keeps:

- **During the `useState` initializer** (`update` still unassigned): the initial synchronous subscribe is ignored, unchanged from before.
- **After init, before commit**: a change sets a `pending` flag instead of calling `setState`.
- **At commit**: the effect flips `mounted`, then flushes a single coalesced refresh if anything was pending.
- **After commit**: refreshes fire immediately, unchanged.

The mount counter stays in the `useState` initializer, which React **double-invokes under StrictMode** - that double-increment is what balances StrictMode's single intermediate effect-cleanup, so StrictMode subscription survival is unchanged. (An earlier attempt that moved setup into a `if (!ref.current)` body guard broke exactly this and is deliberately avoided.)

## Testing

Adds `packages/react/src/runtime.test.ts`. Because `act()` masks the warning, these tests stub `Runtime` with a hand-driven hook lifecycle and assert the behavior directly:

- no setter call before commit,
- one coalesced flush on commit (regardless of how many pre-commit changes arrived),
- immediate refresh after commit,
- callback cleanup on unmount.

Verified gate-sensitive: the two defer tests go red if the gate is removed. `runtime.ts` is at 100% line + function coverage. Full `@expressive/react` suite: 181 pass, 0 fail. Also verified end-to-end in a browser (the original redirect scenario): warning gone on both mount and post-mount redirects, correct navigation, no regressions.