### PR TITLE
ci: skip PR verify on bot-authored version PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   verify:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The changeset bot's "Version Packages" PR is gated behind manual workflow approval (repo requires approval for external contributors; `github-actions[bot]` counts as external), so its `verify` run sits in `action_required` every release.

Skip `verify` on bot-authored PRs via a job-level `if: github.actor != 'github-actions[bot]'`. The Version PR is mechanical - `changeset version` only bumps version strings, dependency ranges, and CHANGELOGs; the source is identical to what already passed `verify` on the feature PRs. `ci:publish` still builds before publishing, so a build break is caught at release time.

Only affects `pr.yml`; merging the Version PR still triggers `release.yml` normally. Fork-PR approval security is unchanged.

Note: if branch protection later requires the `verify` check, a job skipped via `if` can read as a missing required check - at that point switch to authoring Version PRs with a GitHub App token instead.