### PR TITLE
fix(react): prevent subscription leak on Suspense-discarded renders (#118)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-state",

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, act } from '@testing-library/react';
 import { mock, expect, it, describe } from 'bun:test';
 import React from 'react';
+import { observer } from '@expressive/mvc';
 
 import { mockError, mockPromise } from '../test.setup';
 import { Component, Consumer, set } from '.';
@@ -1700,5 +1701,103 @@ describe('strict mode', () => {
     expect(order).toEqual(['construct', 'construct', 'init']);
 
     element.unmount();
+  });
+});
+
+describe('suspense discard (issue #118)', () => {
+  // When a render is discarded by Suspense (a sibling suspends), React creates
+  // a new fiber on retry. Each new fiber runs the useState initializer again,
+  // which previously called watch() without cleaning up the prior call's
+  // subscription, leaking one listener per discarded render attempt.
+  // The fix: component() tracks the latest watch cleanup in pendingStop and
+  // cancels the previous subscription before establishing a new one.
+
+  it('does not accumulate subscriptions across discarded renders', async () => {
+    class Model extends Component {}
+
+    // Capture the React-managed Component instance via the `is` prop.
+    let instance: Model | undefined;
+
+    const pending = mockPromise();
+    let suspendCount = 0;
+
+    // This sibling suspends on its first two renders, then resolves.
+    // Each suspension discards the WIP tree (including Model's render).
+    const SiblingThatSuspends = () => {
+      if (suspendCount++ < 2) throw pending;
+      return null;
+    };
+
+    // Measure listener count on a normally-committed component (no discards).
+    let baseline: number;
+    await act(async () => {
+      render(
+        <React.Suspense fallback={null}>
+          <Model is={(c: Model) => { instance = c; }} />
+        </React.Suspense>
+      );
+    });
+    baseline = observer(instance!)!.listeners.size;
+
+    // Now test with Suspense discards.
+    instance = undefined;
+    suspendCount = 0;
+
+    await act(async () => {
+      render(
+        <React.Suspense fallback={<span>loading</span>}>
+          <Model is={(c: Model) => { instance = c; }} />
+          <SiblingThatSuspends />
+        </React.Suspense>
+      );
+    });
+
+    // Shows fallback while sibling is suspended.
+    screen.getByText('loading');
+
+    // Resolve the promise – React retries and commits.
+    await act(async () => { pending.resolve(); });
+
+    const withDiscards = observer(instance!)!.listeners.size;
+
+    // Without the fix, withDiscards would be baseline + 2*numDiscards
+    // because each discarded render leaked its watch subscription.
+    expect(withDiscards).toBe(baseline);
+  });
+
+  it('destroys the instance only once on unmount after discards', async () => {
+    const didDestroy = mock();
+
+    class Model extends Component {
+      protected new() {
+        return () => didDestroy();
+      }
+    }
+
+    const pending = mockPromise();
+    let suspendCount = 0;
+    const SiblingThatSuspends = () => {
+      if (suspendCount++ < 2) throw pending;
+      return null;
+    };
+
+    let element: ReturnType<typeof render>;
+    await act(async () => {
+      element = render(
+        <React.Suspense fallback={null}>
+          <Model />
+          <SiblingThatSuspends />
+        </React.Suspense>
+      );
+    });
+
+    await act(async () => { pending.resolve(); });
+
+    expect(didDestroy).not.toHaveBeenCalled();
+
+    await act(async () => { element!.unmount(); });
+
+    // The cleanup (from.set(null)) should fire exactly once.
+    expect(didDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -70,10 +70,17 @@ Object.defineProperties(proto, {
 function component(from: Component, context: Context) {
   const { render } = from;
   const Render = () => render.call(from, from.props);
+  // Tracks the watch cleanup from the most recent render attempt.
+  // On a Suspense discard, React creates a new fiber (new useRef/useState)
+  // but the same closure runs again; calling pendingStop before the new
+  // watch ensures at most one subscription exists at any time.
+  let pendingStop: (() => void) | undefined;
   const Component = () => {
     from = useHook((refresh) => {
-      watch(from, refresh);
+      pendingStop?.();                    // discard previous render's subscription
+      pendingStop = watch(from, refresh); // track for potential next-render cleanup
       return () => {
+        pendingStop = undefined;          // committed – no longer a discard candidate
         from.set(null);
         context.pop();
       };


### PR DESCRIPTION
Fixes #118.

## Root cause

`useHook` in `packages/react/src/runtime.ts` calls the user-supplied `callback` inside the `useState` lazy initializer (render phase). In `component.ts`, that callback calls `watch(from, refresh)`, registering a listener on the Component's observable. Cleanup is only registered via `useEffect` (commit phase).

When React **discards a render** — because a sibling or descendant in the same Suspense boundary throws a promise — the fiber is thrown away and effects never run. The `watch` subscription established during render is never cancelled. Each Suspense retry creates a new fiber (fresh `useRef`/`useState`), runs the initializer again, and leaks another subscription. N retries → N+1 orphaned listeners.

In the router this becomes visible: `Route.render` registers into `parent.inner` as a render-phase side-effect; the cold-load Suspense churn (≈50 retries) inflated NavLinks to 149 anchors instead of ~7.

## Approach

Added a `pendingStop` closure variable inside `component()`. The `useHook` callback now:

1. **Calls `pendingStop?.()` before `watch()`** — cancels the previous render attempt's subscription if it was never committed.
2. **Stores the new `watch` cleanup in `pendingStop`** — so the next render attempt (if this one is discarded) can cancel it.
3. **Clears `pendingStop` in the returned unmount handler** — once the component commits, the subscription is "owned" and should not be proactively cancelled on the next re-render.

```ts
// Before (leaked subscription per discard)
from = useHook((refresh) => {
  watch(from, refresh);
  return () => { from.set(null); context.pop(); };
});

// After (at most 1 pending subscription at any time)
from = useHook((refresh) => {
  pendingStop?.();                    // cancel previous discarded render
  pendingStop = watch(from, refresh); // track for potential cancellation
  return () => {
    pendingStop = undefined;          // committed – owned, not pending
    from.set(null);
    context.pop();
  };
});
```

## First-render read-tracking tradeoff

`watch()` is still called in the `useState` initializer (render phase) so that the tracking proxy is available during the component's first render body execution. This preserves the reactive dependency tracking that was the original reason for render-phase setup.

The fix does **not** defer setup to commit (via `useSyncExternalStore` or similar). Deferring would break first-render tracking: the component body would read from an untracked object on its first render, and no future property-change re-renders would fire. Preserving render-phase setup is correct; the fix simply bounds the lifetime of any uncommitted subscription to "until the next render attempt on the same closure".

## Scope limitation: `subcomponents()`

The `subcomponents()` path (`<this.Sidebar id="a" />` and `<this.Sidebar id="b" />`) shares a single memoized `Component` function across all concurrent slot renders. A naive shared `pendingStop` would cause slot B's render to cancel slot A's subscription in the same render pass, breaking independent subscriptions. This path is left unchanged; leaked subscriptions there are bounded (no `from.set(null)` is called, and `setState` on a dead fiber is a no-op in React 18). A per-slot coordination mechanism is deferred to a follow-up.

## Tests

Two regression tests added to `packages/react/src/component.test.tsx` under `describe('suspense discard (issue #118)')`:

1. **Listener count after N discards equals no-discard baseline** — renders a `Model` component inside `<Suspense>` with a sibling that suspends twice; after resolution asserts `observer(instance).listeners.size` equals a baseline measured from a normally-committed component.

2. **Instance destroyed exactly once after discards** — verifies the `new()` cleanup fires exactly once on unmount even after multiple Suspense retries (guards against `from.set(null)` being called on the discarded render's cleanup).

## Suite results

```
packages/react:  186 pass  0 fail  (was 184 pass before this PR — 2 new tests added)
packages/mvc:    458 pass  0 fail
tsc --noEmit:    clean on both packages
```

## Router integration note

The direct cause of the 149-anchor NavLinks inflation was `Route.render` registering into `parent.inner` as a render-phase side-effect. With this fix, each Suspense retry cancels the previous render's `watch` subscription on the Component, so the leaked `Route.render` callbacks are no longer live when properties change. The registration count will converge to the correct value. Full verification requires running the examples app, which is not available in this environment, but the mechanism is the same as the regression tests demonstrate at the model level.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TqWfe6DxryM95KeKtAJcY5)_