### PR TITLE
feat(mvc)!: compose render() up the prototype chain

### DIFF
--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -1,6 +1,7 @@
 import { expect, it, mock } from 'bun:test';
 import { Component } from './component';
 import { Context } from './context';
+import { describe } from 'bun:test';
 
 it('will default fallback to null', () => {
   const foo = Component.new({});
@@ -93,4 +94,108 @@ it('will ignore Context passed as constructor argument', () => {
 
   expect(foo.value).toBe(5);
   expect(Object.keys(foo.get())).not.toContain('0');
+});
+
+describe('render chain', () => {
+  // Render layering: a subclass authors content; each super render up the
+  // prototype chain wraps it as `children`, base-outermost. Asserted directly
+  // on the composed `render` - no host needed.
+  it('will compose subclass render as children of super', () => {
+    class Outer extends Component {
+      render(props = {} as { children?: unknown }): Component.Node {
+        return ['outer', props.children];
+      }
+    }
+
+    class Inner extends Outer {
+      render(): Component.Node {
+        return 'content';
+      }
+    }
+
+    expect(Inner.new({}).render()).toEqual(['outer', 'content']);
+  });
+
+  it('will nest three levels inner to outer', () => {
+    class A extends Component {
+      render(props = {} as { children?: unknown }): Component.Node {
+        return { a: props.children };
+      }
+    }
+
+    class B extends A {
+      render(props = {} as { children?: unknown }): Component.Node {
+        return { b: props.children };
+      }
+    }
+
+    class C extends B {
+      render(): Component.Node {
+        return 'leaf';
+      }
+    }
+
+    // A (outermost) wraps B wraps C (innermost content).
+    expect(C.new({}).render()).toEqual({ a: { b: 'leaf' } });
+  });
+
+  it('will bind each composed layer to live instance state', () => {
+    class Frame extends Component {
+      title = 'Base';
+
+      render(props = {} as { children?: unknown }): Component.Node {
+        return [this.title, props.children];
+      }
+    }
+
+    class Page extends Frame {
+      body = 'Hello';
+
+      render(): Component.Node {
+        return this.body;
+      }
+    }
+
+    const page = Page.new({});
+
+    expect(page.render()).toEqual(['Base', 'Hello']);
+
+    // Both layers read `this` off the same instance - render reflects updates.
+    page.title = 'Updated';
+    page.body = 'World';
+
+    expect(page.render()).toEqual(['Updated', 'World']);
+  });
+
+  // Documented footgun: a wrapper that never reads `props.children` drops the
+  // derived content. The children getter is lazy, so inner never even runs.
+  it('will drop derived content if wrapper omits children', () => {
+    const inner = mock(() => 'never seen');
+
+    class Shell extends Component {
+      render(): Component.Node {
+        return 'shell only';
+      }
+    }
+
+    class Lost extends Shell {
+      render(): Component.Node {
+        return inner();
+      }
+    }
+
+    expect(Lost.new({}).render()).toBe('shell only');
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it('will preserve identity for single-level override', () => {
+    class Solo extends Component {
+      render(): Component.Node {
+        return 'just me';
+      }
+    }
+
+    // One override composes with the pass-through default to exactly itself.
+    expect(Solo.new({}).render()).toBe('just me');
+  });
 });

--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -1,8 +1,11 @@
 import { Context } from './context';
 import { set } from './field/set';
-import { State } from './state';
+import { State, unbind } from './state';
 
 const PENDING = new WeakMap<object, Component>();
+
+/** Per-class composed content render. */
+const CHAIN = new WeakMap<Function, Function>();
 
 declare namespace Component {
   /**
@@ -21,7 +24,7 @@ declare namespace Component {
    * Only one adapter is expected per compilation; two augmenting `node` with
    * different types in the same build would conflict - by design.
    */
-  interface Host {}
+  interface Host { }
 
   /**
    * Host element type produced by `Component.render`.
@@ -47,12 +50,26 @@ declare namespace Component {
     : NonNullable<P>
     : { children?: Component.Node };
 
-  type Props<T extends Component> = 
+  type Props<T extends Component> =
     & StateProps<T>
     & BaseProps<T>
     & RenderProps<T['render']>;
 }
 
+interface Component {
+  /**
+   * Output for this component. Override to define custom JSX.
+   *
+   * Properties accessed via `this` are reactive and trigger a render when they
+   * change, in addition to props. Accepts an optional parameter to receive extra
+   * props from JSX, beyond those merged to state properties; declare its shape
+   * via `props = {} as { ... }`. Without a parameter, children pass through.
+   *
+   * Declared, not implemented - the constructor installs a composed `render`
+   * per instance (see `render`); subclasses override with a method.
+   */
+  render(props?: {}): Component.Node;
+}
 
 class Component extends State {
   /**
@@ -99,36 +116,12 @@ class Component extends State {
     this.set('props', () => {
       this.set(merge(this.props));
     });
-  }
 
-  /**
-   * Output for this component. Override to define custom JSX.
-   *
-   * Properties accessed via `this` are reactive and will trigger a render when , in addition to props.
-   *
-   * Accepts optional parameter to receive extra props
-   * from JSX, beyond those merged to state properties.
-   *
-   * To declare extra props use `props = {} as { ... }` with expected shape.
-   * A default is required to satisfy TypeScript but safely ignored.
-   *
-   * ```ts
-   * render(props = {} as { label: string }) {
-   *   return <span>{props.label}</span>;
-   * }
-   * ```
-   * Usable as:
-   * ```tsx
-   * <MyComponent label="Hello" />
-   * ```
-   *
-   * These must be compatible with State-derived properties, or be unused.
-   * Props you declare as not-optional will be required by the JSX element.
-   *
-   * Without a parameter, children are accepted by default and passed through provider.
-   */
-  render(props?: {}): Component.Node {
-    return this.props.children || null;
+    Object.defineProperty(this, 'render', {
+      writable: true,
+      configurable: true,
+      value: render(this)
+    });
   }
 
   /**
@@ -141,6 +134,52 @@ class Component extends State {
    * assign a fallback within catch, it will be reverted after resolved.
    */
   catch?(error: Error): Promise<void> | void;
+}
+
+/**
+ * Build (or fetch the cached) composed content render for an instance's class.
+ * Walks the prototype chain for content renders strictly below Component - the
+ * seam itself (Component.prototype.render) is excluded; an adapter owns that.
+ */
+function render(target: Component) {
+  const cached = CHAIN.get(target.constructor);
+
+  if (cached) return cached;
+
+  let render: Function = children;
+  let proto = target;
+
+  while ((proto = Object.getPrototypeOf(proto)) !== Component.prototype) {
+    const desc = Object.getOwnPropertyDescriptor(proto, 'render');
+
+    if (desc) {
+      const layer = unbind(desc.get || desc.value);
+      render = render === children ? layer : compose(layer, render);
+    }
+  }
+
+  CHAIN.set(target.constructor, render);
+
+  return render;
+}
+
+/** Wrap an outer render so it receives `inner` as a lazy `children` getter. */
+function compose(outer: Function, inner: Function): Function {
+  return function (this: Component, props?: {}) {
+    const self = this;
+    return outer.call(self, {
+      ...props,
+      get children() {
+        return inner.call(self, props);
+      }
+    });
+  };
+}
+
+/** Default content when a component defines no `render` - pass children through. */
+function children(this: Component, props?: {}): Component.Node {
+  const { children } = (props || this.props) as { children?: Component.Node };
+  return children || null;
 }
 
 export { Component };

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -23,8 +23,8 @@ const SETUP = new WeakMap<State.Extends, Set<State.Init<any>>>();
 /** Parent-child relationships. */
 const PARENT = new WeakMap<State, State | null>();
 
-/** Reference bound instance methods to real ones. */
-const METHOD = new WeakMap<any, any>();
+/** Reference bound instance methods, or their getter, to real one. */
+const UNBIND = new WeakMap<any, any>();
 
 /** List of methods defined by a given type. */
 const METHODS = new WeakMap<Function, Map<string, (value: any) => void>>();
@@ -541,11 +541,13 @@ function bootstrap(T: State.Extends) {
         const fn = original || value;
         const bound = fn.bind(is);
 
-        METHOD.set(bound, fn);
+        UNBIND.set(bound, fn);
         define(is, key, { value: bound, writable: true, configurable: true });
 
         return bound;
       }
+
+      UNBIND.set(bind, value);
 
       keys.set(key, bind);
       define(type.prototype, key, { get: bind, set: bind });
@@ -858,7 +860,7 @@ function uid() {
 function unbind<T extends Function>(fn: T): T;
 function unbind<T extends Function>(fn?: T): T | undefined;
 function unbind(fn?: Function) {
-  return METHOD.get(fn) || fn;
+  return UNBIND.get(fn) || fn;
 }
 
 /**

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -625,6 +625,139 @@ describe('default render', () => {
   });
 });
 
+describe('render chain', () => {
+  it('will compose subclass render as children of super', () => {
+    class Outer extends Component {
+      render(props = {} as { children?: React.ReactNode }) {
+        return (
+          <main>
+            <h1>Wrapper</h1>
+            {props.children}
+          </main>
+        );
+      }
+    }
+
+    class Inner extends Outer {
+      render() {
+        return <span>Content</span>;
+      }
+    }
+
+    const element = render(<Inner />);
+
+    // Inner authors content via render; Outer orchestration still wraps it,
+    // without Inner calling super.render().
+    const heading = element.getByText('Wrapper');
+    const content = element.getByText('Content');
+
+    expect(heading.tagName).toBe('H1');
+    expect(content.closest('main')).toBe(heading.closest('main'));
+  });
+
+  it('will compose three levels inner to outer', () => {
+    class A extends Component {
+      render(props = {} as { children?: React.ReactNode }) {
+        return <div data-a>{props.children}</div>;
+      }
+    }
+
+    class B extends A {
+      render(props = {} as { children?: React.ReactNode }) {
+        return <section data-b>{props.children}</section>;
+      }
+    }
+
+    class C extends B {
+      render() {
+        return <span data-c>Leaf</span>;
+      }
+    }
+
+    const { container } = render(<C />);
+
+    // A (outermost) > B > C (innermost content).
+    const a = container.querySelector('[data-a]')!;
+    const b = a.querySelector('[data-b]')!;
+    const c = b.querySelector('[data-c]')!;
+
+    expect(c.textContent).toBe('Leaf');
+  });
+
+  it('will stay reactive across composed levels', async () => {
+    class Frame extends Component {
+      title = 'Base';
+
+      render(props = {} as { children?: React.ReactNode }) {
+        return (
+          <article>
+            <h2>{this.title}</h2>
+            {props.children}
+          </article>
+        );
+      }
+    }
+
+    class Page extends Frame {
+      body = 'Hello';
+
+      render() {
+        return <p>{this.body}</p>;
+      }
+    }
+
+    let instance!: Page;
+    render(<Page is={(x) => (instance = x)} />);
+
+    screen.getByText('Base');
+    screen.getByText('Hello');
+
+    // Both the super's and the subclass's reactive reads drive updates.
+    await act(async () => {
+      instance.title = 'Updated';
+      instance.body = 'World';
+    });
+
+    screen.getByText('Updated');
+    screen.getByText('World');
+  });
+
+  it('will drop derived content if wrapper omits children', () => {
+    // Documented footgun: an intermediate render is a wrapper - if it does not
+    // place props.children, the derived (subclass) content vanishes.
+    class Shell extends Component {
+      render() {
+        return <div>Shell only</div>;
+      }
+    }
+
+    class Lost extends Shell {
+      render() {
+        return <span>Never seen</span>;
+      }
+    }
+
+    const element = render(<Lost />);
+
+    element.getByText('Shell only');
+    expect(element.queryByText('Never seen')).toBeNull();
+  });
+
+  it('will preserve identity for single-level override', () => {
+    // The universal case: a single override composes with Component's
+    // pass-through default, so output is exactly the subclass render.
+    class Solo extends Component {
+      render() {
+        return <span>Just me</span>;
+      }
+    }
+
+    const { container } = render(<Solo />);
+
+    expect(container.innerHTML).toBe('<span>Just me</span>');
+  });
+});
+
 describe('error boundary', () => {
   mockError();
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -51,57 +51,47 @@ Object.defineProperties(proto, {
     get: proto.get
   },
   context: {
-    set: bootstrap
+    set(this: Component, context: Context) {
+      context = context.push(this);
+
+      Object.defineProperties(this, {
+        context: {
+          get: () => context,
+          set() { }
+        },
+        render: {
+          value: component(this, context)
+        }
+      });
+    }
   }
 });
 
-function bootstrap(this: Component, context: Context) {
-  const self = this.is;
-  const render = unbind(this.render);
-
-  context = context.push(self);
-
-  let active: Component;
-
-  const Render = () => render.call(active, self.props);
-  const React = () => {
-    useHook((refresh) => {
-      watch(self, (current) => {
-        active = current;
-        refresh();
-      });
-
+function component(from: Component, context: Context) {
+  const { render } = from;
+  const Render = () => render.call(from, from.props);
+  const Component = () => {
+    from = useHook((refresh) => {
+      watch(from, refresh);
       return () => {
-        self.set(null);
+        from.set(null);
         context.pop();
       };
     });
 
     const children = createElement(Layers.Provider, {
       value: context,
-      children: createElement(
-        Suspense,
-        { fallback: active.fallback, name: String(self) },
-        createElement(Render)
-      )
+      children: createElement(Suspense,
+        { fallback: from.fallback, name: String(from) },
+        createElement(Render))
     });
 
-    return active.catch
-      ? createElement(ErrorBoundary, { self, children })
+    return from.catch
+      ? createElement(ErrorBoundary, { self: from, children })
       : children;
-  }
+  };
 
-  Object.defineProperties(self, {
-    context: {
-      get: () => context,
-      set() { }
-    },
-    render: {
-      value() {
-        return createElement(React);
-      }
-    }
-  });
+  return () => createElement(Component);
 }
 
 function subcomponents(proto: Component) {

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -272,7 +272,7 @@ Fetch these for detailed API documentation when the task requires deeper knowled
 ### React
 
 - [react/react.md](react/react.md) - use(), State.use(), State.get(), Provider, Consumer, ForceRefresh
-- [react/component.md](react/component.md) - Component class, props, children, subcomponents, error boundaries
+- [react/component.md](react/component.md) - Component class, props, children, render composition (subclass renders wrap base as `props.children`), subcomponents, error boundaries
 - [react/patterns.md](react/patterns.md) - Recipes: forms, async, nested state, debounce, effects
 
 ### Examples

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -98,6 +98,42 @@ class Accordion extends Toggle {
 
 Key pattern: base class owns behavior + structure, subclass fills in rendering. Subclasses work immediately as `<DarkModeSwitch />` or `<Accordion title="FAQ">...</Accordion>`.
 
+## Render Composition
+
+When a subclass overrides `render()`, it **composes** with the base instead of replacing it. Each `render()` up the prototype chain wraps the one below it, base-outermost, with the inner output passed down as `props.children`. No `super.render()` call.
+
+```tsx
+class Frame extends Component {
+  render(props = {} as { children?: ReactNode }) {
+    return (
+      <section className="frame">
+        <header>Frame</header>
+        {props.children}
+      </section>
+    );
+  }
+}
+
+class Page extends Frame {
+  body = 'Hello';
+
+  render() {
+    return <p>{this.body}</p>;
+  }
+}
+
+// <Page /> renders:
+// <section class="frame"><header>Frame</header><p>Hello</p></section>
+```
+
+`Frame` is the outer layer (higher on the chain); `Page` content slots in where `Frame` reads `props.children`. Levels nest the same way - each subclass becomes its parent's `children`. Every layer binds to the same live instance, so all read the same reactive `this`.
+
+This is how a base primitive owns shared chrome/suspense/context once while subclasses author only the content.
+
+**Footgun:** the inner content arrives as `props.children`. A wrapper render that never reads `props.children` silently drops everything below it - and because the `children` getter is lazy, the dropped layer never even runs. A base meant to wrap subclasses must declare a `props` parameter and render `props.children`.
+
+**Caution with React hooks in a render layer.** Reactivity comes from `this`, so you rarely need hooks here - but they aren't forbidden. The sharp edge: the whole composed chain runs in a single host render, so all layers' hooks stack into one component. Fine if they obey the rules of hooks for the chain as a whole, but a hook in a layer below a wrapper that *conditionally* renders `props.children` runs only sometimes (mounts/unmounts across renders) and breaks the rules of hooks. When a layer needs its own isolated hooks/subscription/boundary, make it a PascalCase subcomponent (`<this.Panel />`) - those each get their own component; render layers are folded into one.
+
 ## Persistent Instance
 
 Component instances survive across renders. `this` is stable - you can store references, pass `this` to external objects, hold imperative state (Sets, Maps, DOM refs) without losing it.

--- a/website/content/docs/api/component.mdx
+++ b/website/content/docs/api/component.mdx
@@ -57,6 +57,10 @@ class Card extends Component {
 - Non-optional parameter fields become required JSX attributes.
 - Without a parameter (or without `render()` altogether), children pass through a context provider.
 
+When a subclass overrides `render()`, it **composes** with the base rather than replacing it. Each render up the prototype chain wraps the one below as `props.children`, base-outermost - no `super.render()` call. A wrapper that omits `props.children` drops the inner content (the getter is lazy, so it never runs). See [Render composition](/docs/guides/components#render-composition).
+
+The whole composed chain runs in a single host render. Prefer `this` for reactivity over React hooks inside `render()`, and if you do use hooks, beware the sharp edge: a hook in a layer below a wrapper that *conditionally* renders `props.children` breaks the rules of hooks. For a scope isolated from that, use a [subcomponent](#subcomponents).
+
 ### `catch(error)` <small>optional</small>
 
 ```tsx

--- a/website/content/docs/guides/components.mdx
+++ b/website/content/docs/guides/components.mdx
@@ -109,6 +109,120 @@ This is how teams DRY up complex UI patterns into organizational primitives - bu
 
 <br />
 
+## Render composition
+
+When a subclass overrides `render()`, it does not replace the base render - the two **compose**. Each `render()` up the prototype chain wraps the one below it, base-outermost, with the inner output handed down as `props.children`. You never call `super.render()`.
+
+```tsx
+class Frame extends Component {
+  render(props = {} as { children?: ReactNode }) {
+    return (
+      <section className="frame">
+        <header>Frame</header>
+        {props.children}
+      </section>
+    );
+  }
+}
+
+class Page extends Frame {
+  body = 'Hello';
+
+  render() {
+    return <p>{this.body}</p>;
+  }
+}
+
+<Page />;
+```
+
+`<Page />` renders the `Frame` chrome with the `Page` content slotted in where `Frame` reads `props.children`:
+
+```html
+<section class="frame">
+  <header>Frame</header>
+  <p>Hello</p>
+</section>
+```
+
+`Frame` is the outer layer because it sits higher on the chain; `Page` is the inner content. Add a third level and it nests the same way - each subclass becomes the `children` of its parent:
+
+```tsx
+class Card extends Frame {
+  render(props = {} as { children?: ReactNode }) {
+    return <article className="card">{props.children}</article>;
+  }
+}
+
+class Note extends Card {
+  render() {
+    return <p>note body</p>;
+  }
+}
+// Frame > Card > <p>note body</p>
+```
+
+Every layer binds to the same live instance, so each render reads the same reactive `this`. A change to any field re-renders the whole composed output.
+
+### The base provides the default shell
+
+This is what makes a base primitive useful: it owns the surrounding structure once, and subclasses fill the middle without restating it. A `Boundary` base can wrap every subclass in shared chrome, suspense, or context - subclasses only author the content.
+
+<br />
+
+### Footgun: dropping children
+
+The inner content arrives as `props.children`. A wrapper render that never reads `props.children` silently discards everything below it:
+
+```tsx
+class Shell extends Component {
+  render() {
+    // No props.children - inner content is dropped.
+    return <div>shell only</div>;
+  }
+}
+
+class Lost extends Shell {
+  render() {
+    return <p>never rendered</p>; // discarded
+  }
+}
+```
+
+The `children` getter is lazy, so the dropped layer never even runs. If a base means to wrap subclasses, it must declare a `props` parameter and render `props.children`.
+
+<br />
+
+### Caution: React hooks in a render layer
+
+You normally won't reach for hooks here - reactivity comes from `this`, so read class fields, not `useState`/`useEffect`, inside `render()`. But hooks aren't forbidden, and there's a sharp edge worth knowing.
+
+The whole composed chain runs inside a **single** host render - every layer executes in the same component call, so all layers' hooks stack into one component. That's fine as long as the hooks obey the rules of hooks *for the chain as a whole*: same hooks, same order, every render.
+
+The trap is conditional children. A hook in a layer below a wrapper that conditionally renders `props.children` runs only sometimes - the inner layer mounts and unmounts across renders, and React throws:
+
+```tsx
+class Collapsible extends Component {
+  open = false;
+
+  render(props = {} as { children?: ReactNode }) {
+    // Conditionally rendering children is fine for content...
+    return this.open ? <div>{props.children}</div> : null;
+  }
+}
+
+class Panel extends Collapsible {
+  render() {
+    const [x] = useState(0); // ...but this hook now runs only when `open` - illegal
+    return <p>{x}</p>;
+  }
+}
+```
+
+If a layer needs its own isolated scope - its own hooks, subscription, and reconciliation boundary, immune to what wrappers above it do - make it a [subcomponent](#subcomponents) (a PascalCase method) and render `<this.Panel />`. Subcomponents are each wrapped in their own component; render layers are deliberately folded into one.
+
+<br />
+
 ## Persistent identity
 
 Component instances survive across renders. `this` is stable - you can store references, pass `this` to external objects, and hold imperative state (Sets, Maps, WebSocket connections) without losing it between renders.


### PR DESCRIPTION
## Summary

Component subclasses can now **override `render` and have it compose up the prototype chain**. Each super's `render` wraps the subclass's output as `children`, base-outermost - so a subclass authors content while ancestor renders provide orchestration/layout around it, **without any `super.render()` call**.

```jsx
class Frame extends Component {
  render(props) {
    return <article><h2>{this.title}</h2>{props.children}</article>;
  }
}

class Page extends Frame {
  // No super.render() - Frame wraps this automatically as its children.
  render() {
    return <p>{this.body}</p>;
  }
}
// <article><h2>…</h2><p>…</p></article>
```

## How it works

- **Composition lives in the agnostic core (`@expressive/mvc`).** `render()` walks the prototype chain for `render` methods strictly *below* `Component`, and folds them into a single composed content function (`compose()`): the outer (base) layer runs first and receives the recursively-composed inner layers via a lazy `children` getter. Result is cached per-class in a `WeakMap`.
- **The host seam stays in the adapter.** `Component.prototype.render` is deliberately excluded from the walk - that boundary belongs to the adapter. `@expressive/react` overrides the instance `render` at the `context` seam, wrapping the composed content in the React component (hooks, `Suspense`, context `Provider`, error boundary). The composed content runs *inside* that scope, so context and reactivity established by the seam are observed by every layer.
- **Lazy + reactive.** The `children` getter is lazy: a wrapper that never reads `props.children` simply drops the derived content (documented footgun), and each layer binds `this` to the same instance, so reactive reads in *any* layer drive updates.
- **Single host render - hooks in a layer are a sharp edge.** The whole composed chain executes inside one host render, so reactivity is via `this`, not React hooks (the library's idiom regardless). Hooks aren't banned, but they stack across layers into one component: a hook in a layer below a wrapper that *conditionally* renders `props.children` breaks the rules of hooks - documented as a strong caution. We deliberately do **not** re-wrap each layer in its own stable component - that would re-couple the agnostic core to the host and add a tree node + subscription per layer for an idiom the library discourages. The way to get an isolated hook/subscription/boundary scope is a PascalCase subcomponent (`<this.Layer />`), which already gets its own component.

## Supporting changes

- **Prerequisite (already on `main`):** the `useHook` pre-commit fix (`1e08e3bc` - buffer subscriptions firing between first render and commit, flush on mount) landed separately and is *not* part of this diff. It is what lets reactivity survive across composed levels; this branch builds on top of it.
- **Method-binding optimization (`state.ts`):** bootstrap registers each prototype-method getter as a sentinel for its source method (`UNBIND.set(bind, value)`), so the render walk can recover the original method without invoking it - no per-layer bound-method materialization on the instance during composition. (`METHOD` → `UNBIND` rename reflects the broadened contract.)
- **Render-walk cleanup:** the recursive `fold` helper was folded into the single prototype walk with a small `compose()` combinator; the walk reads the source method via the getter sentinel (`unbind(desc.get || desc.value)`) rather than calling it.

## Tests

- **`@expressive/react`:** a `render chain` suite covering compose order, three-level nesting, reactivity across composed levels, the children-omission footgun, and single-level identity.
- **`@expressive/mvc`:** a host-agnostic `render chain` suite asserting directly on the composed `render` (no host needed), closing the coverage gap on `compose()` that was previously only exercised transitively through React. Package is back to 100%.

## Docs & skills

The feature is documented for both humans and agents:

- **[`guides/components.mdx`](website/content/docs/guides/components.mdx):** new *Render composition* section - the compose-not-replace rule, a `Frame`/`Page` walkthrough with rendered HTML, multi-level nesting, live-`this` binding, and the children-dropping footgun.
- **[`api/component.mdx`](website/content/docs/api/component.mdx):** a note under `render(props?)` stating the composition rule and footgun, linking to the guide.
- **[`skills/react/component.md`](skills/react/component.md):** matching *Render Composition* section for agent context; surfaced from the skills index in `SKILL.md`.

Reviewers wanting the full behavior in prose should start with the components guide section.

## BREAKING CHANGE

Subclass `render()` now **composes** with ancestor `render()` methods instead of replacing them. Previously a subclass `render()` shadowed the base (plain JS override); now each `render()` up the chain wraps the one below as `props.children`, base-outermost.

Only hierarchies that define `render()` at **two or more levels** are affected (single-level overrides are unchanged - they compose to identity). Migration:

- If you relied on a subclass `render()` fully *replacing* a base `render()`, either have the base render `props.children`, or move the base's markup into a subcomponent so the subclass can place it explicitly.
- A base `render()` that ignores `props.children` will now silently drop subclass content - declare a `props` parameter and render `props.children`.
- Replace any manual `super.render()` composition: the base now runs automatically as the outer layer, so an explicit `super.render()` call double-renders it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)