### PR TITLE
chore(ci): drop author thanks from changelog entries

### DIFF
--- a/.changeset/changelog-no-thanks.cjs
+++ b/.changeset/changelog-no-thanks.cjs
@@ -1,0 +1,9 @@
+const github = require('@changesets/changelog-github').default;
+
+module.exports = {
+  getDependencyReleaseLine: github.getDependencyReleaseLine,
+  async getReleaseLine(changeset, type, options) {
+    const line = await github.getReleaseLine(changeset, type, options);
+    return line.replace(/Thanks \[@[^\]]+\]\([^)]+\)! ?- /, '');
+  },
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "gabeklein/expressive-mvc" }],
+  "changelog": ["./changelog-no-thanks.cjs", { "repo": "gabeklein/expressive-mvc" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
Wraps `@changesets/changelog-github` to strip the "Thanks [@user]!" phrase from generated changelog lines, while keeping the commit and PR backlinks. CI-only; no changeset.

I'm the only author for now, it's noisy.