### PR TITLE
feat(mvc): exclude non-settable members from inferred JSX props

### DIFF
--- a/.changeset/stateprops-exclude-readonly.md
+++ b/.changeset/stateprops-exclude-readonly.md
@@ -1,0 +1,10 @@
+---
+"@expressive/mvc": minor
+"@expressive/react": minor
+---
+
+Exclude non-settable members from inferred JSX props.
+
+`Component.StateProps` now drops get-only accessors and `readonly` fields from the prop surface a component accepts. These members can never be meaningfully assigned from JSX, so offering them as props only invited no-op or type-erroring assignments. Writable fields, get/set accessors, callbacks, and methods are unaffected.
+
+The exclusion is the one structurally-detectable case (via a `readonly`-probe); TypeScript cannot distinguish a method from a callback field, so a blanket function exclusion is intentionally not attempted. The new behavior is consistent with `set`, which already rejects `readonly` keys.

--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -255,3 +255,44 @@ describe('leading function argument', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('props (static types)', () => {
+  class Test extends Component {
+    value = 0;
+    onClick = () => {};
+    readonly id = 1;
+    get computed() { return this.value * 2 }
+    get pair() { return this.value }
+    set pair(next: number) { this.value = next }
+    method() {}
+  }
+
+  it('will accept writable fields and callbacks', () => {
+    const props: Component.StateProps<Test> = {
+      value: 1,
+      onClick: () => {},
+      pair: 2,
+      method() {}
+    };
+
+    expect(props).toBeDefined();
+  });
+
+  it('will reject get-only accessors', () => {
+    const props: Component.StateProps<Test> = {
+      // @ts-expect-error - get-only accessor is not a settable prop
+      computed: 4
+    };
+
+    expect(props).toBeDefined();
+  });
+
+  it('will reject readonly fields', () => {
+    const props: Component.StateProps<Test> = {
+      // @ts-expect-error - readonly field is not a settable prop
+      id: 2
+    };
+
+    expect(props).toBeDefined();
+  });
+});

--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -9,6 +9,19 @@ const PENDING = new WeakMap<object, Component>();
 /** Per-class composed content render. */
 const CHAIN = new WeakMap<Function, Function>();
 
+type IfEquals<X, Y, A, B> =
+  (<T>() => T extends X ? 1 : 2) extends
+  (<T>() => T extends Y ? 1 : 2) ? A : B;
+
+/** Keys of T which are settable (excludes get-only accessors and `readonly`). */
+type Acceptable<T> = {
+  [P in keyof T]-?: IfEquals<
+    { [Q in P]: T[P] },
+    { -readonly [Q in P]: T[P] },
+    P, never
+  >;
+}[keyof T];
+
 declare namespace Component {
   /**
    * Host element type produced by `Component.render`. Delegates to the
@@ -36,7 +49,7 @@ declare namespace Component {
   }
 
   type StateProps<T extends State> = {
-    [K in Exclude<keyof T, keyof Component>]?: T[K];
+    [K in Exclude<keyof T, keyof Component> & Acceptable<T>]?: T[K];
   };
 
   type RenderProps<T> = [T] extends [(props: infer P) => any]

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -91,7 +91,7 @@ declare namespace State {
     : T[K];
   };
 
-  /** Subset of `keyof T` which are not methods or defined by base State U. **/
+  /** Subset of `keyof T` not defined by base State. **/
   type Field<T> = Exclude<keyof T, keyof State>;
 
   /** Any valid key for state, including but not limited to Field<T>. */

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -144,6 +144,23 @@ describe('element props', () => {
     );
   });
 
+  it('will only offer settable members as JSX props', () => {
+    class Bar extends Component {
+      value = 0;
+      onClick = () => {};
+      readonly id = 1;
+      get computed() { return this.value * 2 }
+    }
+
+    render(<Bar value={1} onClick={() => {}} />);
+
+    // @ts-expect-error - get-only accessor is not a settable prop
+    (() => <Bar computed={4} />);
+
+    // @ts-expect-error - readonly field is not a settable prop
+    (() => <Bar id={2} />);
+  });
+
   it('will trigger set instruction', () => {
     class Foo extends Component {
       value = set('foobar', didSet);


### PR DESCRIPTION
Closes #157.

## What

`Component.StateProps<T>` previously derived the JSX prop surface purely by key, surfacing every own member - including ones that can't meaningfully be *set* from JSX. This narrows it to **settable** members only.

- **Dropped:** get-only accessors and `readonly` fields - assigning them from JSX was always a no-op or a type error.
- **Kept:** writable fields, get/set accessors, callbacks, and methods.

Implemented via a `readonly`-probe (`IfEquals` / `Acceptable`), kept as private module-scope helpers - no new public surface. This is the one structurally-detectable non-settable case; TypeScript cannot distinguish a method from a callback field, so a blanket function exclusion is intentionally **not** attempted (it would wrongly drop legitimate callback props).

## Notes

- Corrected the `State.Field` JSDoc, which falsely claimed it excludes methods.
- The new behavior is consistent with `set`, which already rejects `readonly` keys at the type level - so `readonly` now means "locked everywhere" (props, `set`, direct assignment), not "hidden from props but pokeable."
- Verified through real JSX DX in the React adapter, not just the type in isolation.

## Tests

- `packages/mvc` - `StateProps` unit type tests (`@ts-expect-error` on get-only/readonly).
- `packages/react` - JSX-level sanity test confirming rejection at the attribute site.

All three packages (mvc / react / preact) type-check and test green.