### PR TITLE
feat(react): fallback === false opts a Component out of its Suspense boundary

### DIFF
--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -36,7 +36,11 @@ declare namespace Component {
     /** Callback for newly created instance. Only called once. */
     is?: (instance: T) => void;
 
-    /** Fallback to show when suspended or in error recovery. */
+    /**
+     * Fallback to show when suspended or in error recovery.
+     * Pass `false` to opt out of the component's own suspense boundary,
+     * letting suspension bubble to an ancestor.
+     */
     fallback?: Component.Node;
   }
 
@@ -86,6 +90,8 @@ class Component extends State {
    * Can be set as a class property or overridden via the `fallback` JSX prop.
    *
    * Defaults to null - nothing will be rendered.
+   * Set `false` to opt out of having a boundary at all - suspension then
+   * bubbles to the nearest ancestor boundary.
    */
   fallback: Component.Node = set(null);
 

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -504,6 +504,54 @@ describe('suspense', () => {
     element.getByText('Hello World');
   });
 
+  it('fallback === false opts out of the boundary, bubbling to an ancestor', async () => {
+    const ready = mockPromise<void>();
+    let done = false;
+    ready.then(() => { done = true; });
+    const Slow = () => {
+      if (!done) throw ready;
+      return <span>Hello World</span>;
+    };
+
+    class Transparent extends Component {
+      fallback = false as const; // Suspense-transparent: no own boundary
+    }
+
+    const element = render(
+      <React.Suspense fallback={<span>OUTER</span>}>
+        <Transparent>
+          <Slow />
+        </Transparent>
+      </React.Suspense>
+    );
+
+    // own boundary opted out -> child suspension bubbles to the ancestor
+    element.getByText('OUTER');
+
+    await act(async () => { ready.resolve(); });
+
+    element.getByText('Hello World');
+  });
+
+  it('default boundary catches its own subtree (control for opt-out)', () => {
+    const Slow = () => { throw new Promise<void>(() => {}); }; // never resolves
+
+    class Own extends Component {
+      fallback = (<span>INNER</span>);
+    }
+
+    const element = render(
+      <React.Suspense fallback={<span>OUTER</span>}>
+        <Own>
+          <Slow />
+        </Own>
+      </React.Suspense>
+    );
+
+    // own boundary catches - never reaches OUTER
+    element.getByText('INNER');
+  });
+
   it('will update with new fallback', async () => {
     class Foo extends Component {
       value = set<string>();

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -95,11 +95,17 @@ function component(from: Component, context: Context) {
       };
     }) || from;
 
+    const rendered = createElement(Render);
+
+    // fallback === false opts out of the auto-Suspense boundary,
+    // letting a child's suspension bubble to an ancestor boundary.
     const children = createElement(Layers.Provider, {
       value: context,
-      children: createElement(Suspense,
-        { fallback: from.fallback, name: String(from) },
-        createElement(Render))
+      children: from.fallback === false
+        ? rendered
+        : createElement(Suspense,
+          { fallback: from.fallback, name: String(from) },
+          rendered)
     });
 
     return from.catch


### PR DESCRIPTION
## What

Every `Component` normally wraps its output in its own `Suspense` boundary using `this.fallback`. This adds an opt-out: setting `fallback = false` renders no boundary at all, making the component Suspense-transparent - a descendant's suspension bubbles to the nearest ancestor boundary. Context (`Layers.Provider`) is unaffected.

## Behavior change

Previously `fallback = false` was passed through as the Suspense fallback (a valid ReactNode rendering nothing) - the boundary still existed and trapped suspension locally. Now `false` removes the boundary. Any other value, including `null` (the default) and `undefined`, behaves as before.

## Tests

- `fallback === false` lets a suspending child reach an ancestor boundary, then resolves in place.
- Control: a normal fallback still catches its own subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)