### PR TITLE
feat(router): protected nested getter seam for subclass child injection

### DIFF
--- a/.changeset/router-nested-seam.md
+++ b/.changeset/router-nested-seam.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+Add a `protected get nested` extension point to `Route`. It defaults to the children declared in JSX; a subclass overrides the getter to opine on the child routes of its own scope - add, remove, or reorder - composing on `super.nested`. The result flows through every registration-form behavior (`inner`, `active`, `matches`, default gating) and the see-through gate for that scope, so contributed routes participate in matching and render as if declared. Because `nested` is pure analysis (it returns nodes and never triggers a page render), `matched` can consult it without breaking the lazy render gate. A subclass that contributes routes can flip its own leaf<->see-through classification, reflecting its effective children.

--- a/.changeset/router-routes-seam.md
+++ b/.changeset/router-routes-seam.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+Add a `protected routes()` extension point to `Route`. Subclasses override it to opine on the child routes of their own scope - add, remove, or reorder - returning JSX nodes that flow through every registration-form behavior (`inner`, `active`, `matches`, default gating) and the see-through gate for that scope. The default implementation passes children through unchanged, so plain `Route` behavior is unaffected. Because `routes()` is pure analysis (it returns nodes and never triggers a page render), `matched` can consult it without breaking the lazy render gate. A subclass that contributes routes can flip its own leaf<->see-through classification, reflecting its effective children.

--- a/.changeset/router-routes-seam.md
+++ b/.changeset/router-routes-seam.md
@@ -1,5 +1,0 @@
----
-"@expressive/router": minor
----
-
-Add a `protected routes()` extension point to `Route`. Subclasses override it to opine on the child routes of their own scope - add, remove, or reorder - returning JSX nodes that flow through every registration-form behavior (`inner`, `active`, `matches`, default gating) and the see-through gate for that scope. The default implementation passes children through unchanged, so plain `Route` behavior is unaffected. Because `routes()` is pure analysis (it returns nodes and never triggers a page render), `matched` can consult it without breaking the lazy render gate. A subclass that contributes routes can flip its own leaf<->see-through classification, reflecting its effective children.

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react';
 import { describe, expect, it } from 'bun:test';
-import { Consumer } from '@expressive/react';
+import { Component, Consumer } from '@expressive/react';
 
 import { location, browserRouter, renderAct } from '../test.setup';
 import { Route } from './route';
@@ -648,6 +648,83 @@ describe('extends', () => {
       </Route>
     );
     expect(view.container.textContent).toBe('About');
+  });
+
+  describe('routes() seam', () => {
+    class Page extends Route {
+      Default: () => any = () => <span>fallback</span>;
+      protected routes(given: Component.Node): Component.Node {
+        return (<>{given}<Route default as={this.Default} /></>) as any;
+      }
+    }
+
+    it('converts a subclass Default into a child default route', () => {
+      location('/section/missing');
+      const view = render(
+        <Route>
+          <Page to="section/*">
+            <Route to="info" as={() => <span>info</span>} />
+          </Page>
+        </Route>
+      );
+      expect(view.container.textContent).toBe('fallback');
+    });
+
+    it('lets a real sibling match win over the injected default', () => {
+      location('/section/info');
+      const view = render(
+        <Route>
+          <Page to="section/*">
+            <Route to="info" as={() => <span>info</span>} />
+          </Page>
+        </Route>
+      );
+      expect(view.container.textContent).toBe('info');
+    });
+
+    it('reclassifies a leaf as a see-through scope when only a default is contributed', () => {
+      location('/section/anything');
+      const view = render(
+        <Route>
+          <Page to="section/*" />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('fallback');
+    });
+
+    it('contributed default suppresses an ancestor default (section 404)', () => {
+      location('/section/missing');
+      const view = render(
+        <Route>
+          <Page to="section/*">
+            <Route to="info" as={() => <span>info</span>} />
+          </Page>
+          <Route default as={() => <span>app-404</span>} />
+        </Route>
+      );
+      expect(view.container.textContent).toBe('fallback');
+    });
+
+    it('does not run subclass content when unmatched', () => {
+      let ran = 0;
+      class Tracked extends Route {
+        protected routes(given: Component.Node): Component.Node {
+          return (
+            <>{given}<Route default as={() => { ran++; return <span>x</span>; }} /></>
+          ) as any;
+        }
+      }
+      location('/elsewhere');
+      const view = render(
+        <Route>
+          <Tracked to="section/*">
+            <Route to="info" as={() => <span>info</span>} />
+          </Tracked>
+        </Route>
+      );
+      expect(view.container.textContent).toBe('');
+      expect(ran).toBe(0);
+    });
   });
 
   describe('structural children', () => {

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -650,11 +650,11 @@ describe('extends', () => {
     expect(view.container.textContent).toBe('About');
   });
 
-  describe('routes() seam', () => {
+  describe('nested seam', () => {
     class Page extends Route {
       Default: () => any = () => <span>fallback</span>;
-      protected routes(given: Component.Node): Component.Node {
-        return (<>{given}<Route default as={this.Default} /></>) as any;
+      protected get nested(): Component.Node {
+        return (<>{super.nested}<Route default as={this.Default} /></>) as any;
       }
     }
 
@@ -708,9 +708,9 @@ describe('extends', () => {
     it('does not run subclass content when unmatched', () => {
       let ran = 0;
       class Tracked extends Route {
-        protected routes(given: Component.Node): Component.Node {
+        protected get nested(): Component.Node {
           return (
-            <>{given}<Route default as={() => { ran++; return <span>x</span>; }} /></>
+            <>{super.nested}<Route default as={() => { ran++; return <span>x</span>; }} /></>
           ) as any;
         }
       }

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -77,7 +77,7 @@ export class Route extends Component {
 
     if (isRoot(this)) return true;
 
-    const children = this.effective();
+    const children = effective(this);
 
     if (allRoutes(children))
       return scopeResolves(this, children, this.router.path);
@@ -101,7 +101,7 @@ export class Route extends Component {
     const scan = (routes: Route[]): boolean => {
       for (const route of routes) {
         if (route.redirect || route.default) continue;
-        if (allRoutes(route.effective())) {
+        if (allRoutes(effective(route))) {
           if (scan(route.inner)) return true;
           continue;
         }
@@ -124,7 +124,7 @@ export class Route extends Component {
     const collect = (routes: Route[]): string[] =>
       routes.flatMap((route) => {
         if (route.redirect || route.default) return [];
-        if (!allRoutes(route.effective()))
+        if (!allRoutes(effective(route)))
           return match(route.base, route.to) ? [route.path] : [];
 
         // A scope counts via a matched descendant, or its own section default.
@@ -165,19 +165,6 @@ export class Route extends Component {
     return children;
   }
 
-  private effective(): Component.Node {
-    const self = this.is;
-    const given = (this.props as { children?: Component.Node }).children;
-    const memo = ROUTES.get(self);
-
-    if (memo && memo.given === given)
-      return memo.out;
-
-    const out = this.routes(given);
-    ROUTES.set(self, { given, out });
-    return out;
-  }
-
   resolve(url: string): string {
     return this.router.resolve(this, url);
   }
@@ -207,7 +194,7 @@ export class Route extends Component {
     if (Object.getOwnPropertyDescriptor(props, 'children')?.get)
       return matched ? props.children : null;
 
-    const children = this.effective();
+    const children = effective(this);
 
     // Matched: render content (in `as` chrome if present). Unmatched: a
     // see-through scope still mounts children (registration); a leaf renders null.
@@ -218,15 +205,52 @@ export class Route extends Component {
   }
 }
 
+/**
+ * This scope's effective children - `route.routes()` applied to the declared
+ * children, memoized by input identity (keyed on the real instance, mirroring
+ * the `match` getter so observer proxies share one entry).
+ */
+function effective(route: Route): Component.Node {
+  const self = route.is;
+  const given = (route.props as { children?: Component.Node }).children;
+  const memo = ROUTES.get(self);
+
+  if (memo && memo.given === given)
+    return memo.out;
+
+  const out = route['routes'](given);
+  ROUTES.set(self, { given, out });
+  return out;
+}
+
+/**
+ * Route nodes declared directly within `children`, Fragments flattened (same
+ * base) and non-Route nodes skipped, each paired with its `to` segment. The
+ * shared lexical-walk primitive behind the see-through gate and `as`-arbitration.
+ */
+function lexicalRoutes(children: Component.Node) {
+  const out: { props: RouteProps; to: string }[] = [];
+
+  for (const node of childrenOf(children)) {
+    if (!isElement(node)) continue;
+
+    const type = typeOf(node);
+    if (type === Fragment) {
+      out.push(...lexicalRoutes((propsOf(node) as RouteProps).children));
+      continue;
+    }
+    if (!Route.is(type)) continue;
+
+    const props = propsOf(node) as RouteProps;
+    out.push({ props, to: typeof props.to === 'string' ? props.to : '' });
+  }
+
+  return out;
+}
+
 /** Does `children` hold a direct default Route? Such a scope resolves to it. */
 function hasDefault(children: Component.Node): boolean {
-  return childrenOf(children).some((node) => {
-    if (!isElement(node)) return false;
-    const type = typeOf(node);
-    if (type === Fragment)
-      return hasDefault((propsOf(node) as RouteProps).children);
-    return Route.is(type) && (propsOf(node) as RouteProps).default;
-  });
+  return lexicalRoutes(children).some(({ props }) => props.default);
 }
 
 /** Is `path` inside `base`'s subtree? The root base ('') contains everything. */
@@ -277,32 +301,12 @@ type RouteProps = {
  * `*`-delegation case) - the documented limits of the lexical model.
  */
 export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
-  for (const node of childrenOf(children)) {
-    if (!isElement(node)) continue;
-
-    const type = typeOf(node);
-
-    if (type === Fragment) {
-      if (matchesAnywhere((propsOf(node) as RouteProps).children, base, path)) return true;
-      continue;
-    }
-
-    if (!Route.is(type)) continue;
-
-    const props = propsOf(node) as RouteProps;
-    if (props.redirect || props.default) continue;
-
-    const to = typeof props.to === 'string' ? props.to : '';
-
-    if (allRoutes(props.children)) {
-      if (matchesAnywhere(props.children, base + patternSegment(to), path)) return true;
-      continue;
-    }
-
-    if (matchPattern(fullPattern(base, to), path)) return true;
-  }
-
-  return false;
+  return lexicalRoutes(children).some(({ props, to }) => {
+    if (props.redirect || props.default) return false;
+    if (allRoutes(props.children))
+      return matchesAnywhere(props.children, base + patternSegment(to), path);
+    return matchPattern(fullPattern(base, to), path) !== null;
+  });
 }
 
 type Contender = {
@@ -321,7 +325,7 @@ function cedes(parent: Route, child: Route, path: () => string): boolean {
   // Fallback/redirect never competes by order, so it's never arbitrated.
   if (child.default || child.redirect) return false;
 
-  const rivals = contenders(parent.props.children, scopeBase(parent));
+  const rivals = possible(parent.props.children, scopeBase(parent));
   if (rivals.length < 2 || !rivals.some((r) => r.path === child.path)) return false;
 
   const at = path();
@@ -337,33 +341,15 @@ function cedes(parent: Route, child: Route, path: () => string): boolean {
  * declaration order, each paired with its claimed path and a match test.
  * Recurses Fragments, stops at nested Route scopes. Lexical only (reads `to`).
  */
-function contenders(children: Component.Node, base: string): Contender[] {
-  const out: Contender[] = [];
-
-  for (const node of childrenOf(children)) {
-    if (!isElement(node)) continue;
-
-    const type = typeOf(node);
-
-    if (type === Fragment) {
-      out.push(...contenders((propsOf(node) as RouteProps).children, base));
-      continue;
-    }
-
-    if (!Route.is(type)) continue;
-
-    const props = propsOf(node) as RouteProps;
-    if (!props.as || props.redirect || props.default) continue;
-
-    const to = typeof props.to === 'string' ? props.to : '';
-    const matches = allRoutes(props.children)
-      ? (path: string) => matchesAnywhere(props.children, base + patternSegment(to), path)
-      : (path: string) => matchPattern(fullPattern(base, to), path) !== null;
-
-    out.push({ path: base + patternSegment(to), matches });
-  }
-
-  return out;
+function possible(children: Component.Node, base: string): Contender[] {
+  return lexicalRoutes(children)
+    .filter(({ props }) => props.as && !props.redirect && !props.default)
+    .map(({ props, to }) => ({
+      path: base + patternSegment(to),
+      matches: allRoutes(props.children)
+        ? (path: string) => matchesAnywhere(props.children, base + patternSegment(to), path)
+        : (path: string) => matchPattern(fullPattern(base, to), path) !== null,
+    }));
 }
 
 function allRoutes(children: Component.Node): boolean {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -154,21 +154,16 @@ export class Route extends Component {
   }
 
   /**
-   * Opine on this scope's child routes before matching and registration.
-   * Receives the children as declared via JSX; return the effective set - add,
-   * remove, or reorder. Default passes through. Consulted by both matching and
-   * render, so contributed routes participate in this scope's control flow as
-   * if declared.
+   * This scope's child routes - the effective set matching and render consult.
+   * Defaults to the children declared via JSX. Override this getter (a subclass
+   * extension seam) to opine on them - add, remove, or reorder - composing on
+   * `super.nested`; both matching and render read the result, so contributed
+   * routes participate in this scope's control flow as if declared. Memoized by
+   * the framework (recomputes when `props` change), so contributed routes have
+   * stable identity within a render pass.
    */
-  protected routes(children: Component.Node): Component.Node {
-    return children;
-  }
-
-  /** This scope's children with `routes()` applied - the effective set matching
-   * and render consult. Memoized by the framework (recomputes when `props`
-   * change), so contributed routes have stable identity within a render pass. */
   protected get nested(): Component.Node {
-    return this.routes((this.props as { children?: Component.Node }).children);
+    return (this.props as { children?: Component.Node }).children;
   }
 
   resolve(url: string): string {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -7,6 +7,7 @@ import { fullPattern, matchPattern, patternSegment } from './url';
 
 const PARAMS = new WeakMap<Route, Record<string, string> | undefined>();
 const CHILDREN = new WeakMap<Route, Route[]>();
+const ROUTES = new WeakMap<Route, { given: Component.Node; out: Component.Node }>();
 
 export class Route extends Component {
   router = set(() => this.get(Router, false) || new Router());
@@ -75,7 +76,11 @@ export class Route extends Component {
       return parent ? parent.matched && !parent.matches.length : false;
 
     if (isRoot(this)) return true;
-    if (hasRoutes(this)) return scopeResolves(this, this.router.path);
+
+    const children = this.effective();
+
+    if (allRoutes(children))
+      return scopeResolves(this, children, this.router.path);
 
     return !!this.match;
   }
@@ -96,7 +101,7 @@ export class Route extends Component {
     const scan = (routes: Route[]): boolean => {
       for (const route of routes) {
         if (route.redirect || route.default) continue;
-        if (hasRoutes(route)) {
+        if (allRoutes(route.effective())) {
           if (scan(route.inner)) return true;
           continue;
         }
@@ -119,7 +124,7 @@ export class Route extends Component {
     const collect = (routes: Route[]): string[] =>
       routes.flatMap((route) => {
         if (route.redirect || route.default) return [];
-        if (!hasRoutes(route))
+        if (!allRoutes(route.effective()))
           return match(route.base, route.to) ? [route.path] : [];
 
         // A scope counts via a matched descendant, or its own section default.
@@ -147,6 +152,30 @@ export class Route extends Component {
   /** Directory-style anchor for relative navigation. */
   get anchor(): string {
     return this.router.anchor(this);
+  }
+
+  /**
+   * Opine on this scope's child routes before matching and registration.
+   * Receives the children as declared via JSX; return the effective set - add,
+   * remove, or reorder. Default passes through. Consulted by both matching and
+   * render, so contributed routes participate in this scope's control flow as
+   * if declared.
+   */
+  protected routes(children: Component.Node): Component.Node {
+    return children;
+  }
+
+  private effective(): Component.Node {
+    const self = this.is;
+    const given = (this.props as { children?: Component.Node }).children;
+    const memo = ROUTES.get(self);
+
+    if (memo && memo.given === given)
+      return memo.out;
+
+    const out = this.routes(given);
+    ROUTES.set(self, { given, out });
+    return out;
   }
 
   resolve(url: string): string {
@@ -178,7 +207,7 @@ export class Route extends Component {
     if (Object.getOwnPropertyDescriptor(props, 'children')?.get)
       return matched ? props.children : null;
 
-    const { children } = props;
+    const children = this.effective();
 
     // Matched: render content (in `as` chrome if present). Unmatched: a
     // see-through scope still mounts children (registration); a leaf renders null.
@@ -191,9 +220,13 @@ export class Route extends Component {
 
 /** Does `children` hold a direct default Route? Such a scope resolves to it. */
 function hasDefault(children: Component.Node): boolean {
-  return childrenOf(children).some(
-    (node) => isElement(node) && Route.is(typeOf(node)) && (propsOf(node) as RouteProps).default
-  );
+  return childrenOf(children).some((node) => {
+    if (!isElement(node)) return false;
+    const type = typeOf(node);
+    if (type === Fragment)
+      return hasDefault((propsOf(node) as RouteProps).children);
+    return Route.is(type) && (propsOf(node) as RouteProps).default;
+  });
 }
 
 /** Is `path` inside `base`'s subtree? The root base ('') contains everything. */
@@ -216,21 +249,16 @@ function scopeBase(route: Route): string {
 
 /** Lexical (gate-form): scope resolves via a descendant match or its own
  * section default within base - used by `matched`, before children register. */
-function scopeResolves(route: Route, path: string): boolean {
+function scopeResolves(route: Route, children: Component.Node, path: string): boolean {
   const base = scopeBase(route);
-  return matchesAnywhere(route.props.children, base, path)
-    || (hasDefault(route.props.children) && within(base, path));
+  return matchesAnywhere(children, base, path)
+    || (hasDefault(children) && within(base, path));
 }
 
 /** Registration-form: scope owns a default catching the path within base -
  * used by `matches` so a section 404 suppresses an ancestor 404. */
 function defaultCatches(route: Route, path: string): boolean {
   return route.inner.some((c) => c.default) && within(scopeBase(route), path);
-}
-
-/** Has lexical child Routes - i.e. a see-through scope (vs. a leaf). */
-function hasRoutes(route: Route): boolean {
-  return allRoutes(route.props.children);
 }
 
 type RouteProps = {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -7,7 +7,6 @@ import { fullPattern, matchPattern, patternSegment } from './url';
 
 const PARAMS = new WeakMap<Route, Record<string, string> | undefined>();
 const CHILDREN = new WeakMap<Route, Route[]>();
-const ROUTES = new WeakMap<Route, { given: Component.Node; out: Component.Node }>();
 
 export class Route extends Component {
   router = set(() => this.get(Router, false) || new Router());
@@ -77,10 +76,10 @@ export class Route extends Component {
 
     if (isRoot(this)) return true;
 
-    const children = effective(this);
+    const { nested } = this;
 
-    if (allRoutes(children))
-      return scopeResolves(this, children, this.router.path);
+    if (allRoutes(nested))
+      return scopeResolves(this, nested, this.router.path);
 
     return !!this.match;
   }
@@ -101,7 +100,7 @@ export class Route extends Component {
     const scan = (routes: Route[]): boolean => {
       for (const route of routes) {
         if (route.redirect || route.default) continue;
-        if (allRoutes(effective(route))) {
+        if (allRoutes(route.nested)) {
           if (scan(route.inner)) return true;
           continue;
         }
@@ -124,7 +123,7 @@ export class Route extends Component {
     const collect = (routes: Route[]): string[] =>
       routes.flatMap((route) => {
         if (route.redirect || route.default) return [];
-        if (!allRoutes(effective(route)))
+        if (!allRoutes(route.nested))
           return match(route.base, route.to) ? [route.path] : [];
 
         // A scope counts via a matched descendant, or its own section default.
@@ -165,6 +164,13 @@ export class Route extends Component {
     return children;
   }
 
+  /** This scope's children with `routes()` applied - the effective set matching
+   * and render consult. Memoized by the framework (recomputes when `props`
+   * change), so contributed routes have stable identity within a render pass. */
+  protected get nested(): Component.Node {
+    return this.routes((this.props as { children?: Component.Node }).children);
+  }
+
   resolve(url: string): string {
     return this.router.resolve(this, url);
   }
@@ -194,7 +200,7 @@ export class Route extends Component {
     if (Object.getOwnPropertyDescriptor(props, 'children')?.get)
       return matched ? props.children : null;
 
-    const children = effective(this);
+    const children = this.nested;
 
     // Matched: render content (in `as` chrome if present). Unmatched: a
     // see-through scope still mounts children (registration); a leaf renders null.
@@ -203,24 +209,6 @@ export class Route extends Component {
 
     return allRoutes(children) ? <>{children}</> : null;
   }
-}
-
-/**
- * This scope's effective children - `route.routes()` applied to the declared
- * children, memoized by input identity (keyed on the real instance, mirroring
- * the `match` getter so observer proxies share one entry).
- */
-function effective(route: Route): Component.Node {
-  const self = route.is;
-  const given = (route.props as { children?: Component.Node }).children;
-  const memo = ROUTES.get(self);
-
-  if (memo && memo.given === given)
-    return memo.out;
-
-  const out = route['routes'](given);
-  ROUTES.set(self, { given, out });
-  return out;
 }
 
 /**
@@ -303,9 +291,10 @@ type RouteProps = {
 export function matchesAnywhere(children: Component.Node, base: string, path: string): boolean {
   return lexicalRoutes(children).some(({ props, to }) => {
     if (props.redirect || props.default) return false;
-    if (allRoutes(props.children))
-      return matchesAnywhere(props.children, base + patternSegment(to), path);
-    return matchPattern(fullPattern(base, to), path) !== null;
+
+    return allRoutes(props.children)
+      ? matchesAnywhere(props.children, base + patternSegment(to), path)
+      : matchPattern(fullPattern(base, to), path) !== null;
   });
 }
 

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -191,39 +191,40 @@ Navigates to `to` when mounted, gated on `when` (default `true`). Pushes by defa
 ## Extending Route: contributing child routes
 
 A `Route` subclass can opine on its own scope's children before matching and
-registration via the `protected routes()` seam. It receives the children as
-declared and returns the effective set - add, remove, or reorder. The default
-passes through. Both matching and render read the result, so contributed routes
-participate in this scope's control flow (matching, `inner` registration,
-default-resolution, `matches`, and render) exactly as if declared in JSX.
+registration by overriding the `protected get nested()` seam. It defaults to the
+children declared in JSX; override it to return the effective set - add, remove,
+or reorder - composing on `super.nested`. Both matching and render read the
+result, so contributed routes participate in this scope's control flow
+(matching, `inner` registration, default-resolution, `matches`, and render)
+exactly as if declared in JSX.
 
 ```tsx
 class Page extends Route {
   Default = NotFound;
 
-  protected routes(given: Component.Node): Component.Node {
-    return <>{given}<Route default as={this.Default} /></>;
+  protected get nested(): Component.Node {
+    return <>{super.nested}<Route default as={this.Default} /></>;
   }
 }
 ```
 
 `<Page to="docs/*">…</Page>` now resolves to `Default` whenever no child of the
 scope matches - a section fallback the caller never had to write. `Default` is
-the subclass's own surface; `Route` gains only the `routes()` seam.
+the subclass's own surface; `Route` exposes only the `nested` seam.
 
 Scope and caveats:
 - **Own scope only.** Contributed routes are first-class *within this Route*.
   They are invisible to walks that inspect this Route as a bare JSX element from
   the outside - sibling `as`-slot arbitration and a parent scope recursing into
-  this element's lexical children - which have no instance to call `routes()` on.
+  this element's lexical children - which have no instance to read `nested` from.
   Same blind spot as class-field `to` (see below).
 - **Classification follows effective children.** Contributing a default to a
   `to`-leaf turns it into a see-through scope (matched by prefix rather than
   exact pattern). Intended - the leaf/scope distinction reflects what the scope
   effectively contains.
-- Put injection in `routes()`, not `render()`: it is pure analysis (returns
-  nodes, never runs a page render), so matching can consult it without the
-  circularity and lazy-gate problems of deciding matches from render output.
+- Contribute via `nested`, not `render()`: it is pure analysis (returns nodes,
+  never runs a page render), so matching can consult it without the circularity
+  and lazy-gate problems of deciding matches from render output.
 
 ## Lexical matching - the limits
 

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -188,6 +188,43 @@ Navigates to `to` when mounted, gated on `when` (default `true`). Pushes by defa
 <Redirect to="/home" replace />
 ```
 
+## Extending Route: contributing child routes
+
+A `Route` subclass can opine on its own scope's children before matching and
+registration via the `protected routes()` seam. It receives the children as
+declared and returns the effective set - add, remove, or reorder. The default
+passes through. Both matching and render read the result, so contributed routes
+participate in this scope's control flow (matching, `inner` registration,
+default-resolution, `matches`, and render) exactly as if declared in JSX.
+
+```tsx
+class Page extends Route {
+  Default = NotFound;
+
+  protected routes(given: Component.Node): Component.Node {
+    return <>{given}<Route default as={this.Default} /></>;
+  }
+}
+```
+
+`<Page to="docs/*">…</Page>` now resolves to `Default` whenever no child of the
+scope matches - a section fallback the caller never had to write. `Default` is
+the subclass's own surface; `Route` gains only the `routes()` seam.
+
+Scope and caveats:
+- **Own scope only.** Contributed routes are first-class *within this Route*.
+  They are invisible to walks that inspect this Route as a bare JSX element from
+  the outside - sibling `as`-slot arbitration and a parent scope recursing into
+  this element's lexical children - which have no instance to call `routes()` on.
+  Same blind spot as class-field `to` (see below).
+- **Classification follows effective children.** Contributing a default to a
+  `to`-leaf turns it into a see-through scope (matched by prefix rather than
+  exact pattern). Intended - the leaf/scope distinction reflects what the scope
+  effectively contains.
+- Put injection in `routes()`, not `render()`: it is pure analysis (returns
+  nodes, never runs a page render), so matching can consult it without the
+  circularity and lazy-gate problems of deciding matches from render output.
+
 ## Lexical matching - the limits
 
 Matching is computed statically from the JSX tree in the same render. It does **not** see:


### PR DESCRIPTION
## Summary

Adds a `protected get nested` extension point to `Route`, letting subclasses opine on their own scope's child routes (add/remove/reorder) before matching and registration - e.g. converting a `Default` subcomponent into a child `<Route default>` without the caller declaring it lexically.

`nested` defaults to the children declared in JSX. A subclass overrides the getter and composes on `super.nested`:

```tsx
class Page extends Route {
  Default = NotFound;

  protected get nested(): Component.Node {
    return <>{super.nested}<Route default as={this.Default} /></>;
  }
}
```

The result flows through every registration-form behavior (`inner`, `active`, `matches`, default gating) and the see-through gate. Because `nested` is pure analysis (returns nodes, never triggers a page render), `matched` can consult it without breaking the lazy render gate. A subclass that contributes routes can flip its own leaf<->see-through classification, reflecting its effective children.

This relies on mvc computing the most-derived getter and resolving `super.nested` to the base getter without recursion (verified); reads inside the base getter stay tracked.

## Commits (squash on merge)

- **feat**: the seam, effective-children resolution, tests, skill docs
- **refactor**: factor the repeated Fragment-flatten + Route-filter JSX walk shared by `hasDefault`/`matchesAnywhere`/as-arbitration into one `lexicalRoutes` helper; rename `contenders` -> `possible`
- **refactor**: replace the hand-rolled memo (WeakMap + module helper) with a framework-memoized getter
- **refactor**: collapse the original `routes(children)` method and the applier getter into a single overridable `nested` getter - one protected member instead of two

## Changeset

`@expressive/router` minor (new `protected` extension point). Refactor commits carry no changeset (no observable behavior change).

## Tests

172 router tests pass; covers default injection, sibling-match precedence, `matches` participation, leaf->see-through reclassification, and pass-through parity with plain `Route`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)