### PR TITLE
Optionally carry Claude Code login into fresh Codespaces

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -118,21 +118,18 @@ one-time `claude auth login`. If you spin up new Codespaces often, you can snaps
 your login into a **user Codespaces secret** and have new Codespaces restore it
 automatically:
 
-1. In a logged-in Codespace, give `gh` permission to manage your Codespaces user
-   secrets. The built-in `GITHUB_TOKEN` is repo-scoped and can't — and `gh` won't
-   override an env-provided token — so drop it and log in (or export a PAT that has
-   the `codespace` scope):
-   ```bash
-   unset GITHUB_TOKEN GH_TOKEN && gh auth login   # grant the 'codespace' scope
-   # or: export GH_TOKEN=<PAT with codespace scope>
-   ```
-2. Snapshot the current login into the `CLAUDE_AUTH_ARCHIVE` secret:
+1. In a logged-in Codespace, snapshot the current login into the `CLAUDE_AUTH_ARCHIVE`
+   secret:
    ```bash
    bash .devcontainer/sync-claude-auth.sh
    ```
-   This stores a base64 tar.gz of `.credentials.json` (auth) plus `.claude.json`
-   (folder trust + the Remote Control confirmation), scoped to this repo.
-3. New Codespaces auto-restore it: `postCreateCommand` runs
+   The script handles `gh` auth for you — the built-in Codespaces `GITHUB_TOKEN` is
+   repo-scoped and can't write user secrets, so it sets that token aside and ensures
+   a `gh` login with the `codespace` scope (complete the one-time web code when
+   prompted). It then stores a base64 tar.gz of `.credentials.json` (auth) plus
+   `.claude.json` (folder trust + the Remote Control confirmation), scoped to this
+   repo.
+2. New Codespaces auto-restore it: `postCreateCommand` runs
    [`restore-claude-auth.sh`](./restore-claude-auth.sh), which unpacks the secret
    into `CLAUDE_CONFIG_DIR` **only if there's no existing login** (it never clobbers
    a live one). RC then comes up authenticated and trusted with no prompts.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,10 +30,16 @@ tmux attach -t claude-rc     # Ctrl-b then d to detach
 The session lives only as long as the container is running. Codespaces auto-suspend
 when idle, which ends the session until the next start (when it relaunches).
 
-> **First run on a brand-new Codespace** may show a one-time "trust this folder"
-> prompt. Attach to the tmux session once to accept it; the acceptance persists in
-> `~/.claude` for subsequent starts. (This is separate from permissions and is the
-> only thing that can block the headless launch.)
+> **Brand-new Codespace with no stored login?** The `claude-rc` session starts the
+> interactive `claude auth login` *first* (then Remote Control), and a rendered
+> `LOGIN-REQUIRED.md` opens automatically to point you there. Just
+> `tmux attach -t claude-rc`, finish the login (URL + code), and RC starts. This is
+> only needed when there's no restorable login — see
+> [Carrying your login to fresh Codespaces](#carrying-your-login-to-fresh-codespaces-optional).
+>
+> A one-time "trust this folder" prompt may also appear there; accept it once and it
+> persists. (Both are separate from permissions and are the only things that can hold
+> up the launch.)
 
 ### Approving actions
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -118,10 +118,13 @@ one-time `claude auth login`. If you spin up new Codespaces often, you can snaps
 your login into a **user Codespaces secret** and have new Codespaces restore it
 automatically:
 
-1. In a logged-in Codespace, make sure `gh` can manage your Codespaces user secrets
-   (the default Codespaces token can't — it's repo-scoped):
+1. In a logged-in Codespace, give `gh` permission to manage your Codespaces user
+   secrets. The built-in `GITHUB_TOKEN` is repo-scoped and can't — and `gh` won't
+   override an env-provided token — so drop it and log in (or export a PAT that has
+   the `codespace` scope):
    ```bash
-   gh auth refresh -h github.com -s codespace   # or: gh auth login
+   unset GITHUB_TOKEN GH_TOKEN && gh auth login   # grant the 'codespace' scope
+   # or: export GH_TOKEN=<PAT with codespace scope>
    ```
 2. Snapshot the current login into the `CLAUDE_AUTH_ARCHIVE` secret:
    ```bash

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -111,6 +111,44 @@ for other inference use — it can't shadow the full-scope login RC needs.
 > re-login; local *stop/start* is unaffected. This setup is optimized for the
 > Codespaces-primary workflow.
 
+### Carrying your login to fresh Codespaces (optional)
+
+A brand-new Codespace starts with an empty `/workspaces`, so by default it needs a
+one-time `claude auth login`. If you spin up new Codespaces often, you can snapshot
+your login into a **user Codespaces secret** and have new Codespaces restore it
+automatically:
+
+1. In a logged-in Codespace, make sure `gh` can manage your Codespaces user secrets
+   (the default Codespaces token can't — it's repo-scoped):
+   ```bash
+   gh auth refresh -h github.com -s codespace   # or: gh auth login
+   ```
+2. Snapshot the current login into the `CLAUDE_AUTH_ARCHIVE` secret:
+   ```bash
+   bash .devcontainer/sync-claude-auth.sh
+   ```
+   This stores a base64 tar.gz of `.credentials.json` (auth) plus `.claude.json`
+   (folder trust + the Remote Control confirmation), scoped to this repo.
+3. New Codespaces auto-restore it: `postCreateCommand` runs
+   [`restore-claude-auth.sh`](./restore-claude-auth.sh), which unpacks the secret
+   into `CLAUDE_CONFIG_DIR` **only if there's no existing login** (it never clobbers
+   a live one). RC then comes up authenticated and trusted with no prompts.
+
+Caveats:
+
+- **The snapshot goes stale.** Claude Code's OAuth credential expires and isn't
+  silently refreshed, so when it lapses, `claude auth login` again and **re-run
+  `sync-claude-auth.sh`** to refresh the secret.
+- **Updating the secret only affects *future* Codespaces** — secrets are injected at
+  start, not mid-session.
+- **48 KB secret limit.** If `.claude.json` grows too large, `sync-claude-auth.sh`
+  errors; drop `.claude.json` from it to store credentials only (you'll then
+  re-accept trust + the RC prompt once per fresh Codespace).
+- **Security.** This stores a full-scope login (capable of opening Remote Control
+  sessions) in a Codespaces secret. Treat it like a credential: keep it scoped to
+  this repo, and to revoke run
+  `gh secret delete CLAUDE_AUTH_ARCHIVE --user --app codespaces` and re-login.
+
 ## Notes
 
 - Remote Control requires a **claude.ai subscription** and a full-scope login (not a

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,16 +30,18 @@ tmux attach -t claude-rc     # Ctrl-b then d to detach
 The session lives only as long as the container is running. Codespaces auto-suspend
 when idle, which ends the session until the next start (when it relaunches).
 
-> **Brand-new Codespace with no stored login?** The `claude-rc` session starts the
-> interactive `claude auth login` *first* (then Remote Control), and a rendered
-> `LOGIN-REQUIRED.md` opens automatically to point you there. Just
-> `tmux attach -t claude-rc`, finish the login (URL + code), and RC starts. This is
-> only needed when there's no restorable login — see
+> **Brand-new Codespace with no stored login?** A rendered `LOGIN-REQUIRED.md` opens
+> automatically pointing you to one command:
+> ```bash
+> bash .devcontainer/setup-remote-control.sh
+> ```
+> It wraps both interactive logins — Claude (`claude auth login`) and, if you opt to
+> remember it, GitHub (`gh`, handled for you) — and then starts Remote Control. It's
+> optional: close the file to skip. See
 > [Carrying your login to fresh Codespaces](#carrying-your-login-to-fresh-codespaces-optional).
 >
-> A one-time "trust this folder" prompt may also appear there; accept it once and it
-> persists. (Both are separate from permissions and are the only things that can hold
-> up the launch.)
+> A one-time "trust this folder" prompt may also appear; accept it once and it
+> persists. (Separate from permissions, and the only thing that can hold up launch.)
 
 ### Approving actions
 
@@ -122,7 +124,11 @@ for other inference use — it can't shadow the full-scope login RC needs.
 A brand-new Codespace starts with an empty `/workspaces`, so by default it needs a
 one-time `claude auth login`. If you spin up new Codespaces often, you can snapshot
 your login into a **user Codespaces secret** and have new Codespaces restore it
-automatically:
+automatically.
+
+The easy path is the wrapper — `bash .devcontainer/setup-remote-control.sh` offers
+this as its "remember this login?" step. The steps below are what that does (and how
+to do it standalone):
 
 1. In a logged-in Codespace, snapshot the current login into the `CLAUDE_AUTH_ARCHIVE`
    secret:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     },
     "remoteUser": "bun",
     "userEnvProbe": "loginInteractiveShell",
-    "postCreateCommand": "sudo mkdir -p /workspaces/.claude && sudo chown -R bun:bun /workspaces/.claude /home/bun/.bun/install/cache && bun install",
+    "postCreateCommand": "sudo mkdir -p /workspaces/.claude && sudo chown -R bun:bun /workspaces/.claude /home/bun/.bun/install/cache && bash .devcontainer/restore-claude-auth.sh && bun install",
     "postStartCommand": "bash .devcontainer/start-remote-control.sh",
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
     "userEnvProbe": "loginInteractiveShell",
     "postCreateCommand": "sudo mkdir -p /workspaces/.claude && sudo chown -R bun:bun /workspaces/.claude /home/bun/.bun/install/cache && bash .devcontainer/restore-claude-auth.sh && bun install",
     "postStartCommand": "bash .devcontainer/start-remote-control.sh",
+    "postAttachCommand": "test -f /workspaces/.claude/LOGIN-REQUIRED.md && code /workspaces/.claude/LOGIN-REQUIRED.md || true",
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {}
     },
@@ -25,7 +26,10 @@
         "vscode": {
             "settings": {
                 "editor.tabSize": 2,
-                "editor.detectIndentation": true
+                "editor.detectIndentation": true,
+                "workbench.editorAssociations": {
+                    "**/LOGIN-REQUIRED.md": "vscode.markdown.preview.editor"
+                }
             },
             "extensions": [
                 "esbenp.prettier-vscode",

--- a/.devcontainer/restore-claude-auth.sh
+++ b/.devcontainer/restore-claude-auth.sh
@@ -31,35 +31,27 @@ Remote Control needs a full-scope `claude auth login` (long-lived tokens are
 inference-only and rejected).
 
 > **This is optional.** If you don't need Remote Control, just **close this file** —
-> the Codespace works normally without it. Follow the steps below only if you want to
+> the Codespace works normally without it. Run the command below only if you want to
 > drive this Codespace from the Claude app.
 
-## Finish it in the waiting session
+## One command does it all
 
-Remote Control is already waiting for you to log in. Attach to it, complete the
-login (a URL + one-time code appears), and the session starts automatically:
-
-```bash
-tmux attach -t claude-rc
-```
-
-Then open the **Code** tab in the Claude app (or claude.ai/code) and pick the
-`expressive-mvc (codespace)` session. Detach from tmux with `Ctrl-b` then `d`.
-
-## Skip this on future Codespaces (optional)
-
-Snapshot the login into a user Codespaces secret so new Codespaces restore it
-automatically:
+In a terminal, run:
 
 ```bash
-bash .devcontainer/sync-claude-auth.sh
+bash .devcontainer/setup-remote-control.sh
 ```
 
-This handles the GitHub side for you — it'll prompt a one-time `gh` authorization
-(another URL + code) the first time, since storing the secret needs the `codespace`
-scope. Re-run it whenever you log in to Claude again.
+It walks you through everything:
 
-(You can close this file once you're logged in.)
+1. **Claude login** — opens a URL + one-time code (required for Remote Control).
+2. **Remember it for future Codespaces?** — optional; if yes, it stores your login in
+   a user Codespaces secret and handles the one-time GitHub (`gh`) authorization for
+   you.
+3. **Starts Remote Control** — then open the **Code** tab in the Claude app (or
+   claude.ai/code) and pick the `expressive-mvc (codespace)` session.
+
+(You can close this file at any time.)
 MD
 }
 

--- a/.devcontainer/restore-claude-auth.sh
+++ b/.devcontainer/restore-claude-auth.sh
@@ -8,20 +8,66 @@
 # .claude.json (folder trust + the "Enable Remote Control?" confirmation), produced
 # by sync-claude-auth.sh after you `claude auth login`.
 #
-# Safe + idempotent: skips if a live login already exists (won't clobber it) or if
-# the secret isn't set. On a non-Codespaces / local container the secret is simply
-# unset, so this is a no-op.
+# When no login can be established, writes a short markdown guide (LOGIN-REQUIRED.md)
+# that VS Code opens, rendered, on attach (see devcontainer.json). When a login is
+# present, that guide is removed.
+#
+# Safe + idempotent: never clobbers a live login; a no-op when the secret is unset
+# (e.g. local containers).
 set -euo pipefail
 
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
+GUIDE="$CONFIG_DIR/LOGIN-REQUIRED.md"
+
+clear_guide() { rm -f "$GUIDE" 2>/dev/null || true; }
+
+write_guide() {
+  mkdir -p "$CONFIG_DIR"
+  cat > "$GUIDE" <<'MD'
+# Claude Code — finish logging in
+
+This Codespace has no Claude Code login yet, so **Remote Control** can't start.
+Remote Control needs a full-scope `claude auth login` (long-lived tokens are
+inference-only and rejected).
+
+> **This is optional.** If you don't need Remote Control, just **close this file** —
+> the Codespace works normally without it. Follow the steps below only if you want to
+> drive this Codespace from the Claude app.
+
+## Finish it in the waiting session
+
+Remote Control is already waiting for you to log in. Attach to it, complete the
+login (a URL + one-time code appears), and the session starts automatically:
+
+```bash
+tmux attach -t claude-rc
+```
+
+Then open the **Code** tab in the Claude app (or claude.ai/code) and pick the
+`expressive-mvc (codespace)` session. Detach from tmux with `Ctrl-b` then `d`.
+
+## Skip this on future Codespaces (optional)
+
+Snapshot the login into a user Codespaces secret so new Codespaces restore it
+automatically:
+
+```bash
+bash .devcontainer/sync-claude-auth.sh
+```
+
+(You can close this file once you're logged in.)
+MD
+}
 
 if [ -f "$CONFIG_DIR/.credentials.json" ]; then
   echo "[claude-auth] Existing login in $CONFIG_DIR; leaving it untouched."
+  clear_guide
   exit 0
 fi
 
 if [ -z "${CLAUDE_AUTH_ARCHIVE:-}" ]; then
-  echo "[claude-auth] No CLAUDE_AUTH_ARCHIVE secret; run 'claude auth login' then sync-claude-auth.sh."
+  echo "[claude-auth] No CLAUDE_AUTH_ARCHIVE secret; a login is needed (see LOGIN-REQUIRED.md)."
+  write_guide
   exit 0
 fi
 
@@ -29,7 +75,8 @@ mkdir -p "$CONFIG_DIR"
 if echo "$CLAUDE_AUTH_ARCHIVE" | base64 -d 2>/dev/null | tar -xzf - -C "$CONFIG_DIR" 2>/dev/null; then
   chmod 600 "$CONFIG_DIR/.credentials.json" 2>/dev/null || true
   echo "[claude-auth] Restored login from CLAUDE_AUTH_ARCHIVE into $CONFIG_DIR."
-  echo "[claude-auth] If it has expired, run 'claude auth login' then sync-claude-auth.sh to refresh."
+  clear_guide
 else
-  echo "[claude-auth] WARNING: could not decode/extract CLAUDE_AUTH_ARCHIVE; run 'claude auth login'." >&2
+  echo "[claude-auth] WARNING: could not decode/extract CLAUDE_AUTH_ARCHIVE; a login is needed." >&2
+  write_guide
 fi

--- a/.devcontainer/restore-claude-auth.sh
+++ b/.devcontainer/restore-claude-auth.sh
@@ -55,6 +55,10 @@ automatically:
 bash .devcontainer/sync-claude-auth.sh
 ```
 
+This handles the GitHub side for you — it'll prompt a one-time `gh` authorization
+(another URL + code) the first time, since storing the secret needs the `codespace`
+scope. Re-run it whenever you log in to Claude again.
+
 (You can close this file once you're logged in.)
 MD
 }

--- a/.devcontainer/restore-claude-auth.sh
+++ b/.devcontainer/restore-claude-auth.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Restore a Claude Code login from the CLAUDE_AUTH_ARCHIVE Codespaces secret into
+# CLAUDE_CONFIG_DIR on container create, so a brand-new Codespace comes up already
+# authenticated for Remote Control (which requires a full-scope `claude auth login`
+# and rejects long-lived tokens).
+#
+# CLAUDE_AUTH_ARCHIVE is a base64'd tar.gz of .credentials.json (auth) and
+# .claude.json (folder trust + the "Enable Remote Control?" confirmation), produced
+# by sync-claude-auth.sh after you `claude auth login`.
+#
+# Safe + idempotent: skips if a live login already exists (won't clobber it) or if
+# the secret isn't set. On a non-Codespaces / local container the secret is simply
+# unset, so this is a no-op.
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
+
+if [ -f "$CONFIG_DIR/.credentials.json" ]; then
+  echo "[claude-auth] Existing login in $CONFIG_DIR; leaving it untouched."
+  exit 0
+fi
+
+if [ -z "${CLAUDE_AUTH_ARCHIVE:-}" ]; then
+  echo "[claude-auth] No CLAUDE_AUTH_ARCHIVE secret; run 'claude auth login' then sync-claude-auth.sh."
+  exit 0
+fi
+
+mkdir -p "$CONFIG_DIR"
+if echo "$CLAUDE_AUTH_ARCHIVE" | base64 -d 2>/dev/null | tar -xzf - -C "$CONFIG_DIR" 2>/dev/null; then
+  chmod 600 "$CONFIG_DIR/.credentials.json" 2>/dev/null || true
+  echo "[claude-auth] Restored login from CLAUDE_AUTH_ARCHIVE into $CONFIG_DIR."
+  echo "[claude-auth] If it has expired, run 'claude auth login' then sync-claude-auth.sh to refresh."
+else
+  echo "[claude-auth] WARNING: could not decode/extract CLAUDE_AUTH_ARCHIVE; run 'claude auth login'." >&2
+fi

--- a/.devcontainer/setup-remote-control.sh
+++ b/.devcontainer/setup-remote-control.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# One interactive command to set up Remote Control. Run it in a terminal:
+#   bash .devcontainer/setup-remote-control.sh
+#
+# It wraps the two interactive logins and the launch:
+#   1. Claude  — full-scope `claude auth login` (required for Remote Control)
+#   2. GitHub  — optional: remember the login for future Codespaces (gh user secret)
+#   3. Start Remote Control
+#
+# Optional: if you don't want Remote Control, you can just skip running this.
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "'claude' not found on PATH." >&2
+  exit 1
+fi
+
+# 1. Claude login (full-scope) -------------------------------------------------
+if [ -f "$CONFIG_DIR/.credentials.json" ]; then
+  echo "==> Step 1/3: Already logged in to Claude."
+else
+  echo "==> Step 1/3: Log in to Claude (a URL + one-time code will appear)."
+  claude auth login
+fi
+
+# 2. Optionally persist to a Codespaces secret (handles the gh login) ----------
+if [ -n "${CODESPACES:-}" ]; then
+  read -r -p "==> Step 2/3: Remember this login for future Codespaces? [y/N] " ans
+  if [[ "${ans:-}" =~ ^[Yy] ]]; then
+    bash "$DIR/sync-claude-auth.sh"
+  else
+    echo "    Skipped — run 'bash .devcontainer/sync-claude-auth.sh' anytime to do it later."
+  fi
+else
+  echo "==> Step 2/3: Not in a Codespace; skipping the secret sync."
+fi
+
+# 3. Start (or restart) Remote Control -----------------------------------------
+echo "==> Step 3/3: Starting Remote Control..."
+tmux kill-session -t claude-rc 2>/dev/null || true
+rm -f "$CONFIG_DIR/LOGIN-REQUIRED.md" 2>/dev/null || true
+bash "$DIR/start-remote-control.sh"
+
+echo "==> Done. Open the Code tab in the Claude app (or claude.ai/code), or:"
+echo "    tmux attach -t claude-rc"

--- a/.devcontainer/start-remote-control.sh
+++ b/.devcontainer/start-remote-control.sh
@@ -34,26 +34,22 @@ fi
 # --spawn same-dir keeps every remote session in the repo working directory (not an
 # isolated git worktree), so edits and session transcripts land where the editor /
 # Claude Code extension attached to this container can see and resume them.
-RC="env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY claude remote-control --spawn same-dir --name 'expressive-mvc (codespace)'"
-
-if [ -f "$CONFIG_DIR/.credentials.json" ]; then
-  # Authenticated: start Remote Control directly.
-  launch="$RC"
-else
-  # No login yet: run the interactive login first, in the session, then start RC.
-  # Attaching to the session shows the login URL/code; RC starts once you finish.
-  launch="echo '>>> Claude login needed for Remote Control — complete the prompt below.'; claude auth login && $RC"
+if [ ! -f "$CONFIG_DIR/.credentials.json" ]; then
+  # No full-scope login yet; Remote Control can't start. Defer to the interactive
+  # wrapper (login + optional persist + start) rather than launch a failing session.
+  echo "[remote-control] No Claude login yet — Remote Control not started."
+  echo "[remote-control] Run: bash .devcontainer/setup-remote-control.sh"
+  exit 0
 fi
 
-tmux new-session -d -s "$SESSION" "$launch"
+# env -u drops the inference-only tokens so RC uses the stored full-scope login.
+# --spawn same-dir keeps every remote session in the repo working directory (not an
+# isolated git worktree), so edits and session transcripts land where the editor /
+# Claude Code extension attached to this container can see and resume them.
+tmux new-session -d -s "$SESSION" \
+  "env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY claude remote-control --spawn same-dir --name 'expressive-mvc (codespace)'"
 
 echo "[remote-control] Started tmux session '$SESSION'."
-if [ -f "$CONFIG_DIR/.credentials.json" ]; then
-  echo "[remote-control] It should appear in the Claude app session list (tap Code)."
-else
-  echo "[remote-control] Not logged in yet — attach to finish login, then RC starts:"
-  echo "[remote-control]   tmux attach -t $SESSION"
-  echo "[remote-control] Afterwards, 'bash .devcontainer/sync-claude-auth.sh' remembers it for future Codespaces."
-fi
+echo "[remote-control] It should appear in the Claude app session list (tap Code)."
 echo "[remote-control] View the URL/QR or check status anytime: tmux attach -t $SESSION"
 

--- a/.devcontainer/start-remote-control.sh
+++ b/.devcontainer/start-remote-control.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 export PATH="$HOME/.local/bin:$PATH"
 SESSION="claude-rc"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
 
 if ! command -v claude >/dev/null 2>&1; then
   echo "[remote-control] 'claude' not found on PATH; skipping." >&2
@@ -33,11 +34,26 @@ fi
 # --spawn same-dir keeps every remote session in the repo working directory (not an
 # isolated git worktree), so edits and session transcripts land where the editor /
 # Claude Code extension attached to this container can see and resume them.
-tmux new-session -d -s "$SESSION" \
-  "env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY claude remote-control --spawn same-dir --name 'expressive-mvc (codespace)'"
+RC="env -u CLAUDE_CODE_OAUTH_TOKEN -u ANTHROPIC_API_KEY claude remote-control --spawn same-dir --name 'expressive-mvc (codespace)'"
+
+if [ -f "$CONFIG_DIR/.credentials.json" ]; then
+  # Authenticated: start Remote Control directly.
+  launch="$RC"
+else
+  # No login yet: run the interactive login first, in the session, then start RC.
+  # Attaching to the session shows the login URL/code; RC starts once you finish.
+  launch="echo '>>> Claude login needed for Remote Control — complete the prompt below.'; claude auth login && $RC"
+fi
+
+tmux new-session -d -s "$SESSION" "$launch"
 
 echo "[remote-control] Started tmux session '$SESSION'."
-echo "[remote-control] It should appear in the Claude app session list (tap Code)."
-echo "[remote-control] If it isn't authenticated, run 'claude auth login' once"
-echo "[remote-control] (persists in the ~/.claude volume), then re-run this script."
-echo "[remote-control] To view the URL/QR or check status: tmux attach -t $SESSION"
+if [ -f "$CONFIG_DIR/.credentials.json" ]; then
+  echo "[remote-control] It should appear in the Claude app session list (tap Code)."
+else
+  echo "[remote-control] Not logged in yet — attach to finish login, then RC starts:"
+  echo "[remote-control]   tmux attach -t $SESSION"
+  echo "[remote-control] Afterwards, 'bash .devcontainer/sync-claude-auth.sh' remembers it for future Codespaces."
+fi
+echo "[remote-control] View the URL/QR or check status anytime: tmux attach -t $SESSION"
+

--- a/.devcontainer/sync-claude-auth.sh
+++ b/.devcontainer/sync-claude-auth.sh
@@ -6,9 +6,11 @@
 # Run this once after each `claude auth login` (the stored snapshot goes stale when
 # the credential expires, so re-run it whenever you re-authenticate).
 #
-# Requires gh authenticated with permission to manage your Codespaces user secrets:
-#   gh auth login                              # interactive, pick the right scopes
-#   gh auth refresh -h github.com -s codespace # or add the scope to an existing login
+# Requires gh authenticated with permission to manage your Codespaces user secrets.
+# Inside a Codespace the built-in GITHUB_TOKEN is repo-scoped and can't write user
+# secrets (and gh won't override an env-provided token), so first either:
+#   unset GITHUB_TOKEN GH_TOKEN && gh auth login   # grant the 'codespace' scope
+#   export GH_TOKEN=<PAT with codespace scope>
 set -euo pipefail
 
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"

--- a/.devcontainer/sync-claude-auth.sh
+++ b/.devcontainer/sync-claude-auth.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Capture the current Claude Code login (after `claude auth login`) and store it in
+# the CLAUDE_AUTH_ARCHIVE *user* Codespaces secret via gh, so future/fresh Codespaces
+# restore it automatically (see restore-claude-auth.sh) with no interactive login.
+#
+# Run this once after each `claude auth login` (the stored snapshot goes stale when
+# the credential expires, so re-run it whenever you re-authenticate).
+#
+# Requires gh authenticated with permission to manage your Codespaces user secrets:
+#   gh auth login                              # interactive, pick the right scopes
+#   gh auth refresh -h github.com -s codespace # or add the scope to an existing login
+set -euo pipefail
+
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
+SECRET="CLAUDE_AUTH_ARCHIVE"
+
+if [ ! -f "$CONFIG_DIR/.credentials.json" ]; then
+  echo "No credentials at $CONFIG_DIR/.credentials.json — run 'claude auth login' first." >&2
+  exit 1
+fi
+
+# Archive credentials + trust/RC config (whichever exist).
+files=(.credentials.json)
+[ -f "$CONFIG_DIR/.claude.json" ] && files+=(.claude.json)
+archive="$(tar -czf - -C "$CONFIG_DIR" "${files[@]}" | base64 -w0)"
+
+# Codespaces secrets cap at ~48 KB.
+if [ "${#archive}" -gt 48000 ]; then
+  echo "Archive is ${#archive} bytes, over the ~48 KB Codespaces secret limit." >&2
+  echo "Drop .claude.json from this script to store credentials only (you'll then" >&2
+  echo "re-accept folder-trust and the Remote Control prompt once per fresh Codespace)." >&2
+  exit 1
+fi
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+repos_flag=()
+if [ -n "$repo" ]; then
+  repos_flag=(--repos "$repo")
+else
+  echo "WARNING: couldn't determine the repo; the user secret may need --repos scoping." >&2
+fi
+
+printf '%s' "$archive" | gh secret set "$SECRET" --user --app codespaces "${repos_flag[@]}"
+echo "Stored $SECRET (${#archive} bytes)${repo:+, scoped to $repo}."
+echo "New Codespaces will restore this login on create. Re-run after each 'claude auth login'."
+echo "To revoke: 'gh secret delete $SECRET --user --app codespaces' (and consider re-logging in)."

--- a/.devcontainer/sync-claude-auth.sh
+++ b/.devcontainer/sync-claude-auth.sh
@@ -6,11 +6,9 @@
 # Run this once after each `claude auth login` (the stored snapshot goes stale when
 # the credential expires, so re-run it whenever you re-authenticate).
 #
-# Requires gh authenticated with permission to manage your Codespaces user secrets.
-# Inside a Codespace the built-in GITHUB_TOKEN is repo-scoped and can't write user
-# secrets (and gh won't override an env-provided token), so first either:
-#   unset GITHUB_TOKEN GH_TOKEN && gh auth login   # grant the 'codespace' scope
-#   export GH_TOKEN=<PAT with codespace scope>
+# gh auth is handled for you: the Codespaces built-in GITHUB_TOKEN is repo-scoped and
+# can't write user secrets, so this script sets it aside and ensures a stored gh login
+# with the 'codespace' scope (you'll complete a one-time web code when prompted).
 set -euo pipefail
 
 CONFIG_DIR="${CLAUDE_CONFIG_DIR:-/workspaces/.claude}"
@@ -20,6 +18,28 @@ if [ ! -f "$CONFIG_DIR/.credentials.json" ]; then
   echo "No credentials at $CONFIG_DIR/.credentials.json — run 'claude auth login' first." >&2
   exit 1
 fi
+
+ensure_gh_user_secret_auth() {
+  # The env-provided GITHUB_TOKEN/GH_TOKEN (Codespaces built-in) is repo-scoped and
+  # can't write user secrets, and gh refuses to manage an env token. Set it aside for
+  # this process and ensure a stored gh login that carries the 'codespace' scope.
+  if [ -n "${GITHUB_TOKEN:-}${GH_TOKEN:-}" ]; then
+    echo "[gh] Ignoring the environment GitHub token (can't write user secrets)."
+    unset GITHUB_TOKEN GH_TOKEN
+  fi
+  if gh auth status -h github.com 2>&1 | grep -q "codespace"; then
+    return 0
+  fi
+  if gh auth status -h github.com >/dev/null 2>&1; then
+    echo "[gh] Adding the 'codespace' scope to your existing gh login..."
+    gh auth refresh -h github.com -s codespace
+  else
+    echo "[gh] Logging in to gh with the 'codespace' scope (open the URL, enter the code)..."
+    gh auth login -h github.com -p https -s codespace -w
+  fi
+}
+
+ensure_gh_user_secret_auth
 
 # Archive credentials + trust/RC config (whichever exist).
 files=(.credentials.json)


### PR DESCRIPTION
## What

Follow-up to #144. A brand-new Codespace starts with an empty `/workspaces`, so by default it needs a one-time `claude auth login` before Remote Control works. This adds an **opt-in** snapshot/restore so new Codespaces come up pre-authenticated.

## How it works

- **`restore-claude-auth.sh`** (run from `postCreateCommand`): if there's no live login and the `CLAUDE_AUTH_ARCHIVE` Codespaces secret is set, it unpacks the archive (base64 `tar.gz` of `.credentials.json` + `.claude.json`) into `CLAUDE_CONFIG_DIR`. Idempotent — never clobbers an existing login, and a no-op when the secret is unset (local containers, or before you've set it up).
- **`sync-claude-auth.sh`** (run manually after `claude auth login`): archives the current login **plus** the trust / "Enable Remote Control?" config and stores it via `gh secret set CLAUDE_AUTH_ARCHIVE --user --app codespaces --repos <this repo>`. Re-run whenever you re-authenticate.

Because the archive includes `.claude.json`, a restored Codespace skips both the folder-trust prompt and the RC-enable confirmation — RC autostarts fully hands-off.

## Why a user secret (not a repo secret)

The secret holds *your personal full-scope login*. A user secret scoped to this repo is injected only into **your** Codespaces; a repo secret would be shared with every collaborator's Codespaces (leaking your login). The script uses the user-scoped form.

## Setup (one-time per refresh)

The built-in Codespaces `GITHUB_TOKEN` is repo-scoped and can't write user secrets, and `gh` won't override an env-provided token, so inside the Codespace:

```bash
unset GITHUB_TOKEN GH_TOKEN && gh auth login   # grant the 'codespace' scope
bash .devcontainer/sync-claude-auth.sh
```

## Caveats (documented in the README)

- **Snapshot goes stale** — Claude's OAuth credential expires and isn't silently refreshed; when it lapses, `claude auth login` again and re-run `sync-claude-auth.sh`.
- **Affects future Codespaces only** — secrets inject at start, not mid-session.
- **48 KB secret limit** — if `.claude.json` grows too large the sync errors; drop it to store credentials only (you'd then re-accept trust + the RC prompt once per fresh Codespace).
- **Security** — a full-scope login (can open Remote Control sessions) is stored in a Codespaces secret; keep it repo-scoped and revoke with `gh secret delete CLAUDE_AUTH_ARCHIVE --user --app codespaces`.

## Verified end-to-end

- `sync` wrote the user secret (13 KB), scoped to the repo, via `gh`.
- A **brand-new Codespace** restored it on create:
  `[claude-auth] Restored login from CLAUDE_AUTH_ARCHIVE into /workspaces/.claude.`

## Diff

Adds `.devcontainer/restore-claude-auth.sh` and `.devcontainer/sync-claude-auth.sh`, wires restore into `postCreateCommand`, and documents the workflow in `.devcontainer/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6rLh75bCv1TbttvwPcDj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6rLh75bCv1TbttvwPcDj9)_