### PR TITLE
chore: decouple website from package CI

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@expressive/preact", "@expressive/examples", "website2"]
+  "ignore": ["@expressive/preact", "@expressive/examples", "website"]
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "examples"
   ],
   "scripts": {
-    "test": "bun run --filter='*' test",
-    "build": "bun run --filter='*' build",
+    "test": "bun run --filter='./packages/*' test",
+    "build": "bun run --filter='./packages/*' build",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "changeset publish",

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website2",
+  "name": "website",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The docs site (deployed separately via Cloudflare) was part of the root `--filter='*'` build/test, so a site-only failure (e.g. an SSR/prerender bug) would block package CI and releases. It also carried the odd package name `website2`.

- Scope root `test`/`build` to `--filter='./packages/*'` - the gate now covers exactly the publishable set (mvc, react, preact, router). `@expressive/examples` has no build/test scripts, so nothing else is lost.
- Rename package `website2` → `website` (directory was already `website`); update the changeset `ignore` entry to match.

Site build/deploy stays entirely on Cloudflare, on its own trigger - package release and site deploy no longer block each other.

No changeset: website is private/ignored; root scripts are CI tooling with no effect on published packages.