### PR TITLE
fix(react): preserve adapter side-effect modules in the published build

### DIFF
--- a/.changeset/react-sideeffects-dist.md
+++ b/.changeset/react-sideeffects-dist.md
@@ -1,0 +1,24 @@
+---
+"@expressive/react": patch
+---
+
+fix: preserve adapter side-effect modules in the published build
+
+`@expressive/react`'s `sideEffects` field listed only `jsx-runtime.ts`, so the
+bundler treated the other side-effect-only imports in `adapter.ts`
+(`state.get.ts`, `state.use.ts`, `component.ts`) as dead and dropped them from
+the emitted dist.
+
+The most visible casualty was `component.ts`, which installs the `context`
+property setter (`bootstrap`) on `Component.prototype`. When React instantiates
+an mvc Component as a class and assigns `this.context`, that setter is what
+activates state - resolving `set()` field instructions into reactive getters and
+swapping in the adapter's reactive render wrapper. Missing from dist, the
+assignment was a no-op: state never activated, `set()` fields stayed as raw
+`Symbol(field-…)` instructions, and React called `render` on the bare instance
+(e.g. `this.router.segment is not a function`). `State.get` / `State.use` were
+also silently absent from the published build.
+
+This only affected consumers of the published packages; the examples alias to
+`src`, where the imports always execute. Adding the three modules to
+`sideEffects` keeps them in the build.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,10 @@
   "sideEffects": [
     "./dist/index.js",
     "./dist/adapter.js",
-    "./src/jsx-runtime.ts"
+    "./src/jsx-runtime.ts",
+    "./src/state.get.ts",
+    "./src/state.use.ts",
+    "./src/component.ts"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

A consumer of the **published** `@expressive/react` dist crashed at render with `this.router.segment is not a function` — an mvc Component's `set()` field was left as a raw `Symbol(field-…)` instead of a resolved reactive getter, and `render` ran on the bare class instance with no adapter wrapper.

## Root cause

`src/adapter.ts` pulls in three modules purely for their side effects:

```ts
import './state.get';   // installs State.get
import './state.use';   // installs State.use
import './component';    // installs the `context` setter (bootstrap) + Component.on
```

But `package.json`'s `sideEffects` array listed only `./src/jsx-runtime.ts`. The bundler therefore treated all three as side-effect-free (they have no consumed exports) and **dropped them from the emitted dist**.

The visible casualty was `component.ts`, which installs the `context` property setter (`bootstrap`) on `Component.prototype`. When React instantiates an mvc Component as a class and assigns `this.context`, that setter activates state — resolving `set()` fields into reactive getters and swapping in the adapter's reactive render wrapper. Absent from dist, the assignment was a no-op: state never activated and `render` ran raw. `State.get` / `State.use` were also silently missing from the published build.

Source-based consumers (the examples alias `@expressive/*` to `src`) always execute these imports, so this was invisible in-repo — the same src-vs-dist gap as the prior published-build fixes.

## Fix

Add the three side-effecting modules to `sideEffects` so the bundler keeps them.

## Verification

- Reproduced against the built dist with a minimal Component using a `set()` field (`segment is not a function`); confirmed fixed after rebuild (renders correctly).
- A test importing the **built dist** failed pre-fix with the exact error and passes post-fix.
- Full suite green across all packages (`bun run test`).