### PR TITLE
fix(react): point build entry at renamed runtime module

### DIFF
--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -5,11 +5,11 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   outDir: 'dist',
-  external: ['./state'],
+  external: ['./runtime'],
   outExtensions: () => ({ js: '.js' }),
   entry: {
     index: 'src/index.ts',
-    state: 'src/state.ts'
+    runtime: 'src/runtime.ts'
   },
   format: ['esm'],
   outputOptions: {


### PR DESCRIPTION
The `@expressive/react/state` → `/runtime` rename renamed `src/state.ts` → `src/runtime.ts` and updated `exports` + `index.ts`, but `tsdown.config.ts` still listed the old entry (`entry.state: 'src/state.ts'`, `external: ['./state']`). As a result **`@expressive/react` fails to build on `main`** (`Cannot resolve entry module src/state.ts`), which would break `ci:publish` and any PR's `bun run build`. (#135's green run predates the rename merge.)

Point the entry and `external` at `runtime`. React now emits `dist/index.js` + `dist/runtime.js`; full package build is green again.

No changeset - internal build fix completing the change already described by the pending `react-runtime-subpath` changeset.