### PR TITLE
fix(router): detect Route subclasses in lexical JSX walk

### DIFF
--- a/.changeset/route-subclass-lexical-detection.md
+++ b/.changeset/route-subclass-lexical-detection.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": patch
+---
+
+Route subclasses are now detected by the lexical JSX walk wherever a plain `Route` is. Previously only `allRoutes` recognized subclasses; the default-detection, see-through-scope, and `as`-slot arbitration walks used a strict `=== Route` identity check and silently skipped subclasses. All four sites now share the subclass-aware `Route.is(...)` test, so a `class Page extends Route` used with JSX props participates in default resolution, scope chrome visibility, and sibling arbitration like any `Route`. (Class-field `to` remains invisible to the lexical walk - unchanged.)

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -598,6 +598,58 @@ describe('extends', () => {
     expect(found).toBeInstanceOf(Profile);
   });
 
+  it('see-through scope chrome shows only when a subclass descendant matches', () => {
+    class Page extends Route {}
+    const Chrome = ({ children }: { children?: React.ReactNode }) => (
+      <div>chrome:{children}</div>
+    );
+
+    location('/section/info');
+    const matched = render(
+      <Route>
+        <Route to="section/*" as={Chrome}>
+          <Page to="info" as={() => <span>info</span>} />
+        </Route>
+      </Route>
+    );
+    expect(matched.container.textContent).toBe('chrome:info');
+
+    location('/elsewhere');
+    const unmatched = render(
+      <Route>
+        <Route to="section/*" as={Chrome}>
+          <Page to="info" as={() => <span>info</span>} />
+        </Route>
+      </Route>
+    );
+    expect(unmatched.container.textContent).toBe('');
+  });
+
+  it('see-through scope resolves via a subclass default child', () => {
+    class Fallback extends Route {}
+    location('/section/anything');
+    const view = render(
+      <Route>
+        <Route to="section/*">
+          <Fallback default as={() => <span>fallback</span>} />
+        </Route>
+      </Route>
+    );
+    expect(view.container.textContent).toBe('fallback');
+  });
+
+  it('arbitrates the `as`-slot between subclass siblings by declaration order', () => {
+    class Page extends Route {}
+    location('/about');
+    const view = render(
+      <Route>
+        <Page to="/about" as={() => <span>About</span>} />
+        <Page to="/:slug" as={() => <span>Slug</span>} />
+      </Route>
+    );
+    expect(view.container.textContent).toBe('About');
+  });
+
   describe('structural children', () => {
     it('mounts child Routes even when the parent is unmatched', () => {
       location('/elsewhere');

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -192,7 +192,7 @@ export class Route extends Component {
 /** Does `children` hold a direct default Route? Such a scope resolves to it. */
 function hasDefault(children: Component.Node): boolean {
   return childrenOf(children).some(
-    (node) => isElement(node) && typeOf(node) === Route && (propsOf(node) as RouteProps).default
+    (node) => isElement(node) && Route.is(typeOf(node)) && (propsOf(node) as RouteProps).default
   );
 }
 
@@ -245,7 +245,7 @@ type RouteProps = {
  * Does any Route within `children` match `path` (composed against `base`)? A
  * synchronous, lexical walk of the JSX - the see-through opt-out gate. Strict:
  * a scope counts only when a descendant matches, never as a greedy prefix.
- * Blind to class-field `to` (subclasses) and component-internal routes (the
+ * Blind to class-field `to` and component-internal routes (the
  * `*`-delegation case) - the documented limits of the lexical model.
  */
 export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
@@ -259,7 +259,7 @@ export function matchesAnywhere(children: Component.Node, base: string, path: st
       continue;
     }
 
-    if (type !== Route) continue;
+    if (!Route.is(type)) continue;
 
     const props = propsOf(node) as RouteProps;
     if (props.redirect || props.default) continue;
@@ -322,7 +322,7 @@ function contenders(children: Component.Node, base: string): Contender[] {
       continue;
     }
 
-    if (type !== Route) continue;
+    if (!Route.is(type)) continue;
 
     const props = propsOf(node) as RouteProps;
     if (!props.as || props.redirect || props.default) continue;
@@ -346,7 +346,7 @@ function allRoutes(children: Component.Node): boolean {
     const type = typeOf(node);
     if (type === Fragment)
       return allRoutes((propsOf(node) as RouteProps).children);
-    return type === Route || (typeof type === 'function' && type.prototype instanceof Route);
+    return Route.is(type);
   });
 }
 


### PR DESCRIPTION
## Problem

`Route` subclasses were not consistently recognized by the router's lexical JSX walk. Of the four detection sites in `route.tsx`, only `allRoutes` was subclass-aware; the other three used a strict `=== Route` identity check and silently skipped any `class Page extends Route`:

- `hasDefault` (default-child detection)
- `matchesAnywhere` (see-through scope resolution / `as`-chrome visibility)
- `contenders` (`as`-slot arbitration by declaration order)

So a Route subclass used with JSX props (`to` / `default` / `as`) wouldn't participate in default resolution, scope chrome visibility, or sibling arbitration the way a plain `<Route>` does.

## Fix

All four sites now share the existing subclass-aware `Route.is(...)` (inherited from `State.is`), which checks identity-or-`prototype instanceof`. No new public surface; `allRoutes`'s hand-rolled check is de-duped onto `Route.is`.

The lexical walk still cannot see a subclass's **class-field** `to` (it reads JSX props only) - that documented limitation is unchanged, and the `matchesAnywhere` doc comment was narrowed to reflect it.

## Tests

Three tests added under `extends`, each isolating one fixed site (verified to fail before the change):

- `see-through scope resolves via a subclass default child` → `hasDefault`
- `see-through scope chrome shows only when a subclass descendant matches` → `matchesAnywhere`
- `arbitrates the as-slot between subclass siblings by declaration order` → `contenders`

`route.tsx` stays at 100% coverage; full suite green across all packages.