### PR TITLE
fix: reads of a destroyed state settle; subscriptions and writes stay loud (#120)

### DIFF
--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -325,6 +325,55 @@ describe('effect', () => {
     await expect(test).toHaveUpdated('bar');
     expect(test.bar).toBe(3);
   });
+
+  describe('destroyed', () => {
+    const error = mockError();
+
+    it('will throw for destroyed subject', () => {
+      const test = {};
+      const effect = mock();
+
+      event(test);
+      event(test, null);
+
+      expect(() => watch(test, effect)).toThrow('terminated');
+      expect(effect).not.toBeCalled();
+    });
+
+    it('will throw for get(effect) on destroyed instance', () => {
+      class Test extends State {
+        foo = 1;
+      }
+
+      const test = Test.new();
+      const effect = mock(($: Test) => void $.foo);
+
+      test.set(null);
+
+      expect(() => test.get(effect)).toThrow('terminated');
+      expect(effect).not.toBeCalled();
+    });
+
+    it('will not re-run when destroyed before dispatch', async () => {
+      class Test extends State {
+        foo = 1;
+      }
+
+      const test = Test.new();
+      const effect = mock(($: Test) => void $.foo);
+
+      test.get(effect);
+      expect(effect).toBeCalledTimes(1);
+
+      test.foo = 2;
+      test.set(null);
+
+      await new Promise((res) => setTimeout(res, 0));
+
+      expect(effect).toBeCalledTimes(1);
+      expect(error).not.toBeCalled();
+    });
+  });
 });
 
 describe('suspense', () => {

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -263,6 +263,8 @@ function watch<T extends object>(
   let previous: T | undefined;
 
   function invoke() {
+    if (observer(target) === null) return;
+
     let ignore: boolean = true;
 
     function onUpdate() {

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -600,6 +600,18 @@ describe('get method', () => {
       await expect(suspense).resolves.toBe('foobar');
     });
 
+    it('will read undefined for pending value after destroyed', () => {
+      class Test extends State {
+        foo = set(() => new Promise<string>(() => {}), true);
+      }
+
+      const test = Test.new();
+
+      test.set(null);
+
+      expect(test.foo).toBeUndefined();
+    });
+
     it('will suspend if undefined in strict mode', async () => {
       class Test extends State {
         foo?: string = undefined;
@@ -1998,6 +2010,45 @@ describe('set method', () => {
       expect(callback).toBeCalledTimes(1);
     });
 
+    it('will disallow set with config if destroyed', () => {
+      class Test extends State {
+        foo = 0;
+      }
+
+      const test = Test.new();
+
+      test.set(null);
+
+      expect(() => test.set('foo', { value: 1 })).toThrow(
+        /Tried to update [\w-]+\.foo but state is destroyed\./
+      );
+    });
+
+    it('will disallow assign if destroyed', () => {
+      class Test extends State {
+        foo = 0;
+      }
+
+      const test = Test.new();
+
+      test.set(null);
+
+      expect(() => test.set({ foo: 1 })).toThrow(/terminated/);
+    });
+
+    it('will still read values after destroyed', () => {
+      class Test extends State {
+        foo = 1;
+      }
+
+      const test = Test.new();
+
+      test.foo = 2;
+      test.set(null);
+
+      expect(test.foo).toBe(2);
+    });
+
     it('will silently skip update after destroyed', () => {
       class Test extends State {
         foo = 0;
@@ -2590,6 +2641,40 @@ describe('on method (static)', () => {
 });
 
 describe('computed (getters)', () => {
+  describe('destroyed', () => {
+    it('will read last value after destroy', () => {
+      class Test extends State {
+        source = 2;
+        get value() {
+          return this.source * 2;
+        }
+      }
+
+      const test = Test.new();
+
+      expect(test.value).toBe(4);
+
+      test.set(null);
+
+      expect(test.value).toBe(4);
+    });
+
+    it('will read undefined if never evaluated before destroy', () => {
+      class Test extends State {
+        source = 2;
+        get value() {
+          return this.source * 2;
+        }
+      }
+
+      const test = Test.new();
+
+      test.set(null);
+
+      expect(test.value).toBeUndefined();
+    });
+  });
+
   describe('property descriptors', () => {
     it('will be enumerable', () => {
       class Test extends State {

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -618,6 +618,8 @@ function compute(this: State, getter: () => unknown, key: string) {
       set: false,
       get: () => {
         if (!proxy) {
+          if (observer(this) === null) return store[key];
+
           connect();
           isAsync = true;
         }
@@ -773,6 +775,8 @@ function access(state: State, property: string, required?: boolean) {
 
   if (METHODS.get(state.constructor)!.has(property))
     return unbind((state as any)[property]);
+
+  if (observer(state) === null) return undefined;
 
   const error = new Error(`${state}.${property} is not yet available.`);
   const promise = new Promise<any>((resolve, reject) => {

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -594,6 +594,27 @@ describe('state props on rerender', () => {
 
     screen.getByText('empty');
   });
+
+  it('will ignore update after instance destroyed', async () => {
+    class Control extends Component {
+      value = 'foo';
+
+      render() {
+        return <span>{this.value}</span>;
+      }
+    }
+
+    let instance!: Control;
+    const view = render(<Control value="bar" is={(c) => (instance = c)} />);
+
+    screen.getByText('bar');
+
+    await act(async () => instance.set(null));
+
+    view.rerender(<Control value="baz" />);
+
+    screen.getByText('bar');
+  });
 });
 
 describe('default render', () => {
@@ -1223,6 +1244,34 @@ describe('error boundary', () => {
 });
 
 describe('subcomponents', () => {
+  const error = mockError();
+
+  it('will render last values after owner destroyed', async () => {
+    class Control extends Component {
+      value = 'foo';
+
+      Inner() {
+        return <span>{this.value}</span>;
+      }
+
+      render() {
+        return <this.Inner />;
+      }
+    }
+
+    let instance!: Control;
+    const view = render(<Control is={(c) => (instance = c)} />);
+
+    screen.getByText('foo');
+
+    await act(async () => instance.set(null));
+
+    view.rerender(<Control />);
+
+    screen.getByText('foo');
+    expect(error).not.toBeCalled();
+  });
+
   it('will wrap PascalCase method as reactive component', async () => {
     class Dashboard extends Component {
       label = 'Hello';

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -1,4 +1,4 @@
-import { watch, unbind, Component } from '@expressive/mvc';
+import { watch, unbind, observer, Component } from '@expressive/mvc';
 import React, { createElement, Suspense } from 'react';
 import { Context, Layers } from './context';
 import { useHook } from './runtime';
@@ -54,7 +54,22 @@ Object.defineProperties(proto, {
     set(this: Component, context: Context) {
       context = context.push(this);
 
+      const props = Object.getOwnPropertyDescriptor(this, 'props')!;
+
       Object.defineProperties(this, {
+        props: {
+          ...props,
+          set: (next: {}) => {
+            if (this.get(null))
+              Object.defineProperty(this, 'props', {
+                value: next,
+                writable: true,
+                configurable: true
+              });
+            else
+              props.set!.call(this, next);
+          }
+        },
         context: {
           get: () => context,
           set() { }
@@ -71,13 +86,14 @@ function component(from: Component, context: Context) {
   const { render } = from;
   const Render = () => render.call(from, from.props);
   const Component = () => {
-    from = useHook((refresh) => {
-      watch(from, refresh);
+    from = useHook<Component>((refresh) => {
+      if (observer(from) !== null)
+        watch(from, refresh);
       return () => {
         from.set(null);
         context.pop();
       };
-    });
+    }) || from;
 
     const children = createElement(Layers.Provider, {
       value: context,
@@ -112,7 +128,7 @@ function subcomponents(proto: Component) {
               let render = unbind(get ? get.call(owner) : value);
               const Component = (props: unknown) =>
                 render.call(
-                  useHook<Component>((set) => watch(owner, set)),
+                  useHook<Component>((set) => watch(owner, set)) || owner,
                   props
                 );
 

--- a/packages/react/src/state.test.tsx
+++ b/packages/react/src/state.test.tsx
@@ -577,6 +577,73 @@ describe('State.get', () => {
     });
   });
 
+  describe('over destroyed instance', () => {
+    class Test extends State {
+      value = 'foo';
+    }
+
+    async function lateConsumer(Consumer: React.FC) {
+      const test = Test.new();
+      const view = render(<Provider for={test}><></></Provider>);
+
+      await act(async () => test.set(null));
+
+      view.rerender(
+        <Provider for={test}>
+          <Consumer />
+        </Provider>
+      );
+
+      return view.container.textContent;
+    }
+
+    it('will render last values', async () => {
+      const text = await lateConsumer(() => <>{Test.get().value}</>);
+
+      expect(text).toBe('foo');
+      expect(error).not.toBeCalled();
+    });
+
+    it('will render last values when optional', async () => {
+      const text = await lateConsumer(() => <>{Test.get(false)?.value}</>);
+
+      expect(text).toBe('foo');
+      expect(error).not.toBeCalled();
+    });
+
+    it('will evaluate factory with last values', async () => {
+      const text = await lateConsumer(() => (
+        <>{Test.get(($) => $.value.toUpperCase())}</>
+      ));
+
+      expect(text).toBe('FOO');
+      expect(error).not.toBeCalled();
+    });
+
+    it('will keep last values in mounted consumer', async () => {
+      const test = Test.new();
+      const Consumer = () => <>{Test.get().value}</>;
+      const view = render(
+        <Provider for={test}>
+          <Consumer />
+        </Provider>
+      );
+
+      expect(view.container.textContent).toBe('foo');
+
+      await act(async () => test.set(null));
+
+      view.rerender(
+        <Provider for={test}>
+          <Consumer />
+        </Provider>
+      );
+
+      expect(view.container.textContent).toBe('foo');
+      expect(error).not.toBeCalled();
+    });
+  });
+
   describe('computed', () => {
     class Test extends State {
       foo = 1;

--- a/packages/react/src/state.ts
+++ b/packages/react/src/state.ts
@@ -1,4 +1,4 @@
-import { State, Context, watch } from '@expressive/mvc';
+import { State, Context, observer, watch } from '@expressive/mvc';
 import { Runtime, useFactory, useHook, useReady } from './runtime';
 
 export { Runtime };
@@ -178,6 +178,15 @@ State.get = function get<T extends State>(
 
     function attach(next: T) {
       unwatch?.();
+
+      if (observer(next) === null) {
+        value = typeof argument === 'function'
+          ? argument.call(next, next, refresh)
+          : next;
+        unwatch = () => {};
+        return release;
+      }
+
       unwatch = watch(
         next,
         (current, changed) => {

--- a/packages/react/src/use.test.tsx
+++ b/packages/react/src/use.test.tsx
@@ -191,13 +191,26 @@ describe('use', () => {
     );
   });
 
-  it('will throw for destroyed observable', () => {
+  it('will render last-known values for destroyed observable', () => {
     const test = Test.new();
 
     test.set(null);
 
-    expect(() => renderHook(() => use(test))).toThrow(
-      'Provided object is no longer observable.'
-    );
+    const hook = renderHook(() => use(test).foo);
+
+    expect(hook.result.current).toBe('foo');
+  });
+
+  it('will keep last-known values after subject destroyed', async () => {
+    const test = Test.new();
+    const hook = renderHook(() => use(test).foo);
+
+    expect(hook.result.current).toBe('foo');
+
+    await act(async () => test.set(null));
+
+    hook.rerender();
+
+    expect(hook.result.current).toBe('foo');
   });
 });

--- a/packages/react/src/use.ts
+++ b/packages/react/src/use.ts
@@ -14,26 +14,28 @@ export function use<T extends object>(subject: T) {
   if (current.source !== subject) {
     const status = observer(subject);
 
-    if (status === null)
-      throw new Error('Provided object is no longer observable.');
-
-    if (!status)
+    if (status === undefined)
       throw new Error('Provided object is not observable.');
-
-    if (!status.ready) event(subject);
 
     current.unwatch?.();
     current.source = subject;
 
-    let init = true;
+    if (status === null) {
+      current.unwatch = undefined;
+      current.proxy = subject;
+    } else {
+      if (!status.ready) event(subject);
 
-    current.unwatch = watch(subject, (next, changed) => {
-      current.proxy = next;
-      if (changed.length && !init)
-        update((x) => x + 1);
-    });
+      let init = true;
 
-    init = false;
+      current.unwatch = watch(subject, (next, changed) => {
+        current.proxy = next;
+        if (changed.length && !init)
+          update((x) => x + 1);
+      });
+
+      init = false;
+    }
   }
 
   Runtime.useEffect(() => () => {


### PR DESCRIPTION
Resolves #120. Prerequisite for #118: destroying an instance is only safe while a React tree may still reference it if that contact no longer throws.

## Why

React holds references to instances longer than any teardown scheme can know — retained element props, dev-mode props diffing, parked transition lanes. Before this change, every contact with a destroyed instance threw, and those throws landed inside render, commit, or listener dispatch: one navigation in the examples app produced 117 uncaught `terminated` errors and corrupted React's scheduler (`'Should not already be working'`). Any teardown timing — even a provably correct one — could crash a live app.

## What changes on merge

**Reads of a destroyed instance settle instead of throwing.** A tree repainting a frame it already had gets last-known values:

| Contact | Now |
|---|---|
| `use(instance)` over a corpse | renders last-known values, never updates again |
| React writing `props` to a still-mounted class `Component` after destroy | write is ignored; `props` becomes plain data |
| Read of a pending (`set`/`get` instruction) property | `undefined` |
| Read of a computed/getter | last-known value; `undefined` if never evaluated |
| `Type.get` after its context owner was destroyed while mounted | last-known values (factory evaluated once) |

Plus one internal fix: an effect re-run enqueued before destroy but dispatched after now bails instead of throwing mid-dispatch — this was the direct source of the scheduler corruption.

**Subscriptions and writes still throw.** `watch()`, `.get(effect)`, property assignment, `.set(...)`, `listener()` (including handing a destroyed instance to `Provider`) — all unchanged and pinned by tests. Reads can't corrupt anything; a subscription or write on a corpse is a genuine use-after-free and stays loud.

## Verification

- mvc 467 / react 191 / preact 32 pass; 100% line + function coverage; every commit independently green.
- Each tolerant guard verified red without it. Examples-app check: cold load 136 → 7 anchors exact, navigation 117 console errors → 0.
- Assertions live in the suites they extend (`use`, `subcomponents`, `State.get`, destroyed-update tests) — no separate contract file. Four commits, one concern each; messages carry per-site rationale, including which adapter seams were deliberately left throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)