### PR TITLE
feat(router): Link active/match getters, subclass-replaceable render

### DIFF
--- a/packages/router/src/link.test.tsx
+++ b/packages/router/src/link.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 
 import { location, browserRouter } from '../test.setup';
 import { Link } from './link';
@@ -75,7 +75,9 @@ describe('Link', () => {
   it('replace=true uses replaceState', async () => {
     const view = render(
       <Route to="/">
-        <Link to="/about" replace>about</Link>
+        <Link to="/about" replace>
+          about
+        </Link>
       </Route>
     );
     const before = window.history.length;
@@ -89,7 +91,12 @@ describe('Link', () => {
   it('forwards extra anchor props (className, aria, data) but not to/replace', () => {
     const view = render(
       <Route to="/">
-        <Link to="/about" replace className="nav" aria-current="page" data-id="x">
+        <Link
+          to="/about"
+          replace
+          className="nav"
+          aria-current="page"
+          data-id="x">
           about
         </Link>
       </Route>
@@ -114,5 +121,127 @@ describe('Link', () => {
 
     await act(async () => fireEvent.click(a, { button: 0 }));
     expect(router.current.path).toBe('/posts/foo/edit');
+  });
+});
+
+describe('Link.match / Link.active', () => {
+  /** Counts renders so laziness can be asserted - reset per test. */
+  let renders = 0;
+
+  /** Intended consumption: a subclass authors its own render (which fully
+   * replaces Link's anchor) and reads `active`/`match` to express activeness
+   * however the host wants - here a className plus a probe attribute. */
+  class NavLink extends Link {
+    render() {
+      renders++;
+      return (
+        <a
+          href={this.href}
+          onClick={this.go}
+          className={this.active ? 'active' : undefined}
+          data-match={String(this.match)}>
+          {this.props.children}
+        </a>
+      );
+    }
+  }
+  beforeEach(() => {
+    renders = 0;
+  });
+
+  it('match is true on an exact path', () => {
+    location('/about');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('data-match')).toBe('true');
+    expect(a.getAttribute('class')).toBe('active');
+  });
+
+  it('match is false on a prefix-only path', () => {
+    location('/blog/post-1');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/blog">blog</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('data-match')).toBe('false');
+    expect(a.getAttribute('class')).toBe('active');
+  });
+
+  it('match is undefined on an unrelated path (no false prefix)', () => {
+    location('/blogging');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/blog">blog</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('data-match')).toBe('undefined');
+    expect(a.getAttribute('class')).toBe(null);
+  });
+
+  it('treats a root link as prefix of everything', () => {
+    location('/about');
+    const view = render(
+      <Route to="*">
+        <NavLink to="/">home</NavLink>
+      </Route>
+    );
+    expect(view.container.querySelector('a')!.getAttribute('data-match')).toBe(
+      'false'
+    );
+  });
+
+  it('toggles across navigation when read in render', async () => {
+    const view = render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    const a = view.container.querySelector('a')!;
+    expect(a.getAttribute('class')).toBe(null);
+
+    await act(async () => router.current.goto('/about'));
+    expect(a.getAttribute('class')).toBe('active');
+
+    await act(async () => router.current.goto('/'));
+    expect(a.getAttribute('class')).toBe(null);
+  });
+
+  it('re-renders on navigation only because render reads active', async () => {
+    render(
+      <Route to="*">
+        <NavLink to="/about">about</NavLink>
+      </Route>
+    );
+    expect(renders).toBe(1);
+
+    await act(async () => router.current.goto('/about'));
+    expect(renders).toBe(2);
+  });
+
+  it('does NOT re-render a Link that reads neither (lazy subscription)', async () => {
+    /** Reads neither `active` nor `match`, so it must stay inert across navigation. */
+    class PlainLink extends Link {
+      render(props = {} as Link.Props) {
+        renders++;
+        return super.render(props);
+      }
+    }
+
+    render(
+      <Route to="*">
+        <PlainLink to="/about">about</PlainLink>
+      </Route>
+    );
+    expect(renders).toBe(1);
+
+    await act(async () => router.current.goto('/about'));
+    expect(renders).toBe(1);
   });
 });

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -28,22 +28,45 @@ export namespace Link {
 export class Link extends Component {
   to = '';
   replace = false;
+  fallback = false;
 
-  private route = get(Route);
+  protected route = get(Route);
 
   /** Absolute resolved path for the rendered `<a href>`. */
   get href(): string {
     return this.route.resolve(this.to);
   }
 
-  private go = (e: ClickEvent) => {
+  /** How the current path relates to this link's target:
+   * `true` exact match, `false` prefix match, `undefined` no match.
+   * Reading this (or `active`) in render subscribes to navigation;
+   * a Link that reads neither stays inert across navigation. */
+  get match(): boolean | undefined {
+    const { href } = this;
+    const { path } = this.route.router;
+
+    if (path === href) return true;
+    if (path.startsWith(href === '/' ? href : href + '/')) return false;
+  }
+
+  /** Whether the current path matches this link's target at all. */
+  get active(): boolean {
+    return this.match !== undefined;
+  }
+
+  protected go = (e: ClickEvent) => {
     if (e.defaultPrevented || e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
     this.route.goto(this.to, this.replace);
   };
 
+  /**
+   * If a subclass authores own render, it will override default anchor wrapping.
+   */
   render({ children, to, replace, ...rest } = {} as Link.Props) {
+    if (children !== this.props.children) return children;
+
     return (
       <a {...rest} href={this.href} onClick={this.go}>
         {children}


### PR DESCRIPTION
Folds nav-active styling into `Link` rather than shipping a separate `NavLink` component.

## What

- **`match` / `active` getters** on `Link`. `match` is tri-state (`true` exact, `false` prefix, `undefined` no match); `active` is the boolean derivation. Both are lazy - a `Link` that reads neither stays inert across navigation (no re-render on route changes).
- **Subclass-replaceable render.** `Link.render` defers to a subclass-authored render (detected via `children` identity from the composition seam) so a subclass fully *owns* the anchor instead of nesting inside the base `<a>`. Plain `<Link>` and render-less subclasses keep the base anchor.
- **`route` / `go` widened to `protected`** so a subclass can build its own anchor (href/onClick/active styling).

## Why this instead of NavLink

`Link` is already a `Component` and extensible. With the getters above, nav styling is expressed by subclassing `Link` and reading `active`/`match`, host-agnostically (web applies `className`/`aria-current`; RN could apply `style`) - no web-coupled props baked into the core.

The replace-seam was the missing piece: render composition makes the ancestor render the *outer* shell, so a naive subclass nested a second `<a>`. The identity-based bailout lets the base opt out of wrapping. That composition contract is documented and tested separately on `main` (`skills/react/component.md`, `component.test.ts`).

Closes #140 (NavLink + the `attributes` seam are superseded; scroll restoration from that PR is unrelated and not included here).

## Tests

`Link.match / Link.active` suite: exact/prefix/none matching, root-link prefix, toggle across navigation, and the laziness assertions (reads active -> re-renders; reads neither -> inert). Full router + mvc suites green.