### PR TITLE
docs: add per-package READMEs

### DIFF
--- a/packages/mvc/README.md
+++ b/packages/mvc/README.md
@@ -11,11 +11,15 @@
 
 ---
 
-The core of [Expressive MVC](https://github.com/gabeklein/expressive-mvc): reactive primitives built around plain classes, with no framework dependency. Provides the `State` model, the renderer-agnostic `Component`, and the JSX runtime that adapters like [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) build on.
+The core of [Expressive MVC](https://github.com/gabeklein/expressive-mvc): reactive primitives built around plain classes, with no framework dependency. Provides the `State` model, instructions, context, and the renderer-agnostic `Component` that adapters like [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) build on.
 
 ```bash
 npm install @expressive/mvc
 ```
+
+## State
+
+A `State` is a class whose fields are reactive - read to subscribe, assign to update. Getters are cached computed values.
 
 ```ts
 import { State } from '@expressive/mvc';
@@ -23,46 +27,108 @@ import { State } from '@expressive/mvc';
 class Counter extends State {
   count = 0;
   increment = () => this.count++;
+
+  get doubled() {
+    return this.count * 2;     // recomputes only when count changes
+  }
 }
 
 const counter = Counter.new();
 
-// effect runs now ("count is 0"), then again whenever `count` changes
-counter.get(({ count }) => console.log(`count is ${count}`));
+// effect runs now, then again whenever read values change
+counter.get(({ count }) => {
+  console.log(`count is ${count}`);
+});
 
-counter.increment(); // -> "count is 1"
+counter.increment();           // -> "count is 1"
 ```
 
-**At a glance**
+Models run and test anywhere - no renderer required.
 
-- **Class-based** - state is a class; fields are reactive, getters are computed.
-- **Fine-grained** - reads subscribe, writes notify; only what changed reacts.
-- **Headless** - models run and test anywhere, no renderer required.
-- **Instructions** - `ref` / `set` / `get` / `hot` shape fields (refs, computed, context injection, reactive collections).
-- **Agnostic `Component`** - a `State` that renders, with a host adapter supplying the framework.
+## Instructions
 
-**Computed & instructions**
+Field initializers that change how a property behaves:
 
-Getters are cached computed values; `set` / `get` / `ref` / `hot` shape how fields behave.
+| | |
+|---|---|
+| `ref()` | a mutable reference (e.g. a DOM node) that's still reactive |
+| `set()` | computed values, smart setters, side-effects on assignment |
+| `get()` | dependency injection - pull another `State` from context |
+| `hot()` | a shallow-reactive array or object |
 
 ```ts
-import { State, get, set, hot } from '@expressive/mvc';
+import { State, set, hot } from '@expressive/mvc';
 
 class Cart extends State {
-  items = hot<Item[]>([]);               // shallow-reactive collection
-  coupon = set('', code => apply(code)); // assignment side-effect
+  items = hot<Item[]>([]);                  // reactive collection
+  coupon = set('', code => apply(code));    // side-effect on assignment
+}
+```
 
-  get total() {                          // recomputes only when items change
-    return this.items.reduce((n, i) => n + i.price, 0);
+## Lifecycle
+
+```ts
+class Timer extends State {
+  seconds = 0;
+
+  new() {                              // runs once on activation
+    const id = setInterval(() => this.seconds++, 1000);
+    return () => clearInterval(id);    // returned cleanup runs on destroy
   }
 }
 
-class Checkout extends State {
-  cart = get(Cart);                      // injected from context
+const timer = Timer.new();   // construct + activate
+timer.set(null);             // destroy - runs cleanup, freezes state
+```
+
+## Context & composition
+
+States find each other through context, and compose by holding one another:
+
+```ts
+import { State, get } from '@expressive/mvc';
+
+class Session extends State {
+  user = 'guest';
+}
+
+class Profile extends State {
+  session = get(Session);    // injected from the nearest provider
+  address = new Address();   // nested state - its changes bubble up
 }
 ```
 
-To render in a UI framework, add an adapter: [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) or `@expressive/preact`.
+An adapter (e.g. [`@expressive/react`](https://www.npmjs.com/package/@expressive/react)) supplies the provider that places a `State` in a tree; `get()` pulls it back out.
+
+## Events
+
+Any property or arbitrary key can be dispatched and listened to:
+
+```ts
+const off = counter.set('refresh', () => reload());   // listen
+counter.set('refresh');                               // dispatch
+off();                                                // stop listening
+```
+
+## Framework-agnostic components
+
+`@expressive/mvc` ships its own JSX runtime, so you can author components - including reusable libraries - against the core and let any host render them:
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@expressive/mvc"
+  }
+}
+```
+
+`Component` - a `State` that renders - lives here as the agnostic base. For using it in an app (rendering, props, subcomponents, suspense), see **[`@expressive/react`](https://www.npmjs.com/package/@expressive/react)**.
+
+---
+
+To render state in a UI framework, add an adapter: [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) or `@expressive/preact`.
 
 Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
 

--- a/packages/mvc/README.md
+++ b/packages/mvc/README.md
@@ -1,0 +1,71 @@
+<h1 align="center">@expressive/mvc</h1>
+
+<p align="center">
+  Class-based reactive state management - framework-agnostic core.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@expressive/mvc"><img alt="NPM" src="https://badge.fury.io/js/%40expressive%2Fmvc.svg"></a>
+  <img src="https://img.shields.io/badge/Coverage-100%25-brightgreen.svg">
+</p>
+
+---
+
+The core of [Expressive MVC](https://github.com/gabeklein/expressive-mvc): reactive primitives built around plain classes, with no framework dependency. Provides the `State` model, the renderer-agnostic `Component`, and the JSX runtime that adapters like [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) build on.
+
+```bash
+npm install @expressive/mvc
+```
+
+```ts
+import { State } from '@expressive/mvc';
+
+class Counter extends State {
+  count = 0;
+  increment = () => this.count++;
+}
+
+const counter = Counter.new();
+
+// effect runs now ("count is 0"), then again whenever `count` changes
+counter.get(({ count }) => console.log(`count is ${count}`));
+
+counter.increment(); // -> "count is 1"
+```
+
+**At a glance**
+
+- **Class-based** - state is a class; fields are reactive, getters are computed.
+- **Fine-grained** - reads subscribe, writes notify; only what changed reacts.
+- **Headless** - models run and test anywhere, no renderer required.
+- **Instructions** - `ref` / `set` / `get` / `hot` shape fields (refs, computed, context injection, reactive collections).
+- **Agnostic `Component`** - a `State` that renders, with a host adapter supplying the framework.
+
+**Computed & instructions**
+
+Getters are cached computed values; `set` / `get` / `ref` / `hot` shape how fields behave.
+
+```ts
+import { State, get, set, hot } from '@expressive/mvc';
+
+class Cart extends State {
+  items = hot<Item[]>([]);               // shallow-reactive collection
+  coupon = set('', code => apply(code)); // assignment side-effect
+
+  get total() {                          // recomputes only when items change
+    return this.items.reduce((n, i) => n + i.price, 0);
+  }
+}
+
+class Checkout extends State {
+  cart = get(Cart);                      // injected from context
+}
+```
+
+To render in a UI framework, add an adapter: [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) or `@expressive/preact`.
+
+Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
+
+## License
+
+MIT

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,0 +1,31 @@
+<h1 align="center">@expressive/preact</h1>
+
+<p align="center">
+  Preact adapter for Expressive MVC - class-based reactive state.
+</p>
+
+---
+
+The Preact adapter for [Expressive MVC](https://github.com/gabeklein/expressive-mvc). It mirrors the [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) API - `State.use()`, `State.get()`, `Component`, `Provider` / `Consumer` - against a Preact host.
+
+> **Note:** This package is currently internal and not published to npm. It is kept in parity with the React adapter; track [the repo](https://github.com/gabeklein/expressive-mvc) for availability.
+
+```tsx
+import { State } from '@expressive/preact';
+
+class Counter extends State {
+  count = 0;
+  increment = () => this.count++;
+}
+
+function CounterWidget() {
+  const { count, increment } = Counter.use();
+  return <button onClick={increment}>{count}</button>;
+}
+```
+
+Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
+
+## License
+
+MIT

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -6,25 +6,9 @@
 
 ---
 
-The Preact adapter for [Expressive MVC](https://github.com/gabeklein/expressive-mvc). It mirrors the [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) API - `State.use()`, `State.get()`, `Component`, `Provider` / `Consumer` - against a Preact host.
+The Preact adapter for [Expressive MVC](https://github.com/gabeklein/expressive-mvc). Its API mirrors [`@expressive/react`](https://www.npmjs.com/package/@expressive/react) - `State.use()`, `State.get()`, `Component`, `Provider` / `Consumer` - against a Preact host. See the [`@expressive/react` README](https://github.com/gabeklein/expressive-mvc/blob/main/packages/react/README.md) for usage.
 
-> **Note:** This package is currently internal and not published to npm. It is kept in parity with the React adapter; track [the repo](https://github.com/gabeklein/expressive-mvc) for availability.
-
-```tsx
-import { State } from '@expressive/preact';
-
-class Counter extends State {
-  count = 0;
-  increment = () => this.count++;
-}
-
-function CounterWidget() {
-  const { count, increment } = Counter.use();
-  return <button onClick={increment}>{count}</button>;
-}
-```
-
-Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
+> **Note:** This package is currently internal and not published to npm. Track [the repo](https://github.com/gabeklein/expressive-mvc) for availability.
 
 ## License
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -115,6 +115,37 @@ class DarkModeSwitch extends Toggle {
 
 The base owns behavior and structure; subclasses author only the rendering. This is the same mechanism `@expressive/router`'s `NavLinks` exposes through its overridable `Item` / `List` / `Group` members.
 
+### Self-providing context
+
+A `Component` provides *itself* to context automatically - no `Provider` needed. Both its own render output and any `children` passed in can read it with `get()`.
+
+```tsx
+class Tabs extends Component {
+  active = 0;
+  render(props = {} as { children?: React.ReactNode }) {
+    return <div className="tabs">{props.children}</div>;
+  }
+}
+
+function Tab({ index, label }: { index: number; label: string }) {
+  const tabs = Tabs.get();              // reads the enclosing Tabs instance
+  return (
+    <button
+      className={tabs.active === index ? 'on' : undefined}
+      onClick={() => (tabs.active = index)}>
+      {label}
+    </button>
+  );
+}
+
+<Tabs>
+  <Tab index={0} label="One" />
+  <Tab index={1} label="Two" />
+</Tabs>;
+```
+
+It works the same whether the consumer is part of the Component's own render or is passed in as `children` - both sit under the instance's context. A render-less `Component` still self-provides, which is what makes it useful purely as a context/boundary placement.
+
 ## Shared state via context
 
 Provide a model once; descendants read it with `State.get()` - no props, no selectors.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,95 @@
+<h1 align="center">@expressive/react</h1>
+
+<p align="center">
+  React adapter for Expressive MVC - class-based reactive state.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@expressive/react"><img alt="NPM" src="https://badge.fury.io/js/%40expressive%2Freact.svg"></a>
+  <img src="https://img.shields.io/badge/Coverage-100%25-brightgreen.svg">
+</p>
+
+---
+
+The React adapter for [Expressive MVC](https://github.com/gabeklein/expressive-mvc). Define state as a class, use it in a component, and reads automatically subscribe - components re-render only when accessed values change.
+
+```bash
+npm install @expressive/react react
+```
+
+```tsx
+import { State } from '@expressive/react';
+
+class Counter extends State {
+  count = 0;
+  increment = () => this.count++;
+  decrement = () => this.count--;
+}
+
+function CounterWidget() {
+  const { count, increment, decrement } = Counter.use();
+
+  return (
+    <div>
+      <button onClick={decrement}>-</button>
+      <span>{count}</span>
+      <button onClick={increment}>+</button>
+    </div>
+  );
+}
+```
+
+When the state belongs to one rendered unit, extend `Component` and give it a `render`:
+
+```tsx
+import { Component } from '@expressive/react';
+
+class Counter extends Component {
+  count = 0;
+  render() {
+    return <button onClick={() => this.count++}>{this.count}</button>;
+  }
+}
+
+<Counter />;
+```
+
+## Shared state via context
+
+Provide a model once; descendants read it with `State.get()` - no props, no selectors.
+
+```tsx
+import { Provider } from '@expressive/react';
+
+class Session extends State {
+  user = 'guest';
+}
+
+function App() {
+  return (
+    <Provider for={Session}>
+      <Profile />
+    </Provider>
+  );
+}
+
+function Profile() {
+  const { user } = Session.get();   // nearest Session in context
+  return <p>Signed in as {user}</p>;
+}
+```
+
+**At a glance**
+
+- **`State.use()`** - create an instance bound to a component's lifecycle.
+- **`State.get()`** - read shared state from context, no prop drilling.
+- **`Provider` / `Consumer`** - explicit hierarchical dependency injection.
+- **`Component`** - smart controls and shells whose behavior lives in the tree.
+- **Suspense** - async values and promises integrate with React Suspense.
+- **`@expressive/react/runtime`** - the host-agnostic runtime layer adapters build on.
+
+Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
+
+## License
+
+MIT

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -113,7 +113,7 @@ class DarkModeSwitch extends Toggle {
 }
 ```
 
-The base owns behavior and structure; subclasses author only the rendering. This is the same mechanism `@expressive/router`'s `NavLinks` exposes through its overridable `Item` / `List` / `Group` members.
+The base owns behavior and structure; subclasses author only the rendering. This is the same mechanism `@expressive/router`'s [`NavLinks`](https://github.com/gabeklein/expressive-mvc/blob/main/packages/router/README.md#generated-navigation) exposes through its overridable `Item` / `List` / `Group` members.
 
 ### Self-providing context
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -39,7 +39,9 @@ function CounterWidget() {
 }
 ```
 
-When the state belongs to one rendered unit, extend `Component` and give it a `render`:
+## Component
+
+`Component` is a `State` that owns its own rendering - a persistent class instance with lifecycle, context, suspense, and error handling baked in. Reach for it when state is intrinsic to a rendered unit: form controls, layout shells, route controllers, media players.
 
 ```tsx
 import { Component } from '@expressive/react';
@@ -53,6 +55,65 @@ class Counter extends Component {
 
 <Counter />;
 ```
+
+Anything read through `this` in `render()` is reactive; the instance survives across renders, so refs, sockets, and Maps held on `this` persist. State fields also become optional JSX props (`<Counter count={5} />`).
+
+### Render composition
+
+When a subclass overrides `render()`, it **composes** with its base rather than replacing it - no `super.render()`. Each `render()` up the prototype chain wraps the one below, base-outermost, with the inner output arriving as `props.children`.
+
+```tsx
+class Frame extends Component {
+  render(props = {} as { children?: React.ReactNode }) {
+    return (
+      <section className="frame">
+        <header>Frame</header>
+        {props.children}
+      </section>
+    );
+  }
+}
+
+class Page extends Frame {
+  body = 'Hello';
+  render() {
+    return <p>{this.body}</p>;
+  }
+}
+
+// <Page /> -> <section class="frame"><header>Frame</header><p>Hello</p></section>
+```
+
+Every layer binds to the same live instance, so all read the same reactive `this`. A base that wraps must declare a `props` parameter and render `props.children` - a layer that ignores it silently drops everything below. (A base can also choose to *defer* to a subclass's render, e.g. a leaf `<a>` that's overridable; the base detects the subclass content by identity and returns it as-is.)
+
+### Subcomponents
+
+PascalCase members become their own reactive React components scoped to the live instance. They read the parent's reactive `this` directly - no props plumbing - yet each is an isolated component with its own hooks and boundary. Subclasses override them to customize pieces without touching behavior.
+
+```tsx
+abstract class Toggle extends Component {
+  active = false;
+  toggle = () => (this.active = !this.active);
+
+  Active() { return null; }       // subclasses fill these in
+  Inactive() { return null; }
+
+  render() {
+    return (
+      <div onClick={this.toggle}>
+        {this.active ? <this.Active /> : <this.Inactive />}
+      </div>
+    );
+  }
+}
+
+class DarkModeSwitch extends Toggle {
+  Active() { return <span>Dark</span>; }
+  Inactive() { return <span>Light</span>; }
+}
+```
+
+The base owns behavior and structure; subclasses author only the rendering. This is the same mechanism `@expressive/router`'s `NavLinks` exposes through its overridable `Item` / `List` / `Group` members.
 
 ## Shared state via context
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -93,7 +93,10 @@ PascalCase members become their own reactive React components scoped to the live
 ```tsx
 abstract class Toggle extends Component {
   active = false;
-  toggle = () => (this.active = !this.active);
+
+  toggle = () => {
+    this.active = !this.active;
+  };
 
   Active() { return null; }       // subclasses fill these in
   Inactive() { return null; }
@@ -113,7 +116,7 @@ class DarkModeSwitch extends Toggle {
 }
 ```
 
-The base owns behavior and structure; subclasses author only the rendering. This is the same mechanism `@expressive/router`'s [`NavLinks`](https://github.com/gabeklein/expressive-mvc/blob/main/packages/router/README.md#generated-navigation) exposes through its overridable `Item` / `List` / `Group` members.
+The base owns behavior and structure; subclasses author only the rendering. Override a subcomponent as a **method** when it takes no props, or as an **arrow field** when you want its props type inferred from the base - which is how `@expressive/router`'s [`NavLinks`](https://github.com/gabeklein/expressive-mvc/blob/main/packages/router/README.md#generated-navigation) exposes its overridable `Item` / `List` / `Group` members.
 
 ### Self-providing context
 
@@ -146,6 +149,45 @@ function Tab({ index, label }: { index: number; label: string }) {
 
 It works the same whether the consumer is part of the Component's own render or is passed in as `children` - both sit under the instance's context. A render-less `Component` still self-provides, which is what makes it useful purely as a context/boundary placement.
 
+### Props
+
+State fields become optional JSX props, **merged onto the instance every render** - passing `count={5}` is the same as assigning `this.count = 5`. Extra props beyond fields are read through a parameter on `render`:
+
+```tsx
+class Greeting extends Component {
+  name = 'World';                                  // -> optional `name` prop
+
+  render(props = {} as { loud?: boolean }) {       // extra render prop
+    return <h1>Hello {this.name}{props.loud && '!!!'}</h1>;
+  }
+}
+
+<Greeting name="React" loud />;
+```
+
+Every Component also accepts three special props:
+
+- **`is`** - callback handed the instance once, at creation.
+- **`ref`** - standard React ref; set after mount, cleared on unmount.
+- **`fallback`** - Suspense/error UI, overriding the instance's own.
+
+### Suspense
+
+A value that isn't ready yet suspends the render; `fallback` shows in the meantime.
+
+```tsx
+import { Component, set } from '@expressive/react';
+
+class Profile extends Component {
+  user = set<User>();              // undefined until set - suspends render
+  fallback = <Spinner />;
+
+  render() {
+    return <span>{this.user.name}</span>;
+  }
+}
+```
+
 ## Shared state via context
 
 Provide a model once; descendants read it with `State.get()` - no props, no selectors.
@@ -177,8 +219,7 @@ function Profile() {
 - **`State.get()`** - read shared state from context, no prop drilling.
 - **`Provider` / `Consumer`** - explicit hierarchical dependency injection.
 - **`Component`** - smart controls and shells whose behavior lives in the tree.
-- **Suspense** - async values and promises integrate with React Suspense.
-- **`@expressive/react/runtime`** - the host-agnostic runtime layer adapters build on.
+- **Suspense & error boundaries** - async values suspend; `catch()` handles child errors.
 
 Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,138 @@
+<h1 align="center">@expressive/router</h1>
+
+<p align="center">
+  Class-based declarative router built on Expressive MVC.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@expressive/router"><img alt="NPM" src="https://badge.fury.io/js/%40expressive%2Frouter.svg"></a>
+</p>
+
+---
+
+A host-agnostic router for [Expressive MVC](https://github.com/gabeklein/expressive-mvc). Routes are declared as nested JSX, matching is computed lexically from that tree (not a separate config), and navigation state lives on a reactive `Router` any component can read or drive.
+
+```bash
+npm install @expressive/router @expressive/react react
+```
+
+## Declaring routes
+
+Routes nest to mirror the URL. `to` is the pattern segment, `as` is the page (or layout) component. A layout receives its matched children via `children`.
+
+```tsx
+import '@expressive/react';           // registers the host adapter
+import { BrowserRouter, Route } from '@expressive/router';
+
+<BrowserRouter>
+  <Route as={RootLayout}>
+    <Route as={HomePage} />                {/* index - matches the parent path */}
+    <Route to="blog" as={BlogLayout}>
+      <Route as={BlogIndex} />             {/* /blog */}
+      <Route to=":slug" as={BlogPost} />   {/* /blog/:slug */}
+    </Route>
+    <Route to="login" redirect="/" />      {/* matched -> redirects */}
+    <Route default as={NotFound} />        {/* nothing else matched */}
+  </Route>
+</BrowserRouter>;
+```
+
+| Prop | Meaning |
+| --- | --- |
+| `to` | URL segment. `:name` captures a param, `*` is a catch-all. Omit for an index route. |
+| `as` | Component rendered when matched (as a layout, receives `children`). |
+| `default` | Matches when no sibling did - scoped to its parent (root = app 404, nested = section 404). |
+| `redirect` | When matched, redirect here instead of rendering. |
+| `label` / `meta` | Display name / free-form metadata for nav and breadcrumbs (ignored by matching). |
+
+Siblings competing for the same slot arbitrate **first-match by declaration order**. Without an ancestor `Router`, a `<Route>` spins up a headless in-memory one; `BrowserRouter` binds to the address bar.
+
+## Reading the match
+
+A page reads the nearest `Route` from context and uses its reactive getters:
+
+```tsx
+import { Consumer } from '@expressive/react';
+import { Route } from '@expressive/router';
+
+const BlogPost = () => (
+  <Consumer for={Route}>
+    {route => <article>post: {route.match!.slug}</article>}
+  </Consumer>
+);
+```
+
+Read `route.matched` (boolean) in render so same-pattern navigations (`/blog/a` → `/blog/b`) reconcile in place instead of remounting.
+
+## Navigation state & the `query` record
+
+`Router` exposes location as reactive surfaces - `path`, a `query` record, and a derived `url`. The query string **is state**: read a key to subscribe, write one to navigate.
+
+```tsx
+router.goto('/posts?page=2');   // push
+router.goto('/posts', true);    // replace
+router.url = '/posts?page=2';   // assigning url navigates
+
+router.query.page;              // read - subscribes to just this param
+router.query.page = '2';        // write - pushes a new entry, like goto
+delete router.query.sort;       // delete - also navigates
+```
+
+Subclass to declare known params for autocomplete and typo-safety:
+
+```tsx
+class Search extends Router {
+  declare query: { q?: string; page?: string };
+}
+```
+
+## Links
+
+`Link` renders an `<a>` that navigates on plain left-click (modifier/middle clicks fall through). It exposes its own match state, so active styling needs no separate component:
+
+```tsx
+import { Link } from '@expressive/router';
+
+<Link to="blog">Blog</Link>
+<Link to="/posts?page=2" replace>Page 2</Link>
+```
+
+```tsx
+// active links by subclassing - read `active` / `match`
+class NavLink extends Link {
+  render() {
+    return (
+      <a href={this.href} onClick={this.go}
+         className={this.active ? 'active' : undefined}
+         aria-current={this.active ? 'page' : undefined}>
+        {this.props.children}
+      </a>
+    );
+  }
+}
+```
+
+## Redirect & generated nav
+
+```tsx
+import { Redirect, NavLinks } from '@expressive/router';
+
+<Redirect to="/login" when={!user} />     {/* navigates on mount, gated by `when` */}
+
+// NavLinks renders a nav tree from the route hierarchy;
+// override Item / List / Group to control structure
+class SideNav extends NavLinks {
+  List = p => <ul className="side">{p.children}</ul>;
+  Group = p => <section><h3>{p.route.label}</h3>{p.children}</section>;
+}
+```
+
+---
+
+Routes are plain `@expressive/mvc` Components, so they render under any Expressive host adapter.
+
+Full guide and API reference → **[github.com/gabeklein/expressive-mvc](https://github.com/gabeklein/expressive-mvc)**
+
+## License
+
+MIT

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -49,20 +49,18 @@ Siblings competing for the same slot arbitrate **first-match by declaration orde
 
 ## Reading the match
 
-A page reads the nearest `Route` from context and uses its reactive getters:
+A page reads the nearest `Route` from context with `get()` and uses its reactive getters:
 
 ```tsx
-import { Consumer } from '@expressive/react';
 import { Route } from '@expressive/router';
 
-const BlogPost = () => (
-  <Consumer for={Route}>
-    {route => <article>post: {route.match!.slug}</article>}
-  </Consumer>
-);
+const BlogPost = () => {
+  const { match } = Route.get();      // nearest Route in context; subscribes
+  return <article>post: {match!.slug}</article>;
+};
 ```
 
-Read `route.matched` (boolean) in render so same-pattern navigations (`/blog/a` → `/blog/b`) reconcile in place instead of remounting.
+Read `matched` (boolean) in render so same-pattern navigations (`/blog/a` → `/blog/b`) reconcile in place instead of remounting.
 
 ## Navigation state & the `query` record
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -112,20 +112,42 @@ class NavLink extends Link {
 }
 ```
 
-## Redirect & generated nav
+## Redirect
+
+`Redirect` navigates to `to` when mounted, gated on `when` (default `true`), and renders nothing. The `Route` `redirect` prop is an always-replace shorthand for it.
 
 ```tsx
-import { Redirect, NavLinks } from '@expressive/router';
+import { Redirect } from '@expressive/router';
 
-<Redirect to="/login" when={!user} />     {/* navigates on mount, gated by `when` */}
+<Redirect to="/login" when={!user} />     {/* navigates on mount when `when` is true */}
+<Redirect to="/home" replace />           {/* overwrite the current entry */}
+```
 
-// NavLinks renders a nav tree from the route hierarchy;
-// override Item / List / Group to control structure
+## Generated navigation
+
+`NavLinks` renders a navigation tree from the route hierarchy - it walks the declared routes and emits links automatically. Its rendering is built from PascalCase **subcomponents** you override to shape the output:
+
+| Member | Renders |
+| --- | --- |
+| `Item` | A single link (defaults to a `Link` using the route's `label`). |
+| `List` | The container wrapping a level of items. |
+| `Group` | A nested section; transparent by default - override to turn route nesting into headed sections. |
+
+```tsx
+import { NavLinks } from '@expressive/router';
+
 class SideNav extends NavLinks {
-  List = p => <ul className="side">{p.children}</ul>;
-  Group = p => <section><h3>{p.route.label}</h3>{p.children}</section>;
+  List = (props) => <ul className="side">{props.children}</ul>;
+  Group = (props) => (
+    <section>
+      <h3>{props.route.label}</h3>
+      {props.children}
+    </section>
+  );
 }
 ```
+
+These members are overridable reactive subcomponents bound to the live instance - the same render/subcomponent model `Component` provides (see **Component → Subcomponents** in [`@expressive/react`](https://www.npmjs.com/package/@expressive/react)).
 
 ---
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -147,7 +147,7 @@ class SideNav extends NavLinks {
 }
 ```
 
-These members are overridable reactive subcomponents bound to the live instance - the same render/subcomponent model `Component` provides (see **Component → Subcomponents** in [`@expressive/react`](https://www.npmjs.com/package/@expressive/react)).
+These members are overridable reactive subcomponents bound to the live instance - the same model `Component` provides, via [render composition](https://github.com/gabeklein/expressive-mvc/blob/main/packages/react/README.md#render-composition) and [subcomponents](https://github.com/gabeklein/expressive-mvc/blob/main/packages/react/README.md#subcomponents).
 
 ---
 


### PR DESCRIPTION
Each package currently renders a blank "no readme" panel on npm. Adds a tasteful, at-a-glance README to each package ahead of the release - intro, install, one example, and a short feature sampling. Depth is deferred to the repo / docs site.

- **mvc** - framework-agnostic core (`State`, agnostic `Component`, JSX runtime).
- **react** - React adapter (`State.use`, `Component`, context, Suspense, `/runtime`).
- **router** - first release; declarative `<Route>` trees, reactive `Router`/`query`, `Link`.
- **preact** - mirrors the React adapter; marked internal/unpublished.

npm always bundles `README.md` regardless of the `files` field, so no packaging changes were needed. Intended to merge before the version PR (#155) so the first publish ships with READMEs.