### PR TITLE
refactor(router): author against the agnostic JSX pragma

### DIFF
--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -1,5 +1,5 @@
-import { Component, get } from '@expressive/react';
-import { AnchorHTMLAttributes, MouseEvent } from 'react';
+import { Component, get } from '@expressive/mvc';
+import type { AnchorHTMLAttributes, MouseEvent } from 'react';
 
 import { Route } from './route';
 

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource react */
 import { Component, get } from '@expressive/react';
 import { AnchorHTMLAttributes, MouseEvent } from 'react';
 

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -1,12 +1,27 @@
 import { Component, get } from '@expressive/mvc';
-import type { AnchorHTMLAttributes, MouseEvent } from 'react';
+import type { JSX } from '@expressive/mvc/jsx-runtime';
 
 import { Route } from './route';
 
+/** Host anchor attributes when the adapter declares intrinsics; `{}` agnostically. */
+type AnchorProps = JSX.IntrinsicElements extends { a: infer T } ? T : {};
+
+/** What `go` reads off a click - structural, no host event type needed. */
+interface ClickEvent {
+  defaultPrevented: boolean;
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  preventDefault(): void;
+}
+
 export namespace Link {
-  export type Props = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  export type Props = AnchorProps & {
     to?: string;
     replace?: boolean;
+    children?: Component.Node;
   };
 }
 
@@ -21,7 +36,7 @@ export class Link extends Component {
     return this.route.resolve(this.to);
   }
 
-  private go = (e: MouseEvent<HTMLAnchorElement>) => {
+  private go = (e: ClickEvent) => {
     if (e.defaultPrevented || e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource react */
 import { Component, get } from '@expressive/react';
 import { AnchorHTMLAttributes, MouseEvent } from 'react';
 

--- a/packages/router/src/nav.test.tsx
+++ b/packages/router/src/nav.test.tsx
@@ -153,3 +153,84 @@ it('Group slot can wrap a group as a section (opt-in)', async () => {
   expect(section!.textContent).toContain('Docs');
   expect(links(view)).toEqual(['/a']);
 });
+
+it('suspending Item takes the whole nav, not one row', async () => {
+  let resolve!: () => void;
+  let ready = false;
+  const pending = new Promise<void>((r) => (resolve = r)).then(() => {
+    ready = true;
+  });
+
+  class MyNav extends NavLinks {
+    Item({ route }: { route: Route }) {
+      if (route.path === '/b' && !ready) throw pending;
+      return <a href={route.path}>{route.path}</a>;
+    }
+  }
+
+  const Page = ({ children }: { children?: React.ReactNode }) => (
+    <div>
+      <span data-page />
+      <MyNav />
+      {children}
+    </div>
+  );
+
+  const view = await renderAct(
+    <Route as={Page}>
+      <Route to="a" />
+      <Route to="b" />
+    </Route>
+  );
+
+  // Entry declares no boundary (fallback = false), so one suspending Item
+  // suspends the nav as a unit - sibling rows don't render around a hole,
+  // and the rest of the page is untouched.
+  expect(links(view)).toEqual([]);
+  expect(view.container.querySelector('[data-page]')).toBeTruthy();
+
+  await act(async () => {
+    resolve();
+    await pending;
+  });
+  expect(links(view)).toEqual(['/a', '/b']);
+});
+
+it('NavLinks fallback shows while an Item suspends', async () => {
+  let resolve!: () => void;
+  let ready = false;
+  const pending = new Promise<void>((r) => (resolve = r)).then(() => {
+    ready = true;
+  });
+
+  class MyNav extends NavLinks {
+    fallback = (<span data-pending />);
+
+    Item({ route }: { route: Route }) {
+      if (!ready) throw pending;
+      return <a href={route.path}>{route.path}</a>;
+    }
+  }
+
+  const Page = ({ children }: { children?: React.ReactNode }) => (
+    <div>
+      <MyNav />
+      {children}
+    </div>
+  );
+
+  const view = await renderAct(
+    <Route as={Page}>
+      <Route to="a" />
+    </Route>
+  );
+
+  expect(view.container.querySelector('[data-pending]')).toBeTruthy();
+
+  await act(async () => {
+    resolve();
+    await pending;
+  });
+  expect(view.container.querySelector('[data-pending]')).toBeNull();
+  expect(links(view)).toEqual(['/a']);
+});

--- a/packages/router/src/nav.tsx
+++ b/packages/router/src/nav.tsx
@@ -1,6 +1,5 @@
-/** @jsxImportSource react */
 import { Component, get, use } from '@expressive/react';
-import { ComponentType, Fragment, ReactNode } from 'react';
+import { Fragment, ReactNode } from 'react';
 
 import { Link } from './link';
 import { Route } from './route';
@@ -58,7 +57,7 @@ export class NavLinks extends Component {
   }
 }
 
-type ItemType = ComponentType<{ route: Route; active: boolean; label?: string; meta: Route['meta'] }>;
+type ItemType = (props: { route: Route; active: boolean; label?: string; meta: Route['meta'] }) => ReactNode;
 
 function Entry(props: { route: Route; Item: ItemType; children?: ReactNode }) {
   const route = use(props.route);

--- a/packages/router/src/nav.tsx
+++ b/packages/router/src/nav.tsx
@@ -1,5 +1,4 @@
-import { Component, get, use } from '@expressive/react';
-import { Fragment, ReactNode } from 'react';
+import { Component, get } from '@expressive/mvc';
 
 import { Link } from './link';
 import { Route } from './route';
@@ -7,11 +6,11 @@ import { Route } from './route';
 export class NavLinks extends Component {
   route = get(Route);
 
-  List(props: { children?: ReactNode }): ReactNode {
+  List(props: { children?: Component.Node }): Component.Node {
     return <ul>{props.children}</ul>;
   }
 
-  Item(props: { route: Route; active: boolean; label?: string; meta: Route['meta'] }): ReactNode {
+  Item(props: { route: Route; active: boolean; label?: string; meta: Route['meta'] }): Component.Node {
     const { route, active, label } = props;
     return (
       <Link to={route.path} aria-current={active ? 'page' : undefined}>
@@ -26,7 +25,7 @@ export class NavLinks extends Component {
    * (the node's `label`/`meta` describe it), turning tree structure into nav
    * sections with no explicit navigation layer.
    */
-  Group(props: { route: Route; children?: ReactNode }): ReactNode {
+  Group(props: { route: Route; children?: Component.Node }): Component.Node {
     return props.children;
   }
 
@@ -34,7 +33,7 @@ export class NavLinks extends Component {
     return this.branch(this.route.inner);
   }
 
-  branch(routes: Route[]): ReactNode {
+  branch(routes: Route[]): Component.Node {
     const { Item, List, Group } = this;
 
     return (
@@ -57,15 +56,27 @@ export class NavLinks extends Component {
   }
 }
 
-type ItemType = (props: { route: Route; active: boolean; label?: string; meta: Route['meta'] }) => ReactNode;
+type ItemType = (props: { route: Route; active: boolean; label?: string; meta: Route['meta'] }) => Component.Node;
 
-function Entry(props: { route: Route; Item: ItemType; children?: ReactNode }) {
-  const route = use(props.route);
+/**
+ * Per-item reactive wrapper. `route` arrives as a prop and becomes a managed
+ * property, so reads in render (`route.matched`) wire cross-state
+ * subscriptions - same idiom as `Route.router`, no host hook involved.
+ */
+class Entry extends Component {
+  route?: Route = undefined;
+  Item?: ItemType = undefined;
 
-  return (
-    <Fragment>
-      <props.Item route={route} active={route.matched} label={route.label} meta={route.meta} />
-      {props.children}
-    </Fragment>
-  )
+  render(props = {} as { children?: Component.Node }) {
+    const { route, Item } = this;
+
+    if (!route || !Item) return null;
+
+    return (
+      <>
+        <Item route={route} active={route.matched} label={route.label} meta={route.meta} />
+        {props.children}
+      </>
+    );
+  }
 }

--- a/packages/router/src/nav.tsx
+++ b/packages/router/src/nav.tsx
@@ -67,6 +67,10 @@ class Entry extends Component {
   route?: Route = undefined;
   Item?: ItemType = undefined;
 
+  /** Entry never suspends itself; no boundary here - a suspending custom
+   * `Item` bubbles to NavLinks (or above) rather than blanking one row. */
+  fallback = false;
+
   render(props = {} as { children?: Component.Node }) {
     const { route, Item } = this;
 

--- a/packages/router/src/nav.tsx
+++ b/packages/router/src/nav.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource react */
 import { Component, get, use } from '@expressive/react';
 import { ComponentType, Fragment, ReactNode } from 'react';
 

--- a/packages/router/src/redirect.ts
+++ b/packages/router/src/redirect.ts
@@ -1,4 +1,4 @@
-import { Component, get } from '@expressive/react';
+import { Component, get } from '@expressive/mvc';
 
 import { Route } from './route';
 

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -770,3 +770,32 @@ describe('default', () => {
     expect(view.container.textContent).toBe('F');
   });
 });
+it('match keeps identity when recompute yields equal params', async () => {
+  location('/posts/foo');
+  let leaf!: Route;
+  render(<Route to="/posts/:id" is={(r) => (leaf = r)} />);
+
+  const first = leaf.match;
+  expect(first).toEqual({ id: 'foo' });
+
+  // Case-insensitive literal: the path changes (forcing recompute) but the
+  // captures are equal, so match returns the previous object - reactive
+  // consumers see no change.
+  await act(async () => router.current.goto('/POSTS/foo'));
+  expect(leaf.match).toBe(first!);
+});
+
+it('deregisters a child from parent.inner on unmount', async () => {
+  location('/');
+  let parent!: Route;
+
+  const view = await renderAct(
+    <Route is={(r) => (parent = r)}>
+      <Route to="a" />
+    </Route>
+  );
+  expect(parent.inner.map((r) => r.path)).toEqual(['/a']);
+
+  await act(async () => view.rerender(<Route is={(r) => (parent = r)} />));
+  expect(parent.inner).toEqual([]);
+});

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -1,11 +1,5 @@
-import { Component, get, set } from '@expressive/react';
-import {
-  Children,
-  ComponentType,
-  Fragment,
-  ReactNode,
-  isValidElement
-} from 'react';
+import { Component, get, set } from '@expressive/mvc';
+import { childrenOf, Fragment, isElement, propsOf, typeOf } from '@expressive/mvc/jsx-runtime';
 
 import { Redirect } from './redirect';
 import { Router } from './router';
@@ -17,7 +11,7 @@ const CHILDREN = new WeakMap<Route, Route[]>();
 export class Route extends Component {
   router = set(() => this.get(Router, false) || new Router());
 
-  as?: ComponentType<{ children?: ReactNode }> = undefined;
+  as?: (props: { children?: Component.Node }) => Component.Node = undefined;
 
   to: string = '';
 
@@ -148,7 +142,7 @@ export class Route extends Component {
     this.router.goto(this.resolve(url), replace);
   }
 
-  render(props = {} as { children?: ReactNode }) {
+  render(props = {} as { children?: Component.Node }) {
     const self = this.is;
     const { parent, as: Component, matched } = this;
 
@@ -182,9 +176,9 @@ export class Route extends Component {
 }
 
 /** Does `children` hold a direct default Route? Such a scope resolves to it. */
-function hasDefault(children: ReactNode): boolean {
-  return Children.toArray(children).some(
-    (node) => isValidElement(node) && node.type === Route && (node.props as RouteProps).default
+function hasDefault(children: Component.Node): boolean {
+  return childrenOf(children).some(
+    (node) => isElement(node) && typeOf(node) === Route && (propsOf(node) as RouteProps).default
   );
 }
 
@@ -229,7 +223,7 @@ type RouteProps = {
   to?: string;
   redirect?: string;
   default?: boolean;
-  children?: ReactNode;
+  children?: Component.Node;
 };
 
 /**
@@ -239,20 +233,20 @@ type RouteProps = {
  * Blind to class-field `to` (subclasses) and component-internal routes (the
  * `*`-delegation case) - the documented limits of the lexical model.
  */
-export function matchesAnywhere(children: ReactNode, base: string, path: string): boolean {
-  for (const node of Children.toArray(children)) {
-    if (!isValidElement(node)) continue;
+export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
+  for (const node of childrenOf(children)) {
+    if (!isElement(node)) continue;
 
-    const { type } = node;
+    const type = typeOf(node);
 
     if (type === Fragment) {
-      if (matchesAnywhere((node.props as RouteProps).children, base, path)) return true;
+      if (matchesAnywhere((propsOf(node) as RouteProps).children, base, path)) return true;
       continue;
     }
 
     if (type !== Route) continue;
 
-    const props = node.props as RouteProps;
+    const props = propsOf(node) as RouteProps;
     if (props.redirect || props.default) continue;
 
     const to = typeof props.to === 'string' ? props.to : '';
@@ -268,14 +262,14 @@ export function matchesAnywhere(children: ReactNode, base: string, path: string)
   return false;
 }
 
-function allRoutes(children: ReactNode): boolean {
-  const nodes = Children.toArray(children);
+function allRoutes(children: Component.Node): boolean {
+  const nodes = childrenOf(children);
 
   return nodes.length > 0 && nodes.every((node) => {
-    if (!isValidElement(node)) return false;
-    const { type } = node;
+    if (!isElement(node)) return false;
+    const type = typeOf(node);
     if (type === Fragment)
-      return allRoutes((node.props as { children?: ReactNode }).children);
+      return allRoutes((propsOf(node) as RouteProps).children);
     return type === Route || (typeof type === 'function' && type.prototype instanceof Route);
   });
 }

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -45,9 +45,12 @@ export class Route extends Component {
   /** Captured params from the current match, or `undefined` when unmatched.
    * Stable identity across reads when captures are unchanged. */
   get match(): Record<string, string> | undefined {
+    // Key by the real instance - this getter runs under observer proxies too,
+    // and per-proxy entries would break identity stability across contexts.
+    const self = this.is;
     const next = this.router.match(this.base, this.to)?.params;
-    const has = PARAMS.has(this);
-    const prev = PARAMS.get(this);
+    const has = PARAMS.has(self);
+    const prev = PARAMS.get(self);
 
     if (has && !next === !prev) {
       if (!next) return prev;
@@ -56,7 +59,7 @@ export class Route extends Component {
         return prev;
     }
 
-    PARAMS.set(this, next);
+    PARAMS.set(self, next);
     return next;
   }
 

--- a/packages/router/src/router.test.tsx
+++ b/packages/router/src/router.test.tsx
@@ -104,6 +104,20 @@ describe('BrowserRouter', () => {
     expect(router.current.path).toBe('/replaced-external');
   });
 
+  it('back/forward delegate to window.history', () => {
+    const back = spyOn(window.history, 'back');
+    const forward = spyOn(window.history, 'forward');
+
+    router.current.back();
+    router.current.forward();
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(forward).toHaveBeenCalledTimes(1);
+
+    back.mockRestore();
+    forward.mockRestore();
+  });
+
   it('removes popstate listener on destroy', () => {
     const remove = spyOn(window, 'removeEventListener');
     router.current.set(null);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,4 @@
-import { Component } from '@expressive/react';
+import { Component } from '@expressive/mvc';
 
 import { Route } from './route';
 import { Match, fullPattern, matchPattern, patternSegment } from './url';

--- a/packages/router/test.setup.ts
+++ b/packages/router/test.setup.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach } from 'bun:test';
 import { act, cleanup, render } from '@testing-library/react';
+
+// React is the declared test host. This import is doubly load-bearing: it
+// registers the JSX runtime (values) AND carries the Host augmentation that
+// lets host tags (<a>, <ul>) and Component.Node typecheck across the whole
+// package - src and tests compile as one program, and no src module imports
+// the adapter.
 import '@expressive/react';
 
 import '../mvc/test.setup';

--- a/packages/router/test.setup.ts
+++ b/packages/router/test.setup.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach } from 'bun:test';
 import { act, cleanup, render } from '@testing-library/react';
+import '@expressive/react';
 
 import '../mvc/test.setup';
 import { BrowserRouter } from './src/router';

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "esModuleInterop": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "@expressive/mvc",
     "lib": ["ES2020", "DOM"],
     "moduleResolution": "bundler",
     "skipLibCheck": true,

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true,
     "types": ["bun", "react"],
     "paths": {
+      "@expressive/mvc/*": ["../mvc/src/*"],
       "@expressive/*": ["../*/src"]
     }
   },


### PR DESCRIPTION
## Summary

First satellite PR of the #130 queue: router authors against the agnostic JSX pragma from #106/#127. **The package's src is now fully adapter-free** - every module value-imports only `@expressive/mvc` (+ `/jsx-runtime`); the built runtime carries zero react imports. React remains the declared test host, bootstrapped in one documented place.

- `tsconfig`: `jsxImportSource: "@expressive/mvc"` package-wide, plus the `@expressive/mvc/*` wildcard path mapping (TS paths can't insert `/src` mid-specifier, so packages compiling adapters from src need the subpath rule).
- `route.tsx`: the lexical walkers (`matchesAnywhere`, `allRoutes`, `hasDefault`) use the seam's `childrenOf` / `isElement` / `typeOf` / `propsOf` and the agnostic `Fragment` sentinel instead of `Children.toArray` / `isValidElement` / `node.type`. `ReactNode` → `Component.Node` throughout; `as` is an agnostic render-function type.
- `nav.tsx`: **resolves #129** - `Entry` is a `Component`; `route` arrives as a prop, becomes a managed property, and reads in render (`route.matched`) wire cross-state subscriptions - the same idiom as `Route.router`. The react `use` hook is gone; no hook concept enters core. Covered by the existing "marks the active link and updates on navigation" test.
- `link.tsx`: fully agnostic - values from `@expressive/mvc`, `Link.Props` derives anchor attributes from the intrinsics manifest, click handler typed structurally. No react imports at all.
- `test.setup.ts`: the single `import '@expressive/react'` is the declared host bootstrap, documented as doubly load-bearing - it registers the runtime (values) and carries the Host augmentation that lets host tags and `Component.Node` typecheck across the package (src + tests compile as one program).

## Shipping posture

Built output (`tsdown`): runtime imports only `@expressive/mvc` + `/jsx-runtime` - a consumer's adapter supplies the host. Types emit in terms of `Component.Node` (unresolved until the consumer's adapter augments - correct for an agnostic package), with zero react references - `Link.Props` derives anchor attributes from `JSX.IntrinsicElements` via the Host manifest (full passthrough under an adapter, `{ to, replace, children }` agnostically). Giving `<a>`/`<ul>` a typed agnostic story not routed through the test program) is #128 (canonical elements).

One react-19 nit surfaced: `ComponentType` admits `Promise<ReactNode>` returns (server components), which agnostic `ElementType` rightly rejects - nav's `ItemType` is a plain function type now.

Dogfood findings already fed back upstream during authoring: the `ElementClass` variance fix and the wildcard tsconfig form both landed via #127.

Resolves #129.

