### PR TITLE
feat(router): redirect/notFound sentinels caught by nearest Route

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -4,4 +4,5 @@ export { Router, BrowserRouter } from './router';
 export { Route } from './route';
 export { Link } from './link';
 export { Redirect } from './redirect';
+export { redirect, notFound } from './sentinel';
 export { NavLinks } from './nav';

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -3,6 +3,7 @@ import { childrenOf, Fragment, isElement, propsOf, typeOf } from '@expressive/mv
 
 import { Redirect } from './redirect';
 import { Router } from './router';
+import { sentinel } from './sentinel';
 import { fullPattern, matchPattern, patternSegment } from './url';
 
 const PARAMS = new WeakMap<Route, Record<string, string> | undefined>();
@@ -29,6 +30,10 @@ export class Route extends Component {
   /** Matches when nothing else in this scope did. Scoped to its parent: a
    * root-level default is the app 404, a nested one the section 404. */
   default = false;
+
+  /** Path abandoned via `notFound()` - this Route stays unmatched while that
+   * path is current. Path-keyed, so navigating away clears it implicitly. */
+  lost?: string = undefined;
 
   /** Nearest mounted Route ancestor, if any. */
   parent = get(Route, false);
@@ -71,6 +76,8 @@ export class Route extends Component {
   get matched(): boolean {
     const { parent } = this;
 
+    if (this.lost && this.lost === this.router.path) return false;
+
     if (this.default)
       return parent ? parent.matched && !parent.matches.length : false;
 
@@ -90,12 +97,12 @@ export class Route extends Component {
    * Redirect/default excluded; see-through scopes seen through to children.
    */
   get active(): Route | undefined | null {
-    const { match } = this.router;
+    const { match, path } = this.router;
     let found: Route | undefined;
 
     const scan = (routes: Route[]): boolean => {
       for (const route of routes) {
-        if (route.redirect || route.default) continue;
+        if (route.redirect || route.default || route.lost === path) continue;
         if (hasRoutes(route)) {
           if (scan(route.inner)) return true;
           continue;
@@ -118,7 +125,7 @@ export class Route extends Component {
     const { match, path } = this.router;
     const collect = (routes: Route[]): string[] =>
       routes.flatMap((route) => {
-        if (route.redirect || route.default) return [];
+        if (route.redirect || route.default || route.lost === path) return [];
         if (!hasRoutes(route))
           return match(route.base, route.to) ? [route.path] : [];
 
@@ -143,6 +150,19 @@ export class Route extends Component {
   goto(url: string, replace = false) {
     if (url === '' || url === '.') return;
     this.router.goto(this.resolve(url), replace);
+  }
+
+  /** Handles `redirect()`/`notFound()` sentinels thrown by descendants; any
+   * other error (or any error once this Route is destroyed) propagates. */
+  catch(error: Error) {
+    const signal = sentinel(error);
+
+    if (!signal || this.get(null)) throw error;
+
+    if (signal.kind === 'redirect')
+      this.goto(signal.to, signal.replace);
+    else
+      this.lost = this.router.path;
   }
 
   render(props = {} as { children?: Component.Node }) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -64,12 +64,14 @@ export class Router extends Component {
   /**
    * Directory-style anchor for relative navigation from a Route. Strips trailing
    * `/*` (catch-all, which belongs to children) and substitutes `:params`.
-   * Always ends with `/`.
+   * Always ends with `/`. When unmatched, `:params` pass through unsubstituted
+   * (no captures exist) - total so passive reads can never throw.
    */
   anchor(route: Route): string {
+    const { match } = route;
     const own = route.to
       .replace(/\/?\*$/, '')
-      .replace(/:(\w+)/g, (_, name) => route.match![name]);
+      .replace(/:(\w+)/g, (text, name) => match ? match[name] : text);
 
     return own.endsWith('/') ? own : own + '/';
   }

--- a/packages/router/src/sentinel.test.tsx
+++ b/packages/router/src/sentinel.test.tsx
@@ -1,0 +1,218 @@
+import { act } from '@testing-library/react';
+import { describe, expect, it } from 'bun:test';
+import { Component } from '@expressive/react';
+
+import { browserRouter, location, mockError, mockPromise, renderAct } from '../test.setup';
+import { Route } from './route';
+import { notFound, redirect } from './sentinel';
+
+const router = browserRouter();
+
+const New = () => <h1>New</h1>;
+
+describe('redirect', () => {
+  mockError();
+
+  it('navigates when thrown from render', async () => {
+    location('/old');
+
+    const view = await renderAct(
+      <Route>
+        <Route to="/old" as={() => redirect('/new')} />
+        <Route to="/new" as={New} />
+      </Route>
+    );
+
+    expect(window.location.pathname).toBe('/new');
+    expect(view.container.textContent).toBe('New');
+  });
+
+  it('replaces history by default', async () => {
+    location('/old');
+    const before = window.history.length;
+
+    await renderAct(
+      <Route>
+        <Route to="/old" as={() => redirect('/new')} />
+        <Route to="/new" as={New} />
+      </Route>
+    );
+
+    expect(window.location.pathname).toBe('/new');
+    expect(window.history.length).toBe(before);
+  });
+
+  it('pushes history when replace is false', async () => {
+    location('/old');
+    const before = window.history.length;
+
+    await renderAct(
+      <Route>
+        <Route to="/old" as={() => redirect('/new', false)} />
+        <Route to="/new" as={New} />
+      </Route>
+    );
+
+    expect(window.location.pathname).toBe('/new');
+    expect(window.history.length).toBe(before + 1);
+  });
+
+  it('resolves relative `to` against the catching Route', async () => {
+    location('/posts/foo');
+
+    await renderAct(
+      <Route>
+        <Route to="/posts/:id" as={() => redirect('edit')} />
+        <Route to="/posts/foo/edit" as={() => <h1>Edit</h1>} />
+      </Route>
+    );
+
+    expect(window.location.pathname).toBe('/posts/foo/edit');
+  });
+
+  it('navigates after suspense churn without crashing', async () => {
+    location('/old');
+    const promise = mockPromise();
+    let loaded = false;
+
+    const Page = () => {
+      if (!loaded) throw promise;
+      redirect('/new');
+    };
+
+    const view = await renderAct(
+      <Route>
+        <Route to="/old" as={Page} />
+        <Route to="/new" as={New} />
+      </Route>
+    );
+
+    expect(view.container.textContent).toBe('');
+
+    await act(async () => {
+      loaded = true;
+      promise.resolve();
+    });
+
+    expect(window.location.pathname).toBe('/new');
+    expect(view.container.textContent).toBe('New');
+  });
+
+  it('rethrows when the catching Route is already destroyed', async () => {
+    location('/old');
+    let route!: Route;
+
+    await renderAct(<Route to="/old" is={(r) => (route = r)} as={New} />);
+
+    let sentinel!: Error;
+    try { redirect('/new'); }
+    catch (error) { sentinel = error as Error; }
+
+    route.set(null);
+
+    expect(() => route.catch!(sentinel)).toThrow(sentinel.message);
+    expect(window.location.pathname).toBe('/old');
+  });
+});
+
+describe('notFound', () => {
+  mockError();
+
+  it('falls through to the default branch', async () => {
+    location('/posts/junk');
+    let root!: Route;
+
+    const view = await renderAct(
+      <Route is={(r) => (root = r)}>
+        <Route to="/posts/:id" as={() => notFound()} />
+        <Route default as={() => <h1>404</h1>} />
+      </Route>
+    );
+
+    expect(view.container.textContent).toBe('404');
+    expect(root.active).toBeUndefined();
+  });
+
+  it('does not affect other paths after navigation', async () => {
+    location('/posts/junk');
+
+    const Post = () => {
+      const { match } = Route.get();
+      if (match!.id === 'junk') notFound();
+      return <h1>Post</h1>;
+    };
+
+    const view = await renderAct(
+      <Route>
+        <Route to="/posts/:id" as={Post} />
+        <Route default as={() => <h1>404</h1>} />
+      </Route>
+    );
+
+    expect(view.container.textContent).toBe('404');
+
+    await act(async () => router.current.goto('/posts/real'));
+
+    expect(view.container.textContent).toBe('Post');
+  });
+});
+
+describe('foreign errors', () => {
+  mockError();
+
+  it('pass through to an outer boundary untouched', async () => {
+    location('/old');
+    const boom = new Error('boom');
+    let caught: Error | undefined;
+
+    class Outer extends Component {
+      fallback = (<h1>Crashed</h1>);
+
+      catch(error: Error) {
+        caught = error;
+        return new Promise<void>(() => {});
+      }
+
+      render() {
+        return (
+          <Route>
+            <Route to="/old" as={() => { throw boom; }} />
+          </Route>
+        );
+      }
+    }
+
+    const view = await renderAct(<Outer />);
+
+    expect(caught).toBe(boom);
+    expect(view.container.textContent).toBe('Crashed');
+    expect(window.location.pathname).toBe('/old');
+  });
+
+  it('pass through non-Error throws too', async () => {
+    location('/old');
+    let caught: unknown;
+
+    class Outer extends Component {
+      fallback = (<h1>Crashed</h1>);
+
+      catch(error: Error) {
+        caught = error;
+        return new Promise<void>(() => {});
+      }
+
+      render() {
+        return (
+          <Route>
+            <Route to="/old" as={() => { throw 'nope'; }} />
+          </Route>
+        );
+      }
+    }
+
+    const view = await renderAct(<Outer />);
+
+    expect(caught).toBe('nope');
+    expect(view.container.textContent).toBe('Crashed');
+  });
+});

--- a/packages/router/src/sentinel.ts
+++ b/packages/router/src/sentinel.ts
@@ -1,0 +1,34 @@
+const SENTINEL = Symbol('sentinel');
+
+type Sentinel =
+  | { kind: 'redirect'; to: string; replace: boolean }
+  | { kind: 'notFound' };
+
+/**
+ * Throw during render or data loading; the nearest Route navigates instead of
+ * rendering. Replaces history by default - the interrupted URL never showed
+ * content, so Back should not return to it. Pass `replace: false` to push.
+ * Relative `to` resolves against the catching Route.
+ */
+export function redirect(to: string, replace = true): never {
+  throw tagged(`Redirect to ${to}`, { kind: 'redirect', to, replace });
+}
+
+/**
+ * Throw during render or data loading; the nearest Route un-matches for the
+ * current URL, so its scope falls through to the `default` (404) branch.
+ */
+export function notFound(): never {
+  throw tagged('Not found', { kind: 'notFound' });
+}
+
+/** Sentinel payload riding `error`, if it was thrown by `redirect`/`notFound`. */
+export function sentinel(error: unknown): Sentinel | undefined {
+  return error instanceof Error
+    ? (error as { [SENTINEL]?: Sentinel })[SENTINEL]
+    : undefined;
+}
+
+function tagged(message: string, signal: Sentinel) {
+  return Object.assign(new Error(message), { [SENTINEL]: signal });
+}


### PR DESCRIPTION
Sentinel-tagged errors a page may throw during render or data loading. Every Route now defines \`catch()\`:

- \`redirect()\` resolves against the catching Route and navigates (replace by default - the interrupted URL never committed).
- \`notFound()\` marks the Route lost for the current path (\`lost\` field, path-keyed so navigating away clears it), so its scope falls through to the default branch.
- Foreign errors, and anything reaching a destroyed Route, rethrow to the next boundary.

New \`sentinel.ts\` module + tests. Router.anchor is now total (unmatched \`:params\` pass through).

**Rebase note:** authored pre-merge; ported \`catch()\` onto main's agnostic render signature. Touches \`route.tsx\` (also touched by #137 specificity) - non-overlapping hunks, but rebase #137 first if both land. PLAN.md dropped.

Typecheck clean; 154 router tests pass.