### PR TITLE
chore: changeset for #172 (goto relative-to-self)

### DIFF
--- a/.changeset/goto-relative-self.md
+++ b/.changeset/goto-relative-self.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+`Route.goto()` now resolves its argument relative to the Route it is called on, and with no argument navigates to that Route itself (its concrete, params-filled path) - enabling "pop from below", where a subroute reaches a named ancestor via context and navigates up to it as currently identified. `goto` always resolves relative to its receiver and an absent argument means `"."` (here), so `''`/`'.'` are no longer dead no-ops. This also fixes `anchor` for nested Routes: it now recovers params from the live path and composes `base` correctly, so relative navigation works from any depth.


### PR DESCRIPTION
#172 (`feat(router): goto() resolves relative to self; fix nested anchor base`) merged without a changeset, so its user-facing change isn't reflected in the version bump or changelog.

This adds the missing changeset (`@expressive/router` minor). Once merged, the bot's "Version Packages" PR (#174) will pick it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)