### PR TITLE
feat(mvc)!: rename Observable export to Observer

### DIFF
--- a/.changeset/observer-export-rename.md
+++ b/.changeset/observer-export-rename.md
@@ -1,0 +1,8 @@
+---
+"@expressive/mvc": minor
+"@expressive/react": minor
+---
+
+Rename the `Observable` export to `Observer`.
+
+The exported symbol is the observer/dispatch type (`Observer.Signal`, `Observer.Notify`, etc.); it was surfaced under the wrong name. The export is renamed clean - import `Observer` instead of `Observable`. The internal `Observable` marker interface (an object that may carry an `Observer`) is unaffected and remains internal.

--- a/packages/mvc/src/index.ts
+++ b/packages/mvc/src/index.ts
@@ -5,6 +5,6 @@ export { set } from './field/set';
 export { ref } from './field/ref';
 
 export { State, State as default, unbind } from './state';
-export { watch, listener, event, Observable, observer, touch } from './observable';
+export { watch, listener, event, Observer, observer, touch } from './observable';
 export { Context } from './context';
 export { Component } from './component';

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -350,7 +350,7 @@ function capture(scope: (release: (update?: boolean | null) => void) => void) {
 export {
   listener,
   event,
-  Observer as Observable,
+  Observer,
   touch,
   pending,
   observer,

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -2,7 +2,7 @@ import { Context } from './context';
 import {
   event,
   listener,
-  Observable,
+  Observer,
   observer,
   pending,
   touch,
@@ -471,7 +471,7 @@ define(State, 'toString', {
 function callback<T extends State>(
   self: T,
   cb: Function,
-  select?: Observable.Signal | Set<Observable.Signal>
+  select?: Observer.Signal | Set<Observer.Signal>
 ) {
   return listener(self, (key) => cb.call(self, key, self), select);
 }

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -44,4 +44,4 @@ Object.assign(Runtime, {
 });
 
 export { State, State as default, Consumer, Provider, use } from '@expressive/react/runtime'
-export { Component, Context, Observable, def, get, ref, set, hot } from '@expressive/mvc';
+export { Component, Context, Observer, def, get, ref, set, hot } from '@expressive/mvc';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -37,5 +37,5 @@ Object.assign(Runtime, {
 });
 
 export { State, State as default, use } from './runtime';
-export { Component, Context, Observable, def, get, ref, set, hot } from '@expressive/mvc';
+export { Component, Context, Observer, def, get, ref, set, hot } from '@expressive/mvc';
 export { Consumer, Provider } from './context';

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -10,7 +10,7 @@ For examples and patterns see `patterns.md`.
 
 ```ts
 export { State, State as default }; // Reexported after agumentation with React features
-export { Context, Observable, def, get, hot, ref, set }; // re-exported from @expressive/mvc
+export { Context, Observer, def, get, hot, ref, set }; // re-exported from @expressive/mvc
 export { use }; // Hook for existing observable instances
 export { Component }; // React Component class
 export { Provider, Consumer }; // Explicit context components


### PR DESCRIPTION
The exported symbol is the observer/dispatch type (`Observer.Signal`, `Observer.Notify`, etc.) - it was surfaced under the wrong name (`Observer as Observable`). Rename it clean.

- `@expressive/mvc`: export `Observer` instead of `Observable`.
- `@expressive/react` + `@expressive/preact`: re-export rename.
- `skills/react` doc updated.
- Internal `Observable` marker interface (an object that may carry an `Observer`) is unaffected and stays internal.

Clean rename, no deprecation alias (pre-1.0, no appreciable user base). Minor changeset for mvc + react.

Full suite green (tsc + tests, all packages).