### PR TITLE
feat(router): NavLink active styling + scroll restoration

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -4,4 +4,5 @@ export { Router, BrowserRouter } from './router';
 export { Route } from './route';
 export { Link, NavLink } from './link';
 export { Redirect } from './redirect';
+export { ScrollRestoration } from './scroll';
 export { NavLinks } from './nav';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -2,6 +2,6 @@ export { matchPattern, fullPattern, patternSegment } from './url';
 export type { Match } from './url';
 export { Router, BrowserRouter } from './router';
 export { Route } from './route';
-export { Link } from './link';
+export { Link, NavLink } from './link';
 export { Redirect } from './redirect';
 export { NavLinks } from './nav';

--- a/packages/router/src/link.test.tsx
+++ b/packages/router/src/link.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { describe, expect, it } from 'bun:test';
 
 import { location, browserRouter } from '../test.setup';
-import { Link } from './link';
+import { Link, NavLink } from './link';
 import { Route } from './route';
 
 const router = browserRouter();
@@ -114,5 +114,102 @@ describe('Link', () => {
 
     await act(async () => fireEvent.click(a, { button: 0 }));
     expect(router.current.path).toBe('/posts/foo/edit');
+  });
+});
+
+describe('NavLink', () => {
+  it('applies active class when path matches exactly', () => {
+    location('/about');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('class')).toBe('active');
+    expect(a.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('prefix-matches by default', () => {
+    location('/blog/post-1');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/blog">blog</NavLink>
+      </Route>
+    );
+    expect(view.container.querySelector('a')!.getAttribute('class')).toBe('active');
+  });
+
+  it('does not match unrelated paths', () => {
+    location('/blogging');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/blog">blog</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('class')).toBe(null);
+    expect(a.hasAttribute('aria-current')).toBe(false);
+  });
+
+  it('exact disables prefix matching', () => {
+    location('/blog/post-1');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/blog" exact>blog</NavLink>
+      </Route>
+    );
+    expect(view.container.querySelector('a')!.getAttribute('class')).toBe(null);
+  });
+
+  it('treats a root link as prefix of everything unless exact', () => {
+    location('/about');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/">home</NavLink>
+        <NavLink to="/" exact>home</NavLink>
+      </Route>
+    );
+    const [loose, strict] = Array.from(view.container.querySelectorAll('a'));
+    expect(loose.getAttribute('class')).toBe('active');
+    expect(strict.getAttribute('class')).toBe(null);
+  });
+
+  it('merges activeClassName with className', () => {
+    location('/about');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about" className="nav" activeClassName="current">about</NavLink>
+      </Route>
+    );
+    expect(view.container.querySelector('a')!.getAttribute('class')).toBe('nav current');
+  });
+
+  it('toggles active class across navigation', async () => {
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('class')).toBe(null);
+
+    await act(async () => router.current.goto('/about'));
+    expect(a.getAttribute('class')).toBe('active');
+
+    await act(async () => router.current.goto('/'));
+    expect(a.getAttribute('class')).toBe(null);
+  });
+
+  it('navigates like a Link', async () => {
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    await act(async () => {
+      fireEvent.click(view.container.querySelector('a')!, { button: 0 });
+    });
+    expect(router.current.path).toBe('/about');
   });
 });

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -29,14 +29,14 @@ export class Link extends Component {
   to = '';
   replace = false;
 
-  private route = get(Route);
+  protected route = get(Route);
 
   /** Absolute resolved path for the rendered `<a href>`. */
   get href(): string {
     return this.route.resolve(this.to);
   }
 
-  private go = (e: ClickEvent) => {
+  protected go = (e: ClickEvent) => {
     if (e.defaultPrevented || e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
@@ -45,9 +45,55 @@ export class Link extends Component {
 
   render({ children, to, replace, ...rest } = {} as Link.Props) {
     return (
-      <a {...rest} href={this.href} onClick={this.go}>
+      <a {...this.attributes(rest)} href={this.href} onClick={this.go}>
         {children}
       </a>
     );
+  }
+
+  /** Maps remaining props to anchor attributes; subclasses may decorate.
+   * A getter (not a method) so overrides stay reactive - state read while
+   * computing it is tracked by render. */
+  protected get attributes() {
+    return (rest: AnchorProps) => rest;
+  }
+}
+
+export namespace NavLink {
+  export type Props = Link.Props & {
+    exact?: boolean;
+    activeClassName?: string;
+  };
+}
+
+export class NavLink extends Link {
+  /** Match only when the path equals `href` exactly; default is prefix match. */
+  exact = false;
+
+  activeClassName = 'active';
+
+  get active(): boolean {
+    const { href } = this;
+    const { path } = this.route.router;
+
+    if (path === href) return true;
+    return !this.exact && path.startsWith(href === '/' ? href : href + '/');
+  }
+
+  protected get attributes() {
+    const { active, activeClassName } = this;
+
+    return (rest: AnchorProps) => {
+      const { exact, activeClassName: _, className, ...attrs } =
+        rest as NavLink.Props;
+
+      return {
+        ...attrs,
+        className: !active ? className
+          : className ? `${className} ${activeClassName}`
+          : activeClassName,
+        'aria-current': active ? 'page' as const : undefined
+      };
+    };
   }
 }

--- a/packages/router/src/scroll.test.tsx
+++ b/packages/router/src/scroll.test.tsx
@@ -1,0 +1,77 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { browserRouter } from '../test.setup';
+import { ScrollRestoration } from './scroll';
+
+const STORAGE = 'expressive-router:scroll';
+const router = browserRouter();
+
+beforeEach(() => {
+  sessionStorage.clear();
+  window.scrollTo(0, 0);
+});
+
+describe('ScrollRestoration', () => {
+  it('scrolls to top on push navigation', async () => {
+    const scrollTo = spyOn(window, 'scrollTo');
+    render(<ScrollRestoration />);
+
+    await act(async () => router.current.goto('/about'));
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('restores saved position on back navigation', async () => {
+    render(<ScrollRestoration />);
+    window.scrollTo(0, 150);
+
+    await act(async () => router.current.goto('/about'));
+    expect(window.scrollY).toBe(0);
+
+    await act(async () => router.current.back());
+    expect(router.current.path).toBe('/');
+    expect(window.scrollY).toBe(150);
+  });
+
+  it('scrolls to top on back when no position was saved', async () => {
+    sessionStorage.setItem(STORAGE, JSON.stringify({}));
+    render(<ScrollRestoration />);
+
+    await act(async () => router.current.goto('/about'));
+    window.scrollTo(0, 80);
+
+    await act(async () => router.current.back());
+    expect(window.scrollY).toBe(0);
+  });
+
+  it('persists positions across instances via sessionStorage', async () => {
+    const view = render(<ScrollRestoration />);
+    window.scrollTo(0, 220);
+
+    await act(async () => router.current.goto('/about'));
+    view.unmount();
+
+    expect(JSON.parse(sessionStorage.getItem(STORAGE)!)).toEqual({ '/': 220 });
+  });
+
+  it('tolerates corrupt storage', async () => {
+    sessionStorage.setItem(STORAGE, 'not json');
+    const scrollTo = spyOn(window, 'scrollTo');
+    render(<ScrollRestoration />);
+
+    await act(async () => router.current.goto('/about'));
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('stops listening after unmount', async () => {
+    const view = render(<ScrollRestoration />);
+    window.scrollTo(0, 90);
+
+    await act(async () => router.current.goto('/about'));
+    view.unmount();
+    window.scrollTo(0, 30);
+
+    await act(async () => router.current.back());
+    expect(window.scrollY).toBe(30);
+  });
+});

--- a/packages/router/src/scroll.ts
+++ b/packages/router/src/scroll.ts
@@ -1,0 +1,53 @@
+import { Component, get } from '@expressive/react';
+
+import { Router } from './router';
+
+const STORAGE = 'expressive-router:scroll';
+
+/**
+ * Scrolls to top on push navigations and restores the saved position on
+ * back/forward. Positions are kept in sessionStorage keyed by pathname -
+ * BrowserRouter delegates the stack to `window.history`, so no per-entry key
+ * is available and distinct history entries sharing a path share a slot.
+ */
+export class ScrollRestoration extends Component {
+  router = get(Router);
+
+  protected new() {
+    const positions = saved();
+    let pop = false;
+    let from = this.router.path;
+
+    const onPop = () => pop = true;
+    window.addEventListener('popstate', onPop);
+
+    const done = this.get(({ router }) => {
+      const { path } = router;
+      if (path === from) return;
+
+      positions[from] = window.scrollY;
+      sessionStorage.setItem(STORAGE, JSON.stringify(positions));
+      from = path;
+
+      window.scrollTo(0, pop ? positions[path] || 0 : 0);
+      pop = false;
+    });
+
+    return () => {
+      window.removeEventListener('popstate', onPop);
+      done();
+    };
+  }
+
+  render() {
+    return null;
+  }
+}
+
+function saved(): Record<string, number> {
+  try {
+    return JSON.parse(sessionStorage.getItem(STORAGE) || '{}');
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Two nav-UX additions:

**NavLink** (\`link.tsx\`) - a \`Link\` subclass that applies \`activeClassName\` (default \`active\`) and \`aria-current="page"\` when the current path matches its \`href\`. \`exact\` opts into equality matching vs the default prefix match. \`attributes\` is a getter (not a method) so subclass overrides stay reactive.

**Scroll restoration** (\`scroll.ts\`) - component that restores scroll position across navigation.

**Rebase note:** authored pre-merge against React types; ported \`AnchorHTMLAttributes<HTMLAnchorElement>\` -> agnostic \`AnchorProps\` (host-intrinsic-derived) and \`MouseEvent\` -> structural \`ClickEvent\`. \`go\` is now \`protected\` for subclass extensibility. PLAN.md dropped.

Typecheck clean; 158 router tests pass.