### PR TITLE
fix(router): first-match sibling arbitration by declaration order

### DIFF
--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -276,10 +276,6 @@ describe('Route', () => {
   });
 
   describe('declaration order', () => {
-    // First matching sibling with `as` wins; precedence is positional, so an
-    // earlier, less-specific pattern shadows a more-specific one below it -
-    // WYSIWYG, like Express routes or `switch` cases. Order specific-first.
-
     it('first matching sibling wins, shadowing later ones', () => {
       location('/posts/new');
       const view = render(

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -275,11 +275,12 @@ describe('Route', () => {
     expect(view.container.textContent).toBe('About');
   });
 
-  describe('specificity', () => {
-    // Siblings arbitrate by match score (literal > :param > *); declaration
-    // order only breaks ties.
+  describe('declaration order', () => {
+    // First matching sibling with `as` wins; precedence is positional, so an
+    // earlier, less-specific pattern shadows a more-specific one below it -
+    // WYSIWYG, like Express routes or `switch` cases. Order specific-first.
 
-    it('literal wins over :param declared first', () => {
+    it('first matching sibling wins, shadowing later ones', () => {
       location('/posts/new');
       const view = render(
         <Route>
@@ -287,38 +288,11 @@ describe('Route', () => {
           <Route to="/posts/new" as={() => <span>literal</span>} />
         </Route>
       );
-      expect(view.container.textContent).toBe('literal');
-    });
-
-    it(':param wins over * declared first', () => {
-      location('/posts/foo');
-      const view = render(
-        <Route>
-          <Route to="*" as={() => <span>catch-all</span>} />
-          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
-        </Route>
-      );
+      // :id matches /posts/new first, so it shadows the literal below it.
       expect(view.container.textContent).toBe('dynamic');
     });
 
-    it('re-arbitrates by specificity on navigation', async () => {
-      location('/posts/foo');
-      const view = render(
-        <Route>
-          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
-          <Route to="/posts/new" as={() => <span>literal</span>} />
-        </Route>
-      );
-      expect(view.container.textContent).toBe('dynamic');
-
-      await act(async () => router.current.goto('/posts/new'));
-      expect(view.container.textContent).toBe('literal');
-
-      await act(async () => router.current.goto('/posts/bar'));
-      expect(view.container.textContent).toBe('dynamic');
-    });
-
-    it('literal declared first wins over :param at the same path', () => {
+    it('literal declared first takes precedence', () => {
       location('/posts/new');
       const view = render(
         <Route>
@@ -329,7 +303,7 @@ describe('Route', () => {
       expect(view.container.textContent).toBe('literal');
     });
 
-    it(':param declared first wins over * at the same path', () => {
+    it(':param declared first shadows a later catch-all', () => {
       location('/posts/foo');
       const view = render(
         <Route>
@@ -340,7 +314,7 @@ describe('Route', () => {
       expect(view.container.textContent).toBe('dynamic');
     });
 
-    it('catch-all matches when no earlier sibling does', () => {
+    it('catch-all declared last catches what earlier siblings miss', () => {
       location('/anything/at/all');
       const view = render(
         <Route>
@@ -351,7 +325,24 @@ describe('Route', () => {
       expect(view.container.textContent).toBe('not-found');
     });
 
-    it('first declared wins on a true tie', () => {
+    it('re-resolves the winner on navigation', async () => {
+      location('/posts/new');
+      const view = render(
+        <Route>
+          <Route to="/posts/new" as={() => <span>literal</span>} />
+          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('literal');
+
+      await act(async () => router.current.goto('/posts/bar'));
+      expect(view.container.textContent).toBe('dynamic');
+
+      await act(async () => router.current.goto('/posts/new'));
+      expect(view.container.textContent).toBe('literal');
+    });
+
+    it('first declared wins among equal matches', () => {
       location('/posts/foo');
       const view = render(
         <Route>

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -275,10 +275,48 @@ describe('Route', () => {
     expect(view.container.textContent).toBe('About');
   });
 
-  describe('declaration order', () => {
-    // Specificity-based arbitration (literal > :param > *) is pending.
-    // For now, the first matching sibling with `as` wins - users declare
-    // more-specific routes before less-specific ones.
+  describe('specificity', () => {
+    // Siblings arbitrate by match score (literal > :param > *); declaration
+    // order only breaks ties.
+
+    it('literal wins over :param declared first', () => {
+      location('/posts/new');
+      const view = render(
+        <Route>
+          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
+          <Route to="/posts/new" as={() => <span>literal</span>} />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('literal');
+    });
+
+    it(':param wins over * declared first', () => {
+      location('/posts/foo');
+      const view = render(
+        <Route>
+          <Route to="*" as={() => <span>catch-all</span>} />
+          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('dynamic');
+    });
+
+    it('re-arbitrates by specificity on navigation', async () => {
+      location('/posts/foo');
+      const view = render(
+        <Route>
+          <Route to="/posts/:id" as={() => <span>dynamic</span>} />
+          <Route to="/posts/new" as={() => <span>literal</span>} />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('dynamic');
+
+      await act(async () => router.current.goto('/posts/new'));
+      expect(view.container.textContent).toBe('literal');
+
+      await act(async () => router.current.goto('/posts/bar'));
+      expect(view.container.textContent).toBe('dynamic');
+    });
 
     it('literal declared first wins over :param at the same path', () => {
       location('/posts/new');

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -145,6 +145,49 @@ export class Route extends Component {
     this.router.goto(this.resolve(url), replace);
   }
 
+  /**
+   * Of the `as`-bearing child Routes competing for this scope's single slot,
+   * decide whether `child` should cede it. Highest specificity wins (literal >
+   * `:param` > catch-all); equal scores break by declaration order. `child`
+   * yields unless it is that winner.
+   *
+   * Arbitration is the parent's call, not the child's, and purely lexical:
+   * contenders and their scores are read from this Route's own children JSX
+   * (their `to` props), so the field is whole before any child mounts - no
+   * first-paint flicker, no walking live siblings. A Route whose pattern isn't
+   * lexically visible (subclass class-field `to`, component-delegated matching)
+   * doesn't contend, and a non-contending `child` is left to its own match
+   * rather than suppressed.
+   *
+   * The verdict turns on `path`, which the child supplies from its own proxy
+   * (so it re-arbitrates on navigation even when its `matched` is unchanged);
+   * `contests` first gates that read to real rivalries, leaving a solitary
+   * matched Route unsubscribed and free to reconcile in place.
+   */
+  contests(child: Route): boolean {
+    // A fallback/redirect never competes on specificity (and a default's path
+    // collides with a bare sibling's), so it's neither a rival nor arbitrated.
+    if (child.default || child.redirect) return false;
+
+    const rivals = contenders(this.props.children, scopeBase(this));
+    return rivals.length > 1 && rivals.some((r) => r.path === child.path);
+  }
+
+  arbitrate(child: Route, path: string): boolean {
+    let best: number | null = null;
+    let winner: string | null = null;
+
+    for (const rival of contenders(this.props.children, scopeBase(this))) {
+      const found = rival.score(path);
+      if (found !== null && (best === null || found > best)) {
+        best = found;
+        winner = rival.path;
+      }
+    }
+
+    return winner !== child.path;
+  }
+
   render(props = {} as { children?: Component.Node }) {
     const self = this.is;
     const { parent, as: Component, matched } = this;
@@ -152,7 +195,10 @@ export class Route extends Component {
     if (parent) {
       register(parent.is, self);
 
-      if (Component && outscored(this, parent)) return null;
+      // Defer the verdict to the parent, but read `path` here (our own proxy)
+      // so a re-arbitration re-renders us; gated to real rivalries first.
+      if (Component && parent.contests(self) && parent.arbitrate(self, this.router.path))
+        return null;
     }
 
     if (this.redirect)
@@ -266,65 +312,31 @@ function bestScore(children: Component.Node, base: string, path: string): number
   return best;
 }
 
-/** Specificity of a Route's own claim on `path`: a leaf's match score, a
- * see-through scope's best descendant score; null when unmatched. */
-function score(route: Route, path: string): number | null {
-  if (hasRoutes(route))
-    return bestScore(route.props.children, scopeBase(route), path);
-
-  const match = route.router.match(route.base, route.to);
-  return match ? match.score : null;
-}
+type Contender = {
+  /** Absolute path this Route claims - matched against a child's `path` to tie
+   * the lexical verdict back to the rendering instance. */
+  path: string;
+  /** Specificity of its claim on a given path; null when it doesn't match. */
+  score: (path: string) => number | null;
+};
 
 /**
- * Should `self` (matched or not) yield its slot? Siblings with `as` compete by
- * specificity score; declaration order breaks ties. Registered siblings are
- * compared directly (reactive via `parent.inner`, so late registrants settle);
- * a lexical scan of the parent's JSX covers higher-scored siblings declared
- * later but not yet mounted.
+ * The `as`-bearing Route nodes declared directly within `children` that vie for
+ * a single slot, each paired with the path it claims and a path-scored lookup.
+ * Recurses Fragments but stops at nested Route scopes - those arbitrate within
+ * their own parent. Lexical only (reads `to` props), so subclass and
+ * component-delegated Routes don't appear - mirroring `bestScore`.
  */
-function outscored(route: Route, parent: Route): boolean {
-  const self = route.is;
-  const siblings = parent.inner;
-  const rivalry = siblings.some((s) => s !== self && s.as);
+function contenders(children: Component.Node, base: string): Contender[] {
+  const out: Contender[] = [];
 
-  // Only competing Routes make the verdict path-dependent; absent rivals,
-  // skip the tracked read so same-pattern navigation reconciles in place.
-  const { path } = rivalry ? route.router : self.router;
-  const own = score(self, path);
-  let before = true;
-
-  for (const sibling of siblings) {
-    if (sibling === self) {
-      before = false;
-      continue;
-    }
-
-    if (!sibling.as || !sibling.matched) continue;
-    if (own === null) {
-      if (before) return true;
-      continue;
-    }
-
-    const rival = score(sibling, path) ?? -Infinity;
-
-    if (rival > own || (rival === own && before)) return true;
-  }
-
-  return own !== null
-    && !!parent.props
-    && outscoredLexically(parent.props.children, scopeBase(parent), path, own);
-}
-
-/** Is a higher-scored competing Route (with `as`) declared within `children`? */
-function outscoredLexically(children: Component.Node, base: string, path: string, own: number): boolean {
   for (const node of childrenOf(children)) {
     if (!isElement(node)) continue;
 
     const type = typeOf(node);
 
     if (type === Fragment) {
-      if (outscoredLexically((propsOf(node) as RouteProps).children, base, path, own)) return true;
+      out.push(...contenders((propsOf(node) as RouteProps).children, base));
       continue;
     }
 
@@ -334,14 +346,14 @@ function outscoredLexically(children: Component.Node, base: string, path: string
     if (!props.as || props.redirect || props.default) continue;
 
     const to = typeof props.to === 'string' ? props.to : '';
-    const rival = allRoutes(props.children)
-      ? bestScore(props.children, base + patternSegment(to), path)
-      : matchPattern(fullPattern(base, to), path)?.score ?? null;
+    const score = allRoutes(props.children)
+      ? (path: string) => bestScore(props.children, base + patternSegment(to), path)
+      : (path: string) => matchPattern(fullPattern(base, to), path)?.score ?? null;
 
-    if (rival !== null && rival > own) return true;
+    out.push({ path: base + patternSegment(to), score });
   }
 
-  return false;
+  return out;
 }
 
 function allRoutes(children: Component.Node): boolean {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -147,26 +147,27 @@ export class Route extends Component {
 
   /**
    * Of the `as`-bearing child Routes competing for this scope's single slot,
-   * decide whether `child` should cede it. Highest specificity wins (literal >
-   * `:param` > catch-all); equal scores break by declaration order. `child`
-   * yields unless it is that winner.
+   * decide whether `child` should cede it. The first one (in declaration order)
+   * that matches the path wins; `child` yields unless it is that one. Precedence
+   * is positional - an earlier, less-specific pattern shadows a later one, the
+   * way Express routes or `switch` cases do - so order specific-before-general.
    *
    * Arbitration is the parent's call, not the child's, and purely lexical:
-   * contenders and their scores are read from this Route's own children JSX
-   * (their `to` props), so the field is whole before any child mounts - no
-   * first-paint flicker, no walking live siblings. A Route whose pattern isn't
-   * lexically visible (subclass class-field `to`, component-delegated matching)
-   * doesn't contend, and a non-contending `child` is left to its own match
-   * rather than suppressed.
+   * contenders come from this Route's own children JSX (their `to` props), in
+   * source order, so the field is whole before any child mounts - no first-paint
+   * flicker, no walking live siblings. A Route whose pattern isn't lexically
+   * visible (subclass class-field `to`, component-delegated matching) doesn't
+   * contend, and a non-contending `child` is left to its own match rather than
+   * suppressed.
    *
    * The verdict turns on `path`, which the child supplies from its own proxy
-   * (so it re-arbitrates on navigation even when its `matched` is unchanged);
+   * (so it re-resolves on navigation even when its `matched` is unchanged);
    * `contests` first gates that read to real rivalries, leaving a solitary
    * matched Route unsubscribed and free to reconcile in place.
    */
   contests(child: Route): boolean {
-    // A fallback/redirect never competes on specificity (and a default's path
-    // collides with a bare sibling's), so it's neither a rival nor arbitrated.
+    // A fallback/redirect never competes by order (and a default's path collides
+    // with a bare sibling's), so it's neither a rival nor arbitrated.
     if (child.default || child.redirect) return false;
 
     const rivals = contenders(this.props.children, scopeBase(this));
@@ -174,18 +175,11 @@ export class Route extends Component {
   }
 
   arbitrate(child: Route, path: string): boolean {
-    let best: number | null = null;
-    let winner: string | null = null;
+    for (const rival of contenders(this.props.children, scopeBase(this)))
+      if (rival.matches(path))
+        return rival.path !== child.path;
 
-    for (const rival of contenders(this.props.children, scopeBase(this))) {
-      const found = rival.score(path);
-      if (found !== null && (best === null || found > best)) {
-        best = found;
-        winner = rival.path;
-      }
-    }
-
-    return winner !== child.path;
+    return true;
   }
 
   render(props = {} as { children?: Component.Node }) {
@@ -280,52 +274,48 @@ type RouteProps = {
  * `*`-delegation case) - the documented limits of the lexical model.
  */
 export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
-  return bestScore(children, base, path) !== null;
-}
-
-/** Highest specificity score among matching Routes lexically within `children`,
- * or null when none match. Same walk (and limits) as `matchesAnywhere`. */
-function bestScore(children: Component.Node, base: string, path: string): number | null {
-  let best: number | null = null;
-
   for (const node of childrenOf(children)) {
     if (!isElement(node)) continue;
 
     const type = typeOf(node);
-    let found: number | null = null;
 
-    if (type === Fragment)
-      found = bestScore((propsOf(node) as RouteProps).children, base, path);
-    else if (type === Route) {
-      const props = propsOf(node) as RouteProps;
-      if (props.redirect || props.default) continue;
-
-      const to = typeof props.to === 'string' ? props.to : '';
-      found = allRoutes(props.children)
-        ? bestScore(props.children, base + patternSegment(to), path)
-        : matchPattern(fullPattern(base, to), path)?.score ?? null;
+    if (type === Fragment) {
+      if (matchesAnywhere((propsOf(node) as RouteProps).children, base, path)) return true;
+      continue;
     }
 
-    if (found !== null && (best === null || found > best)) best = found;
+    if (type !== Route) continue;
+
+    const props = propsOf(node) as RouteProps;
+    if (props.redirect || props.default) continue;
+
+    const to = typeof props.to === 'string' ? props.to : '';
+
+    if (allRoutes(props.children)) {
+      if (matchesAnywhere(props.children, base + patternSegment(to), path)) return true;
+      continue;
+    }
+
+    if (matchPattern(fullPattern(base, to), path)) return true;
   }
 
-  return best;
+  return false;
 }
 
 type Contender = {
   /** Absolute path this Route claims - matched against a child's `path` to tie
    * the lexical verdict back to the rendering instance. */
   path: string;
-  /** Specificity of its claim on a given path; null when it doesn't match. */
-  score: (path: string) => number | null;
+  /** Whether it claims (matches) a given path. */
+  matches: (path: string) => boolean;
 };
 
 /**
  * The `as`-bearing Route nodes declared directly within `children` that vie for
- * a single slot, each paired with the path it claims and a path-scored lookup.
- * Recurses Fragments but stops at nested Route scopes - those arbitrate within
- * their own parent. Lexical only (reads `to` props), so subclass and
- * component-delegated Routes don't appear - mirroring `bestScore`.
+ * a single slot, in declaration order, each paired with the path it claims and
+ * a match test. Recurses Fragments but stops at nested Route scopes - those
+ * arbitrate within their own parent. Lexical only (reads `to` props), so
+ * subclass and component-delegated Routes don't appear.
  */
 function contenders(children: Component.Node, base: string): Contender[] {
   const out: Contender[] = [];
@@ -346,11 +336,11 @@ function contenders(children: Component.Node, base: string): Contender[] {
     if (!props.as || props.redirect || props.default) continue;
 
     const to = typeof props.to === 'string' ? props.to : '';
-    const score = allRoutes(props.children)
-      ? (path: string) => bestScore(props.children, base + patternSegment(to), path)
-      : (path: string) => matchPattern(fullPattern(base, to), path)?.score ?? null;
+    const matches = allRoutes(props.children)
+      ? (path: string) => matchesAnywhere(props.children, base + patternSegment(to), path)
+      : (path: string) => matchPattern(fullPattern(base, to), path) !== null;
 
-    out.push({ path: base + patternSegment(to), score });
+    out.push({ path: base + patternSegment(to), matches });
   }
 
   return out;

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -145,43 +145,6 @@ export class Route extends Component {
     this.router.goto(this.resolve(url), replace);
   }
 
-  /**
-   * Of the `as`-bearing child Routes competing for this scope's single slot,
-   * decide whether `child` should cede it. The first one (in declaration order)
-   * that matches the path wins; `child` yields unless it is that one. Precedence
-   * is positional - an earlier, less-specific pattern shadows a later one, the
-   * way Express routes or `switch` cases do - so order specific-before-general.
-   *
-   * Arbitration is the parent's call, not the child's, and purely lexical:
-   * contenders come from this Route's own children JSX (their `to` props), in
-   * source order, so the field is whole before any child mounts - no first-paint
-   * flicker, no walking live siblings. A Route whose pattern isn't lexically
-   * visible (subclass class-field `to`, component-delegated matching) doesn't
-   * contend, and a non-contending `child` is left to its own match rather than
-   * suppressed.
-   *
-   * The verdict turns on `path`, which the child supplies from its own proxy
-   * (so it re-resolves on navigation even when its `matched` is unchanged);
-   * `contests` first gates that read to real rivalries, leaving a solitary
-   * matched Route unsubscribed and free to reconcile in place.
-   */
-  contests(child: Route): boolean {
-    // A fallback/redirect never competes by order (and a default's path collides
-    // with a bare sibling's), so it's neither a rival nor arbitrated.
-    if (child.default || child.redirect) return false;
-
-    const rivals = contenders(this.props.children, scopeBase(this));
-    return rivals.length > 1 && rivals.some((r) => r.path === child.path);
-  }
-
-  arbitrate(child: Route, path: string): boolean {
-    for (const rival of contenders(this.props.children, scopeBase(this)))
-      if (rival.matches(path))
-        return rival.path !== child.path;
-
-    return true;
-  }
-
   render(props = {} as { children?: Component.Node }) {
     const self = this.is;
     const { parent, as: Component, matched } = this;
@@ -189,9 +152,8 @@ export class Route extends Component {
     if (parent) {
       register(parent.is, self);
 
-      // Defer the verdict to the parent, but read `path` here (our own proxy)
-      // so a re-arbitration re-renders us; gated to real rivalries first.
-      if (Component && parent.contests(self) && parent.arbitrate(self, this.router.path))
+      // `path` read via our own proxy so re-arbitration re-renders us.
+      if (Component && cedes(parent, self, () => this.router.path))
         return null;
     }
 
@@ -303,19 +265,36 @@ export function matchesAnywhere(children: Component.Node, base: string, path: st
 }
 
 type Contender = {
-  /** Absolute path this Route claims - matched against a child's `path` to tie
-   * the lexical verdict back to the rendering instance. */
+  /** Absolute path this Route claims. */
   path: string;
   /** Whether it claims (matches) a given path. */
   matches: (path: string) => boolean;
 };
 
 /**
- * The `as`-bearing Route nodes declared directly within `children` that vie for
- * a single slot, in declaration order, each paired with the path it claims and
- * a match test. Recurses Fragments but stops at nested Route scopes - those
- * arbitrate within their own parent. Lexical only (reads `to` props), so
- * subclass and component-delegated Routes don't appear.
+ * Whether `child` should cede `parent`'s single `as`-slot to an earlier rival.
+ * First contender (declaration order) matching the path wins. `path` is a thunk,
+ * read only once a real rivalry exists, so a solitary match stays unsubscribed.
+ */
+function cedes(parent: Route, child: Route, path: () => string): boolean {
+  // Fallback/redirect never competes by order, so it's never arbitrated.
+  if (child.default || child.redirect) return false;
+
+  const rivals = contenders(parent.props.children, scopeBase(parent));
+  if (rivals.length < 2 || !rivals.some((r) => r.path === child.path)) return false;
+
+  const at = path();
+  for (const rival of rivals)
+    if (rival.matches(at))
+      return rival.path !== child.path;
+
+  return true;
+}
+
+/**
+ * The `as`-bearing Route nodes declared directly within `children`, in
+ * declaration order, each paired with its claimed path and a match test.
+ * Recurses Fragments, stops at nested Route scopes. Lexical only (reads `to`).
  */
 function contenders(children: Component.Node, base: string): Contender[] {
   const out: Contender[] = [];

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -152,11 +152,7 @@ export class Route extends Component {
     if (parent) {
       register(parent.is, self);
 
-      if (Component)
-        for (const sibling of CHILDREN.get(parent.is)!) {
-          if (sibling === self) break;
-          if (sibling.as && sibling.matched) return null;
-        }
+      if (Component && outscored(this, parent)) return null;
     }
 
     if (this.redirect)
@@ -224,6 +220,7 @@ function hasRoutes(route: Route): boolean {
 
 type RouteProps = {
   to?: string;
+  as?: unknown;
   redirect?: string;
   default?: boolean;
   children?: Component.Node;
@@ -237,29 +234,111 @@ type RouteProps = {
  * `*`-delegation case) - the documented limits of the lexical model.
  */
 export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
+  return bestScore(children, base, path) !== null;
+}
+
+/** Highest specificity score among matching Routes lexically within `children`,
+ * or null when none match. Same walk (and limits) as `matchesAnywhere`. */
+function bestScore(children: Component.Node, base: string, path: string): number | null {
+  let best: number | null = null;
+
+  for (const node of childrenOf(children)) {
+    if (!isElement(node)) continue;
+
+    const type = typeOf(node);
+    let found: number | null = null;
+
+    if (type === Fragment)
+      found = bestScore((propsOf(node) as RouteProps).children, base, path);
+    else if (type === Route) {
+      const props = propsOf(node) as RouteProps;
+      if (props.redirect || props.default) continue;
+
+      const to = typeof props.to === 'string' ? props.to : '';
+      found = allRoutes(props.children)
+        ? bestScore(props.children, base + patternSegment(to), path)
+        : matchPattern(fullPattern(base, to), path)?.score ?? null;
+    }
+
+    if (found !== null && (best === null || found > best)) best = found;
+  }
+
+  return best;
+}
+
+/** Specificity of a Route's own claim on `path`: a leaf's match score, a
+ * see-through scope's best descendant score; null when unmatched. */
+function score(route: Route, path: string): number | null {
+  if (hasRoutes(route))
+    return bestScore(route.props.children, scopeBase(route), path);
+
+  const match = route.router.match(route.base, route.to);
+  return match ? match.score : null;
+}
+
+/**
+ * Should `self` (matched or not) yield its slot? Siblings with `as` compete by
+ * specificity score; declaration order breaks ties. Registered siblings are
+ * compared directly (reactive via `parent.inner`, so late registrants settle);
+ * a lexical scan of the parent's JSX covers higher-scored siblings declared
+ * later but not yet mounted.
+ */
+function outscored(route: Route, parent: Route): boolean {
+  const self = route.is;
+  const siblings = parent.inner;
+  const rivalry = siblings.some((s) => s !== self && s.as);
+
+  // Only competing Routes make the verdict path-dependent; absent rivals,
+  // skip the tracked read so same-pattern navigation reconciles in place.
+  const { path } = rivalry ? route.router : self.router;
+  const own = score(self, path);
+  let before = true;
+
+  for (const sibling of siblings) {
+    if (sibling === self) {
+      before = false;
+      continue;
+    }
+
+    if (!sibling.as || !sibling.matched) continue;
+    if (own === null) {
+      if (before) return true;
+      continue;
+    }
+
+    const rival = score(sibling, path) ?? -Infinity;
+
+    if (rival > own || (rival === own && before)) return true;
+  }
+
+  return own !== null
+    && !!parent.props
+    && outscoredLexically(parent.props.children, scopeBase(parent), path, own);
+}
+
+/** Is a higher-scored competing Route (with `as`) declared within `children`? */
+function outscoredLexically(children: Component.Node, base: string, path: string, own: number): boolean {
   for (const node of childrenOf(children)) {
     if (!isElement(node)) continue;
 
     const type = typeOf(node);
 
     if (type === Fragment) {
-      if (matchesAnywhere((propsOf(node) as RouteProps).children, base, path)) return true;
+      if (outscoredLexically((propsOf(node) as RouteProps).children, base, path, own)) return true;
       continue;
     }
 
     if (type !== Route) continue;
 
     const props = propsOf(node) as RouteProps;
-    if (props.redirect || props.default) continue;
+    if (!props.as || props.redirect || props.default) continue;
 
     const to = typeof props.to === 'string' ? props.to : '';
+    const rival = allRoutes(props.children)
+      ? bestScore(props.children, base + patternSegment(to), path)
+      : matchPattern(fullPattern(base, to), path)?.score ?? null;
 
-    if (allRoutes(props.children)) {
-      if (matchesAnywhere(props.children, base + patternSegment(to), path)) return true;
-      continue;
-    }
-
-    if (matchPattern(fullPattern(base, to), path)) return true;
+    if (rival !== null && rival > own) return true;
   }
 
   return false;

--- a/packages/router/src/url.test.ts
+++ b/packages/router/src/url.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'bun:test';
 import { fullPattern, matchPattern, patternSegment } from './url';
 
 const match = (pattern: string, path: string) => matchPattern(pattern, path)?.params;
-const score = (pattern: string, path: string) => matchPattern(pattern, path)!.score;
 
 describe('matchPattern', () => {
   it('matches root', () => {
@@ -136,34 +135,5 @@ describe('patternSegment', () => {
 
   it('preserves literal patterns unchanged', () => {
     expect(patternSegment('/posts/:id')).toBe('/posts/:id');
-  });
-});
-
-describe('match score (specificity)', () => {
-  it('ranks more literal segments higher', () => {
-    expect(score('/posts/new', '/posts/new')).toBeGreaterThan(
-      score('/posts/:id', '/posts/new')
-    );
-  });
-
-  it('ranks :param higher than catch-all', () => {
-    expect(score('/posts/:id', '/posts/foo')).toBeGreaterThan(
-      score('/posts/*', '/posts/foo')
-    );
-  });
-
-  it('ranks empty pattern (exact root) higher than catch-all', () => {
-    expect(score('', '')).toBeGreaterThan(score('*', ''));
-  });
-
-  it('catch-all alone is the least specific', () => {
-    expect(score('*', '/foo')).toBeLessThan(score('/foo', '/foo'));
-    expect(score('*', '/id')).toBeLessThan(score(':id', '/id'));
-  });
-
-  it('longer pattern with literals beats shorter pattern', () => {
-    expect(score('/posts/:id/edit', '/posts/x/edit')).toBeGreaterThan(
-      score('/posts/:id', '/posts/x')
-    );
   });
 });

--- a/packages/router/src/url.ts
+++ b/packages/router/src/url.ts
@@ -1,15 +1,10 @@
 export interface Match {
   params: Record<string, string>;
-  /**
-   * Higher = more specific. Per fixed segment: literal=100, :param=10.
-   * Catch-all subtracts 1; pure-literal patterns add 1.
-   */
-  score: number;
 }
 
 /**
- * Match a `path` against a route `pattern`. Returns captured params + specificity
- * score on success, or null on no match.
+ * Match a `path` against a route `pattern`. Returns captured params on success,
+ * or null on no match.
  *
  * - Literal segments match case-insensitively.
  * - `:name` segments capture into `params.name`.
@@ -27,23 +22,19 @@ export function matchPattern(pattern: string, path: string): Match | null {
     return null;
 
   const params: Record<string, string> = {};
-  let score = catchAll ? -1 : 1;
 
   for (let i = 0; i < fixed; i++) {
     const p = patternParts[i];
     const v = pathParts[i];
-    if (p.startsWith(':')) {
+    if (p.startsWith(':'))
       params[p.slice(1)] = v;
-      score += 10;
-    } else if (p.toLowerCase() === v.toLowerCase()) {
-      score += 100;
-    }
-    else return null;
+    else if (p.toLowerCase() !== v.toLowerCase())
+      return null;
   }
 
   if (catchAll) params['*'] = pathParts.slice(fixed).join('/');
 
-  return { params, score };
+  return { params };
 }
 
 /**


### PR DESCRIPTION
Sibling Routes bearing `as` compete for a scope's single render slot. Arbitration is **first-match by declaration order**: the first contender (in source order) whose pattern matches the path wins; every other sibling cedes. Precedence is positional - an earlier, less-specific pattern shadows a later one, the way Express routes or `switch` cases do - so order specific-before-general.

### How it works

- **Arbitration is the parent's call, not the child's, and purely lexical.** Contenders are read from the parent's children JSX (their `to` props) in source order, so the field is whole before any child mounts - no first-paint flicker, no walking live siblings.
- **Only lexically-visible patterns contend.** A Route whose pattern isn't visible in the JSX (subclass class-field `to`, component-delegated matching) doesn't compete, and a non-contending child is left to its own match rather than suppressed.
- **Fallback/redirect Routes never compete by order** (a `default`'s path collides with a bare sibling's), so they're never arbitrated.
- **Contender scan** recurses Fragments but stops at nested Route scopes - those arbitrate within their own parent.
- **Reconcile-in-place preserved.** The verdict turns on `path`, read via the child's own proxy so re-arbitration re-renders it. That read is gated behind a thunk, called only once a real rivalry exists, so a solitary matched Route stays unsubscribed and reconciles in place across same-pattern navigations.

### Structure

`contests`/`arbitrate` collapsed into a single module-private `cedes(parent, child, path)` helper - `render` is the only caller and neither needs `this`-polymorphism, so Route's public surface matches `main`.

### Rebase note

Authored pre-merge against the React API; ported here to the agnostic JSX pragma (`childrenOf`/`isElement`/`typeOf`/`propsOf`/`Component.Node`). PLAN.md dropped (folded into this summary).

Typecheck clean; 141 router tests pass.
