### PR TITLE
Compose render() up the prototype chain (validation spike)

### DIFF
--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -128,7 +128,8 @@ class Component extends State {
    * Without a parameter, children are accepted by default and passed through provider.
    */
   render(props?: {}): Component.Node {
-    return this.props.children || null;
+    const { children } = (props || this.props) as { children?: Component.Node };
+    return children || null;
   }
 
   /**

--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -1,8 +1,11 @@
 import { Context } from './context';
 import { set } from './field/set';
-import { State } from './state';
+import { State, unbind } from './state';
 
 const PENDING = new WeakMap<object, Component>();
+
+/** Per-class chain of `render` methods, leaf-first up to and including Component. */
+const CHAIN = new WeakMap<Function, Function[]>();
 
 declare namespace Component {
   /**
@@ -99,6 +102,19 @@ class Component extends State {
     this.set('props', () => {
       this.set(merge(this.props));
     });
+
+    // Resolve `render` as a composition up the prototype chain (leaf-first):
+    // each level's output becomes its super's `children`, so a base class
+    // wraps a subclass's content without the subclass calling super.render().
+    // Installed as an own property so `this.render` *is* the composed chain;
+    // adapters and direct callers invoke it like an ordinary render. (An
+    // instance-field `render = fn` initializes after this and shadows it -
+    // composition is bypassed; treat multi-level field render as unsupported.)
+    Object.defineProperty(this, 'render', {
+      configurable: true,
+      writable: true,
+      value: compose(this)
+    });
   }
 
   /**
@@ -142,6 +158,55 @@ class Component extends State {
    * assign a fallback within catch, it will be reverted after resolved.
    */
   catch?(error: Error): Promise<void> | void;
+}
+
+/**
+ * Build the composed render for an instance. Walks the prototype chain
+ * (leaf-first, up to and including Component), collecting each level's own
+ * `render`, then returns a function that threads each level's output into its
+ * super as `children`. All levels are called with the receiver as `this`, so
+ * an adapter's reactive proxy applies uniformly across the chain.
+ */
+function compose(instance: Component) {
+  const type = instance.constructor;
+
+  let chain = CHAIN.get(type);
+
+  if (!chain) {
+    chain = [];
+
+    // Start at the prototype - an instance-field render is handled by shadowing.
+    let level: object = Object.getPrototypeOf(instance);
+
+    while (level) {
+      if (Object.prototype.hasOwnProperty.call(level, 'render')) {
+        const desc = Object.getOwnPropertyDescriptor(level, 'render')!;
+        const fn = unbind(desc.value || desc.get!.call(instance));
+
+        // A render touched before construction completes (e.g. a framework's
+        // render probe) can leave a bound copy that unbinds to the same
+        // prototype method - dedupe so each distinct render appears once.
+        if (!chain.includes(fn))
+          chain.push(fn);
+      }
+
+      if (level === Component.prototype) break;
+      level = Object.getPrototypeOf(level);
+    }
+
+    CHAIN.set(type, chain);
+  }
+
+  const renders = chain;
+
+  return function (this: Component, props?: {}): Component.Node {
+    let node: Component.Node;
+
+    for (let i = 0; i < renders.length; i++)
+      node = renders[i].call(this, i ? { ...props, children: node } : props);
+
+    return node;
+  };
 }
 
 export { Component };

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -625,6 +625,139 @@ describe('default render', () => {
   });
 });
 
+describe('render chain', () => {
+  it('will compose subclass render as children of super', () => {
+    class Outer extends Component {
+      render(props = {} as { children?: React.ReactNode }) {
+        return (
+          <main>
+            <h1>Wrapper</h1>
+            {props.children}
+          </main>
+        );
+      }
+    }
+
+    class Inner extends Outer {
+      render() {
+        return <span>Content</span>;
+      }
+    }
+
+    const element = render(<Inner />);
+
+    // Inner authors content via render; Outer orchestration still wraps it,
+    // without Inner calling super.render().
+    const heading = element.getByText('Wrapper');
+    const content = element.getByText('Content');
+
+    expect(heading.tagName).toBe('H1');
+    expect(content.closest('main')).toBe(heading.closest('main'));
+  });
+
+  it('will compose three levels inner to outer', () => {
+    class A extends Component {
+      render(props = {} as { children?: React.ReactNode }) {
+        return <div data-a>{props.children}</div>;
+      }
+    }
+
+    class B extends A {
+      render(props = {} as { children?: React.ReactNode }) {
+        return <section data-b>{props.children}</section>;
+      }
+    }
+
+    class C extends B {
+      render() {
+        return <span data-c>Leaf</span>;
+      }
+    }
+
+    const { container } = render(<C />);
+
+    // A (outermost) > B > C (innermost content).
+    const a = container.querySelector('[data-a]')!;
+    const b = a.querySelector('[data-b]')!;
+    const c = b.querySelector('[data-c]')!;
+
+    expect(c.textContent).toBe('Leaf');
+  });
+
+  it('will stay reactive across composed levels', async () => {
+    class Frame extends Component {
+      title = 'Base';
+
+      render(props = {} as { children?: React.ReactNode }) {
+        return (
+          <article>
+            <h2>{this.title}</h2>
+            {props.children}
+          </article>
+        );
+      }
+    }
+
+    class Page extends Frame {
+      body = 'Hello';
+
+      render() {
+        return <p>{this.body}</p>;
+      }
+    }
+
+    let instance!: Page;
+    render(<Page is={(x) => (instance = x)} />);
+
+    screen.getByText('Base');
+    screen.getByText('Hello');
+
+    // Both the super's and the subclass's reactive reads drive updates.
+    await act(async () => {
+      instance.title = 'Updated';
+      instance.body = 'World';
+    });
+
+    screen.getByText('Updated');
+    screen.getByText('World');
+  });
+
+  it('will drop derived content if wrapper omits children', () => {
+    // Documented footgun: an intermediate render is a wrapper - if it does not
+    // place props.children, the derived (subclass) content vanishes.
+    class Shell extends Component {
+      render() {
+        return <div>Shell only</div>;
+      }
+    }
+
+    class Lost extends Shell {
+      render() {
+        return <span>Never seen</span>;
+      }
+    }
+
+    const element = render(<Lost />);
+
+    element.getByText('Shell only');
+    expect(element.queryByText('Never seen')).toBeNull();
+  });
+
+  it('will preserve identity for single-level override', () => {
+    // The universal case: a single override composes with Component's
+    // pass-through default, so output is exactly the subclass render.
+    class Solo extends Component {
+      render() {
+        return <span>Just me</span>;
+      }
+    }
+
+    const { container } = render(<Solo />);
+
+    expect(container.innerHTML).toBe('<span>Just me</span>');
+  });
+});
+
 describe('error boundary', () => {
   mockError();
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -57,7 +57,7 @@ Object.defineProperties(proto, {
 
 function bootstrap(this: Component, context: Context) {
   const self = this.is;
-  const render = unbind(this.render);
+  const render = self.render;
 
   context = context.push(self);
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -57,13 +57,24 @@ Object.defineProperties(proto, {
 
 function bootstrap(this: Component, context: Context) {
   const self = this.is;
-  const render = unbind(this.render);
+  const chain = renderChain(self);
 
   context = context.push(self);
 
   let active: Component;
 
-  const Render = () => render.call(active, self.props);
+  const Render = () => {
+    const props = self.props;
+    let node: React.ReactNode;
+
+    // Compose inner -> outer: leaf gets real props, each super receives the
+    // derived output as its `children`. An intermediate render is a wrapper -
+    // it must place `props.children` or the derived content vanishes.
+    for (let i = 0; i < chain.length; i++)
+      node = chain[i].call(active, i ? { ...props, children: node } : props);
+
+    return node;
+  };
   const React = () => {
     useHook((refresh) => {
       watch(self, (current) => {
@@ -102,6 +113,39 @@ function bootstrap(this: Component, context: Context) {
       }
     }
   });
+}
+
+/**
+ * Collect the `render` defined at each level of the prototype chain, leaf-first
+ * up to and including `Component`. Composing these inner->outer turns the chain
+ * into a wrapper/shell stack: most-derived is the innermost content, base is the
+ * outermost wrapper. A single-level override composes with `Component`'s
+ * pass-through default and so is identity.
+ */
+function renderChain(self: Component) {
+  const chain: Function[] = [];
+
+  // Start at the instance itself - a `render` assigned as an instance field
+  // (e.g. `render = FunctionComponent`) shadows the prototype and is the leaf.
+  let level: object = self;
+
+  while (level) {
+    if (Object.prototype.hasOwnProperty.call(level, 'render')) {
+      const desc = Object.getOwnPropertyDescriptor(level, 'render')!;
+      const fn = unbind(desc.value || desc.get!.call(self));
+
+      // A render accessed before bootstrap (e.g. React's DEV-mode render check)
+      // leaves a bound copy on the instance that unbinds to the same prototype
+      // method - dedupe so each distinct render appears once, leaf-first.
+      if (!chain.includes(fn))
+        chain.push(fn);
+    }
+
+    if (level === proto) break;
+    level = Object.getPrototypeOf(level);
+  }
+
+  return chain;
 }
 
 function subcomponents(proto: Component) {

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -57,24 +57,13 @@ Object.defineProperties(proto, {
 
 function bootstrap(this: Component, context: Context) {
   const self = this.is;
-  const chain = renderChain(self);
+  const render = unbind(this.render);
 
   context = context.push(self);
 
   let active: Component;
 
-  const Render = () => {
-    const props = self.props;
-    let node: React.ReactNode;
-
-    // Compose inner -> outer: leaf gets real props, each super receives the
-    // derived output as its `children`. An intermediate render is a wrapper -
-    // it must place `props.children` or the derived content vanishes.
-    for (let i = 0; i < chain.length; i++)
-      node = chain[i].call(active, i ? { ...props, children: node } : props);
-
-    return node;
-  };
+  const Render = () => render.call(active, self.props);
   const React = () => {
     useHook((refresh) => {
       watch(self, (current) => {
@@ -113,39 +102,6 @@ function bootstrap(this: Component, context: Context) {
       }
     }
   });
-}
-
-/**
- * Collect the `render` defined at each level of the prototype chain, leaf-first
- * up to and including `Component`. Composing these inner->outer turns the chain
- * into a wrapper/shell stack: most-derived is the innermost content, base is the
- * outermost wrapper. A single-level override composes with `Component`'s
- * pass-through default and so is identity.
- */
-function renderChain(self: Component) {
-  const chain: Function[] = [];
-
-  // Start at the instance itself - a `render` assigned as an instance field
-  // (e.g. `render = FunctionComponent`) shadows the prototype and is the leaf.
-  let level: object = self;
-
-  while (level) {
-    if (Object.prototype.hasOwnProperty.call(level, 'render')) {
-      const desc = Object.getOwnPropertyDescriptor(level, 'render')!;
-      const fn = unbind(desc.value || desc.get!.call(self));
-
-      // A render accessed before bootstrap (e.g. React's DEV-mode render check)
-      // leaves a bound copy on the instance that unbinds to the same prototype
-      // method - dedupe so each distinct render appears once, leaf-first.
-      if (!chain.includes(fn))
-        chain.push(fn);
-    }
-
-    if (level === proto) break;
-    level = Object.getPrototypeOf(level);
-  }
-
-  return chain;
 }
 
 function subcomponents(proto: Component) {


### PR DESCRIPTION
## What this is

A **validation spike** for #109 — making `Component.render` compose up the prototype chain instead of a subclass override fully replacing its parent. Each level's render output is passed to its super as `children`, so a base class can wrap a subclass's content without `super.render()` and without forbidding the override.

Opening as **draft** for discussion — the mechanic is proven and the suites are green, but the design decisions called out below are still open.

## Outcome: viable, and placeable in core

The idea works, and composition can live entirely in the `Component` contract rather than in adapter logic.

- `Component`'s constructor walks the prototype chain once (cached per class) and installs an **own** `render` that composes each level leaf→outer, threading each level's output into its super as `children`.
- Each level is called with the receiver as `this`, so an adapter's reactive proxy applies uniformly across the whole chain via a **single** call.
- The **react adapter is byte-identical to its original pre-spike form** — it consumes `this.render` as one composed function with zero chain knowledge. This is the proof the composition belongs in core.
- Direct `foo.render()` calls (no adapter) compose too.

A single-level override (the universal case in the repo today) composes with `Component`'s pass-through default → **identity, no behavior change**. The only behavior that changes is multi-level chains, which nothing currently relies on (it can't work today).

## Commits (the validation arc)

1. **adapter-side prototype** — first proof the mechanic works and single-level identity holds.
2. **core-owned composition** — adapter reverted to original; composition moved into `Component`. This is the intended direction.

## Why not a prototype-level getter

- A configurable getter-without-setter on a prototype is classified by mvc as a *reactive computed*; a get+set pair is skipped entirely.
- Resolution always finds the *most-derived* `render`, so a base-class accessor never intercepts a subclass override.
- → The getter must be an **own instance property** to shadow the chain, which is what the constructor install does.

## Validation

- Full **mvc** suite green (461 tests), full **react** suite green (183, incl. 5 new render-chain tests). Both packages typecheck clean.
- New tests cover: two- and three-level wrapping, cross-level reactivity, single-level identity, and the documented "wrapper must place its children" footgun.

## Open decisions (not yet actioned)

1. **Instance-field `render = fn`** — initializes after construction and shadows the composed render. Single-level stays identity; multi-level field render is treated as unsupported (documented inline). Add a warn-guard, or leave as documented bypass?
2. **Reconcile with `as`** (#109 risk #3) — untouched; needs router context to decide.
3. **Route reshape** — not testable here; `@expressive/router`/`Route` isn't in this repo (the website uses React Router). The mechanic is ready for it, but that acceptance criterion has to be validated where Route lives.

Refs #109

https://claude.ai/code/session_01RtW1oKGPkW9S6vF3gRmorE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtW1oKGPkW9S6vF3gRmorE)_