### PR TITLE
feat(router): reactive query record + derived url, synced with navigation

### DIFF
--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -49,6 +49,23 @@ describe('Route', () => {
     expect(view.container.textContent).toBe('id: foo');
   });
 
+  it('exposes the router query, narrowable via declare', () => {
+    class Search extends Route {
+      declare query: { q?: string; page?: string };
+    }
+
+    const route = Search.new();
+    route.router.goto('/posts?q=hi&page=2');
+
+    // Compile-time: declared keys resolve, unknown keys are rejected.
+    const q: string | undefined = route.query.q;
+    // @ts-expect-error - `nope` is not a declared key
+    route.query.nope;
+
+    expect(q).toBe('hi');
+    expect(route.query.page).toBe('2');
+  });
+
   it('updates in place on same-pattern navigation (instance persists)', async () => {
     location('/posts/foo');
     let mountCount = 0;

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -131,6 +131,19 @@ export class Route extends Component {
     return collect(this.inner);
   }
 
+  /**
+   * Live query record from the active Router. Global (not route-scoped) - every
+   * Route sees the same params, unlike `match` which is this Route's captures.
+   * Narrow known keys in a subclass via `declare`, same as on Router:
+   *
+   * ```ts
+   * class Search extends Route {
+   *   declare query: { q?: string; page?: string };
+   * }
+   * ```
+   */
+  query = set(() => this.router.query);
+
   /** Directory-style anchor for relative navigation. */
   get anchor(): string {
     return this.router.anchor(this);

--- a/packages/router/src/router.test.tsx
+++ b/packages/router/src/router.test.tsx
@@ -62,14 +62,129 @@ describe('Router (headless)', () => {
     expect(router.entries).toEqual(['/', '/a', '/c']);
     expect(router.path).toBe('/c');
   });
+
+  it('goto splits query string from path', () => {
+    const router = Router.new();
+    router.goto('/posts?page=2&sort=asc');
+    expect(router.path).toBe('/posts');
+    expect(router.url).toBe('/posts?page=2&sort=asc');
+  });
+
+  it('goto without query clears the query', () => {
+    const router = Router.new();
+    router.goto('/posts?page=2');
+    router.goto('/posts');
+    expect(router.url).toBe('/posts');
+  });
+
+  it('canonicalizes the query so navigation does not push a duplicate entry', async () => {
+    const encoded = Router.new();
+    encoded.goto('/x?q=a%20b');
+    await encoded.set();
+    expect(encoded.entries).toEqual(['/', '/x?q=a+b']);
+
+    const repeated = Router.new();
+    repeated.goto('/x?a=1&a=2');
+    await repeated.set();
+    expect(repeated.entries).toEqual(['/', '/x?a=2']);
+  });
+
+  it('query exposes params as a record', () => {
+    const router = Router.new();
+    router.goto('/posts?page=2');
+    expect(router.query.page).toBe('2');
+  });
+
+  it('subclass may narrow query keys via declare (type-level)', () => {
+    class Search extends Router {
+      declare query: { q?: string; page?: string };
+    }
+
+    const router = Search.new();
+    router.goto('/posts?q=hi&page=2');
+
+    // Compile-time: known keys resolve, unknown keys are rejected.
+    const q: string | undefined = router.query.q;
+    // @ts-expect-error - `nope` is not a declared key
+    router.query.nope;
+
+    expect(q).toBe('hi');
+    expect(router.query.page).toBe('2');
+  });
+
+  it('query updates reactively when search changes', async () => {
+    const router = Router.new();
+    const seen: (string | undefined)[] = [];
+
+    router.get(state => {
+      seen.push(state.query.page);
+    });
+
+    router.goto('/posts?page=1');
+    await router.set();
+    router.goto('/posts?page=2');
+    await router.set();
+
+    expect(seen).toEqual([undefined, '1', '2']);
+  });
+
+  it('writing a query param pushes a new history entry', async () => {
+    const router = Router.new();
+    router.goto('/posts?page=1');
+    router.query.page = '2';
+    await router.set();
+
+    expect(router.url).toBe('/posts?page=2');
+    router.back();
+    expect(router.url).toBe('/posts?page=1');
+  });
+
+  it('deleting a query param navigates', async () => {
+    const router = Router.new();
+    router.goto('/posts?page=2&sort=asc');
+    delete router.query.sort;
+    await router.set();
+
+    expect(router.query.sort).toBeUndefined();
+    expect(router.path).toBe('/posts');
+  });
+
+  it('assigning url navigates (push)', () => {
+    const router = Router.new();
+    router.goto('/a');
+    router.url = '/b?x=1';
+
+    expect(router.path).toBe('/b');
+    expect(router.query.x).toBe('1');
+    expect(router.entries).toEqual(['/', '/a', '/b?x=1']);
+  });
+
+  it('back/forward restore the query from the stack', () => {
+    const router = Router.new();
+    router.goto('/a?x=1');
+    router.goto('/b?y=2');
+
+    router.back();
+    expect(router.url).toBe('/a?x=1');
+
+    router.forward();
+    expect(router.url).toBe('/b?y=2');
+  });
+
+  it('match ignores the query string', () => {
+    const router = Router.new();
+    router.goto('/posts/123?tab=info');
+    expect(router.match('/posts', ':id')).not.toBeNull();
+  });
 });
 
 describe('BrowserRouter', () => {
   const router = browserRouter();
 
   it('initializes from window.location', () => {
-    window.history.replaceState(null, '', '/foo');
+    window.history.replaceState(null, '', '/foo?from=start');
     expect(router.current.path).toBe('/foo');
+    expect(router.current.url).toBe('/foo?from=start');
   });
 
   it('goto pushes history and updates path', () => {
@@ -99,9 +214,43 @@ describe('BrowserRouter', () => {
     expect(router.current.path).toBe('/external');
   });
 
+  it('goto with query updates location and url', () => {
+    act(() => router.current.goto('/results?q=hello'));
+    expect(window.location.pathname).toBe('/results');
+    expect(window.location.search).toBe('?q=hello');
+    expect(router.current.path).toBe('/results');
+    expect(router.current.url).toBe('/results?q=hello');
+    expect(router.current.query.q).toBe('hello');
+  });
+
+  it('clears the query when navigation drops it', () => {
+    act(() => router.current.goto('/results?q=hi'));
+    act(() => window.history.pushState(null, '', '/results'));
+    expect(router.current.url).toBe('/results');
+  });
+
   it('notices external history.replaceState', () => {
     act(() => window.history.replaceState(null, '', '/replaced-external'));
     expect(router.current.path).toBe('/replaced-external');
+  });
+
+  it('does not re-push when external navigation uses non-canonical encoding', async () => {
+    const len = window.history.length;
+    act(() => window.history.pushState(null, '', '/enc?q=a%20b'));
+    await router.current.set();
+
+    expect(router.current.query.q).toBe('a b');
+    // The query listener must treat %20 and + as equal, not push a corrected dup.
+    expect(window.history.length).toBe(len + 1);
+  });
+
+  it('writing a query param pushes to window.history', async () => {
+    act(() => router.current.goto('/page?x=1'));
+    router.current.query.x = '9';
+    await router.current.set();
+
+    expect(window.location.search).toBe('?x=9');
+    expect(window.location.pathname).toBe('/page');
   });
 
   it('back/forward delegate to window.history', () => {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,4 @@
-import { Component } from '@expressive/mvc';
+import { Component, hot, listener } from '@expressive/mvc';
 
 import { Route } from './route';
 import { Match, fullPattern, matchPattern, patternSegment } from './url';
@@ -13,12 +13,44 @@ import { Match, fullPattern, matchPattern, patternSegment } from './url';
 export class Router extends Component {
   path = '/';
 
-  /** In-memory history: visited paths and the cursor into them. */
+  /**
+   * Canonical query state - a reactive record. Read `query.foo` to track a
+   * param; write `query.foo = ...` (or delete) to navigate: a direct mutation
+   * pushes a new history entry, same as if it arrived via `goto`.
+   *
+   * Values are always `string | undefined` (URL params carry no other type).
+   * A subclass may narrow the known keys by redeclaring with `declare`:
+   *
+   * ```ts
+   * class Search extends Router {
+   *   declare query: { q?: string; page?: string };
+   * }
+   * ```
+   */
+  query = hot({} as Record<string, string | undefined>);
+
+  /** In-memory history: visited urls (path + query) and the cursor into them. */
   entries: string[] = [];
   index = 0;
 
   protected new() {
-    this.entries = [this.path];
+    this.entries = [this.url];
+    // Direct `query` mutations push a new entry; URL-driven changes already sit there (pushEntry no-ops).
+    const release = listener(this.query, () => pushEntry(this, this.url), false);
+
+    return () => {
+      release();
+    };
+  }
+
+  /** Full URL as assigned by the environment (path + optional `?query`). Assigning navigates. */
+  get url(): string {
+    const search = searchOf(this.query);
+    return search ? this.path + '?' + search : this.path;
+  }
+
+  set url(to: string) {
+    this.goto(to);
   }
 
   /**
@@ -35,26 +67,36 @@ export class Router extends Component {
 
   goto(to: string, replace = false) {
     assertAbsolute(to);
-    const path = normalize(to);
+    const url = normalize(to);
 
-    if (replace)
-      this.entries[this.index] = path;
-    else {
-      this.entries = [...this.entries.slice(0, this.index + 1), path];
-      this.index = this.entries.length - 1;
-    }
+    if (replace) this.entries[this.index] = url;
+    else pushEntry(this, url);
 
-    this.path = path;
+    this.locate(url);
   }
 
   back() {
-    if (this.index > 0)
-      this.path = this.entries[--this.index];
+    if (this.index > 0) this.locate(this.entries[--this.index]);
   }
 
   forward() {
     if (this.index < this.entries.length - 1)
-      this.path = this.entries[++this.index];
+      this.locate(this.entries[++this.index]);
+  }
+
+  /** Apply a normalized url (path + optional `?query`) to state, reconciling `query` in place. */
+  protected locate(url: string) {
+    const q = url.indexOf('?');
+    this.path = q < 0 ? url : url.slice(0, q);
+
+    const { query } = this;
+    const next = Object.fromEntries(
+      new URLSearchParams(q < 0 ? '' : url.slice(q + 1))
+    );
+
+    for (const key in query) if (!(key in next)) delete query[key];
+
+    Object.assign(query, next);
   }
 
   segment(to: string): string {
@@ -81,7 +123,7 @@ export class Router extends Component {
   }
 }
 
-/** Binds the headless core to `window.location`, syncing `path` on navigation. */
+/** Binds the headless core to `window.location`, syncing `path`/`query` on navigation. */
 export class BrowserRouter extends Router {
   path = window.location.pathname;
 
@@ -91,7 +133,7 @@ export class BrowserRouter extends Router {
   }
 
   // The browser owns the history stack; back/forward delegate to it (popstate
-  // syncs `path`), so the inherited in-memory entries/index go unused here.
+  // syncs path/query), so the inherited in-memory entries/index go unused here.
   back() {
     history.back();
   }
@@ -102,21 +144,49 @@ export class BrowserRouter extends Router {
 
   protected new() {
     const sync = () => {
-      this.path = window.location.pathname;
+      this.locate(window.location.pathname + window.location.search);
     };
+    sync();
     window.addEventListener('popstate', sync);
 
     const origPush = history.pushState.bind(history);
     const origReplace = history.replaceState.bind(history);
-    history.pushState = (...args) => { origPush(...args); sync(); };
-    history.replaceState = (...args) => { origReplace(...args); sync(); };
+    history.pushState = (...args) => {
+      origPush(...args);
+      sync();
+    };
+    history.replaceState = (...args) => {
+      origReplace(...args);
+      sync();
+    };
+
+    // Direct `query` writes push to the browser's history; URL-driven changes
+    // already match (compared canonically, so encoding differences don't dup).
+    const release = listener(
+      this.query,
+      () => {
+        const { url } = this;
+        if (url !== canonicalize(window.location.pathname + window.location.search))
+          history.pushState(null, '', url);
+      },
+      false
+    );
 
     return () => {
+      release();
       window.removeEventListener('popstate', sync);
       history.pushState = origPush;
       history.replaceState = origReplace;
     };
   }
+}
+
+/** Append `url` as a new history entry on a memory router, truncating any forward stack. */
+function pushEntry(router: Router, url: string) {
+  if (url === router.entries[router.index]) return;
+
+  router.entries = [...router.entries.slice(0, router.index + 1), url];
+  router.index = router.entries.length - 1;
 }
 
 function assertAbsolute(to: string) {
@@ -126,7 +196,36 @@ function assertAbsolute(to: string) {
     );
 }
 
-/** Collapse `.`/`..` and stray slashes without touching browser globals. */
+/**
+ * Collapse `.`/`..` and stray slashes without touching browser globals, and
+ * canonicalize the query so stored urls match the `url` getter byte-for-byte.
+ */
 function normalize(to: string): string {
-  return new URL(to, 'x://_').pathname;
+  const { pathname, search } = new URL(to, 'x://_');
+  return canonicalize(pathname + search);
+}
+
+/**
+ * Re-serialize a url's query through the record model (last value per key,
+ * `URLSearchParams` encoding) so it is identical to what the `url` getter emits.
+ * This is what makes the history-dedup a sound string comparison.
+ */
+function canonicalize(url: string): string {
+  const q = url.indexOf('?');
+  if (q < 0) return url;
+
+  const search = searchOf(Object.fromEntries(new URLSearchParams(url.slice(q + 1))));
+  return search ? url.slice(0, q) + '?' + search : url.slice(0, q);
+}
+
+/** Canonical query serialization: skips `undefined`, last-value-per-key, form encoding. */
+function searchOf(query: Record<string, string | undefined>): string {
+  const params = new URLSearchParams();
+
+  for (const key in query) {
+    const value = query[key];
+    if (value !== undefined) params.append(key, value);
+  }
+
+  return params.toString();
 }


### PR DESCRIPTION
Replaces the URL query string with a reactive `query` record as the canonical state, and exposes a derived `url`. No path-less `search` property - the two things consumers want are individual params and the full URL.

## Public surface

- **`query`** - a reactive record (`hot({})`). Read `query.foo` to track a param; **writing** `query.foo = '2'` (or `delete query.foo`) navigates: a direct mutation pushes a new history entry, exactly as if it arrived via `goto`. Single-valued params (repeated keys collapse).
- **`url`** - getter for the full URL (path + serialized query), i.e. the location as assigned by the environment. Assigning (`router.url = '/x?a=1'`) navigates via `goto` (push); use `goto(to, true)` for replace.
- **`path`** - unchanged.

## How it stays in sync

- `locate(url)` is the sole inbound funnel: splits path, reconciles the `query` record in place (add/update/remove keys). `goto`/`back`/`forward` and the browser's `popstate`/patched-`pushState` sync all route through it.
- A `listener` on the `query` proxy is the outbound path: direct mutations serialize and push history. URL-driven changes already match the current location, so the push no-ops (`pushEntry` is idempotent; browser dedupes against `window.location`).

## Notes

- `url` is a getter+setter pair deliberately: a setter-less getter would be picked up as a framework computed, which can't reactively track a `hot` collection's key set (and suspends if read mid-construction). The `goto`-delegating setter keeps it a plain accessor.
- `URLSearchParams`/`URL` are WHATWG globals (Node/Deno/Bun/browser), so the headless core stays host-agnostic - only `BrowserRouter` touches `window`.

Typecheck clean; 156 router tests pass (incl. write-back coverage for `query.foo =`, `delete query.foo`, `url =`, and browser query writes).
