### PR TITLE
chore(router): publish @expressive/router

### DIFF
--- a/.changeset/router-public.md
+++ b/.changeset/router-public.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": patch
+---
+
+Publish `@expressive/router`. The package now depends only on `@expressive/mvc` at runtime - the `@expressive/react` adapter moves to a dev dependency (used by the test host, not shipped). Its `Component`s render under any `@expressive/mvc` host.

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -16,9 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gabeklein/expressive-state.git"
+    "url": "git+https://github.com/gabeklein/expressive-mvc.git"
   },
-  "private": true,
   "files": [
     "dist"
   ],
@@ -40,10 +39,10 @@
     "preversion": "npm run test && npm run build"
   },
   "dependencies": {
-    "@expressive/react": "^0.77.0",
     "@expressive/mvc": "^0.77.0"
   },
   "devDependencies": {
+    "@expressive/react": "^0.77.0",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Makes `@expressive/router` a published package (currently `private`, pinned at the `0.0.0` OIDC bootstrap stub).

- Drop `private` so it publishes.
- The Component-into-mvc migration removed router's runtime need for the react adapter; `src/` imports only `@expressive/mvc`. Move `@expressive/react` to `devDependencies` (still the test JSX host via `test.setup.ts`). **Published runtime deps are now just `@expressive/mvc`** (+ `react` peer).
- Fix stale `repository.url` (`expressive-state` → `expressive-mvc`).
- Patch changeset → `0.0.1`.

Full suite green (tsc + tests, all packages).