### PR TITLE
fix(router): keep overridden render() valid as JSX in built packages

### DIFF
--- a/.changeset/router-render-emit.md
+++ b/.changeset/router-render-emit.md
@@ -1,0 +1,12 @@
+---
+"@expressive/mvc": patch
+"@expressive/router": minor
+---
+
+fix: keep overridden `render` valid as JSX when consuming built packages
+
+When `@expressive/router` was consumed as a built package (outside the monorepo), `<Route>`, `<Link>`, and `<NavLinks>` failed type-checking as JSX (`TS2786`). Their `render` overrides had no explicit return type, so the `.d.ts` emitter baked the host-seam alias's build-time fallback (`unknown`) into the published types, which is not assignable to `ReactNode`.
+
+Two changes fix this:
+- `@expressive/router`: the overridden `render` methods are annotated `: Component.Node`, so the emitter preserves the deferred alias by reference and it re-resolves to the host node type (e.g. `ReactNode`) in a consumer.
+- `@expressive/mvc`: `Component.Node` now falls back to `any` instead of `unknown`. `any` is the only fallback assignable to every host's node type, so an un-annotated `render` override in any host-agnostic package still emits a JSX-valid return.

--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -25,10 +25,13 @@ type Acceptable<T> = {
 declare namespace Component {
   /**
    * Host element type produced by `Component.render`. Delegates to the
-   * {@link Host} manifest on the jsx-runtime entry; resolves to `unknown`
-   * until an adapter augments it with `node`.
+   * {@link Host} manifest on the jsx-runtime entry; falls back to `any`
+   * until an adapter augments it with `node`. `any` (not `unknown`) so an
+   * un-annotated `render` override in a host-agnostic package still emits a
+   * JSX-valid return - `any` is assignable to every host's node type, where
+   * `unknown` is assignable to none.
    */
-  type Node = Host extends { node: infer T } ? T : unknown;
+  type Node = Host extends { node: infer T } ? T : any;
 
   interface BaseProps<T extends Component> {
     /**

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -64,7 +64,7 @@ export class Link extends Component {
   /**
    * If a subclass authores own render, it will override default anchor wrapping.
    */
-  render({ children, to, replace, ...rest } = {} as Link.Props) {
+  render({ children, to, replace, ...rest } = {} as Link.Props): Component.Node {
     if (children !== this.props.children) return children;
 
     return (

--- a/packages/router/src/nav.tsx
+++ b/packages/router/src/nav.tsx
@@ -29,7 +29,7 @@ export class NavLinks extends Component {
     return props.children;
   }
 
-  render() {
+  render(): Component.Node {
     return this.branch(this.route.inner);
   }
 

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -158,7 +158,7 @@ export class Route extends Component {
     this.router.goto(this.resolve(url), replace);
   }
 
-  render(props = {} as { children?: Component.Node }) {
+  render(props = {} as { children?: Component.Node }): Component.Node {
     const self = this.is;
     const { parent, as: Component, matched } = this;
 

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -148,6 +148,12 @@ Both `match`/`active` are **lazy**: a `Link` whose render reads neither stays in
 
 There is no `NavLink` - extend `Link` and read `active`/`match` to express activeness however the host wants (a `className` on web, a `style` on native). A subclass that authors its own `render` **fully replaces** the base anchor rather than nesting inside it (see render composition in the Component skill): the base detects subclass-authored content and defers. `route` and `go` are `protected` so the subclass can wire its own anchor.
 
+> **Gotcha - annotate overridden `render` in agnostic packages.** When a host-agnostic package (router, or any package built against `@expressive/mvc` with no adapter in scope) ships its own `.d.ts`, give every overridden `render` an explicit `: Component.Node` return type:
+> ```tsx
+> render(props = {} as { children?: Component.Node }): Component.Node { ... }
+> ```
+> `Component.Node` is a deferred alias over the host seam - it resolves to the host's node type (e.g. `ReactNode`) only once an adapter augments `Host`. With no annotation, the `.d.ts` emitter resolves the alias at *build* time (no adapter present) and bakes the literal fallback into the published types; it never re-resolves in a consumer, so `<NavLink>` fails JSX validity. The explicit annotation makes the emitter preserve the alias *by reference* so it re-resolves per consumer. This never surfaces inside the monorepo, where path mapping reads source and re-infers - only against the built package.
+
 ```tsx
 class NavLink extends Link {
   render() {


### PR DESCRIPTION
Closes #165.

## Problem

Consumed as a **built package** (outside the monorepo), `<Route>`, `<Link>`, and `<NavLinks>` failed type-checking as JSX (`TS2786` — `'unknown' is not assignable to 'ReactNode'`). `<BrowserRouter>` and other non-render-overriding components worked.

The host seam in `@expressive/mvc` is a deferred alias: `type Node = Host extends { node: infer T } ? T : <fallback>`, which re-resolves to `ReactNode` once `@expressive/react` augments `Host`. The router's `render` overrides had **no explicit return type**, so at router build time (no adapter in scope) the `.d.ts` emitter resolved the alias to its fallback and **baked the literal `unknown`** into the published types — frozen, never re-resolving in a consumer. It didn't reproduce inside the monorepo because `examples/tsconfig.json` path-maps `@expressive/*` to `src` and re-infers `render` in the consumer's host context.

## Fix

- **`@expressive/router`**: annotate the overridden `render` methods (`Route`, `Link`, `NavLinks`) with `: Component.Node`. TS preserves an *explicit annotation* by reference, so the emitted `.d.ts` keeps the deferred alias and it re-resolves to the host node type per consumer.
- **`@expressive/mvc`**: change the `Component.Node` fallback from `unknown` to `any`. The alias spans two contradictory position kinds — opaque host-element objects (`jsx`/`childrenOf` returns, which need the type to *contain* arbitrary objects) and render output (which must be *assignable to* `ReactNode`). No ordinary type or union satisfies both; `any` is uniquely both super- and sub-type of everything, so it also gives un-annotated agnostic `render` overrides a JSX-valid floor for free. (`unknown` is assignable to no host node; `null`/`{}`/unions each break one side — verified exhaustively.)
- **docs**: note the annotation requirement in the router skill so future agnostic-package overrides don't reintroduce this.

## Verification

- `bun run build` + full suite green: mvc 501, react 208, router 165.
- Built `dist/index.d.ts` now emits `render(): Component.Node` for `Route`/`Link`/`NavLinks` (re-resolving), `render(): null` for `Redirect`; no `unknown` baked.

## Note

This escaped because nothing type-checks the **built** `.d.ts` against a real host — the monorepo path-maps to `src`. A CI step that type-checks an external-style consumer against the emitted types (or an in-memory TS-compiler-API emit assertion) would catch this class pre-publish. Left out per discussion; easy follow-up if wanted.