### PR TITLE
feat(router): accept function or class element type as `as`

### DIFF
--- a/.changeset/route-as-element-type.md
+++ b/.changeset/route-as-element-type.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+Widen `Route`'s `as` to accept any function or class element type, including a fellow `Route` subclass, instead of only a `(props) => Node` function. The type is mvc's agnostic `Exclude<JSX.ElementType, string>`, so a `Route`/component class type-checks as `as` while intrinsic host tags stay excluded. This enables `<Route as={SomeRouteClass} />` - e.g. a generated wrapper delegating to a user page class - without a cast. When `as` is itself a `Route`, delegation falls out of the existing see-through machinery: the inner Route is the sole arbiter, receives the outer's computed `nested` as its children, and `Route.get` inside its content resolves the inner instance.

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -1000,3 +1000,98 @@ it('deregisters a child from parent.inner on unmount', async () => {
   await act(async () => view.rerender(<Route is={(r) => (parent = r)} />));
   expect(parent.inner).toEqual([]);
 });
+
+describe('a Route passed as another Route', () => {
+  // The dev-repo codegen shape `<Page to="seg" as={Default}>{children}</Page>`,
+  // where the outer node carries the segment/overrides and the inner (user)
+  // Route is the subtree controller. Delegation falls out of the existing
+  // see-through machinery: the inner Route is the sole arbiter, sees the
+  // outer's computed `nested`, and keeps Route.get / fallback / suspense intact.
+  const Leaf = (label: string) => () => <span>{label}</span>;
+
+  it('lets the inner Route arbitrate and render the matched child', async () => {
+    location('/sub/a');
+    class Inner extends Route {}
+
+    const view = render(
+      <Route to="sub" as={Inner}>
+        <Route to="a" as={Leaf('A')} />
+        <Route to="b" as={Leaf('B')} />
+      </Route>
+    );
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('A');
+  });
+
+  it('resolves Route.get to the inner instance within its own content', async () => {
+    location('/sub');
+    let innerInst!: Route;
+    let resolved!: Route;
+
+    class Inner extends Route {
+      render() {
+        innerInst = this.is;
+        return (
+          <Consumer for={Route}>{(r) => { resolved = r.is; return <span>inner</span>; }}</Consumer>
+        );
+      }
+    }
+
+    const view = render(<Route to="sub" as={Inner} />);
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('inner');
+    expect(resolved).toBeInstanceOf(Inner);
+    expect(resolved).toBe(innerInst);
+  });
+
+  it('sees the outer Route\'s computed nested (outer-injected child matches)', async () => {
+    location('/sub/extra');
+    class Outer extends Route {
+      protected get nested() {
+        return (
+          <>
+            {super.nested}
+            <Route to="extra" as={Leaf('EXTRA')} />
+          </>
+        );
+      }
+    }
+    class Inner extends Route {}
+
+    const view = render(
+      <Outer to="sub" as={Inner}>
+        <Route to="a" as={Leaf('A')} />
+      </Outer>
+    );
+    await act(async () => {});
+
+    expect(view.container.textContent).toBe('EXTRA');
+  });
+
+  it('keeps the inner Route\'s fallback/suspense intact', async () => {
+    location('/sub');
+    let ready = false;
+    let resolve!: () => void;
+    const pending = new Promise<void>((r) => (resolve = r)).then(() => { ready = true; });
+
+    class Inner extends Route {
+      fallback = <span>loading</span>;
+      render() {
+        return <Suspends />;
+      }
+    }
+    const Suspends = () => {
+      if (!ready) throw pending;
+      return <span>ready</span>;
+    };
+
+    const view = render(<Route to="sub" as={Inner} />);
+    await act(async () => {});
+    expect(view.container.textContent).toBe('loading');
+
+    await act(async () => { resolve(); await pending; });
+    expect(view.container.textContent).toBe('ready');
+  });
+});

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -1,5 +1,5 @@
 import { Component, get, set } from '@expressive/mvc';
-import { childrenOf, Fragment, isElement, propsOf, typeOf } from '@expressive/mvc/jsx-runtime';
+import { childrenOf, Fragment, isElement, propsOf, typeOf, type JSX } from '@expressive/mvc/jsx-runtime';
 
 import { Redirect } from './redirect';
 import { Router } from './router';
@@ -11,7 +11,9 @@ const CHILDREN = new WeakMap<Route, Route[]>();
 export class Route extends Component {
   router = set(() => this.get(Router, false) || new Router());
 
-  as?: (props: { children?: Component.Node }) => Component.Node = undefined;
+  /** Component wrapping matched content - a function or class element type
+   * (a fellow Route subclass included), but not an intrinsic host tag. */
+  as?: Exclude<JSX.ElementType, string> = undefined;
 
   to: string = '';
 


### PR DESCRIPTION
## What

Widen `Route`'s `as` from a hand-written function type to mvc's agnostic `Exclude<JSX.ElementType, string>`, so a **function** or **class** element type - including a fellow `Route` subclass - type-checks as `as`, while intrinsic host tags (`as="div"`) stay excluded.

```diff
-  as?: (props: { children?: Component.Node }) => Component.Node = undefined;
+  as?: Exclude<JSX.ElementType, string> = undefined;
```

## Why

Enables `<Route as={SomeRouteClass} />` for consumers (e.g. the bun-dev file-based router, where codegen emits `<Page as={Default}>` and `Default` may be a `Route`/`Page` subclass). Today that requires an `as any` cast.

## Delegation falls out - no runtime change

The original concern was a "double-scope" when `as` is itself a `Route`: two scopes arbitrating one child set. Investigation (probe-driven) showed delegation **already** falls out of the existing see-through machinery:

- the outer passes its computed `nested` in as the inner's children, so the inner sees the outer's overrides for free (and can compose via `super.nested`);
- the inner composes off `scopeBase(outer)` (segment counted once), so with no own `to` there's no double-count and the inner is the sole arbiter;
- `Route.get` inside the inner's content resolves the **inner** instance.

So `route.tsx` needed only the type change. New tests in `route.test.tsx` (`describe('a Route passed as another Route')`) pin the four behaviors:

1. inner Route arbitrates and renders the matched child
2. `Route.get` resolves the inner instance within its content
3. inner sees the outer's computed `nested` (outer-injected child matches)
4. inner's `fallback`/suspense stay intact

## Tests

`bun run test` (router): 179 pass, 0 fail, `route.tsx` 100% coverage.

## Changeset

`minor` for `@expressive/router` (user-facing API widening).