### PR TITLE
ci: add a manual confirmation gate for PRs with no changeset

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,10 +10,25 @@ in the PR for its whole life. The frozen-lockfile install in the `setup`
 action doubles as the internal-dependency desync guard - a workspace version
 that falls outside a sibling's range cannot reach main.
 
-Non-blocking signals: the plan-present warning, `changeset status` (PRs may
-legitimately carry zero changesets), and `npm publish --dry-run` pack
-validation for the publishable packages. `ci:version` sweeps any plan file
-that reaches main regardless.
+Non-blocking signals: the plan-present warning, `changeset status` (a preview
+of which packages would bump), and `npm publish --dry-run` pack validation for
+the publishable packages. `ci:version` sweeps any plan file that reaches main
+regardless.
+
+## changeset.yml (pull requests -> main)
+
+A confirmation gate, not a failure. The `detect` job diffs `.changeset` against
+the base (so changesets already queued on main don't count). If the PR adds its
+own changeset the gate is auto-satisfied. If it doesn't, the `confirm` job runs
+against the `changeset` environment, whose required reviewer holds it as a
+pending approval until a human confirms none is needed (internal refactor,
+test-only, no observable effect). This keeps an accidental omission from
+silently merging a user-facing change unversioned, without ever showing as a red
+failure. Kept separate from `pr.yml` so it stays a fast, self-contained gate.
+
+Branch protection requires both `verify` (from `pr.yml`) and `Confirm no
+changeset needed` to merge. When a changeset is present the `confirm` job is
+skipped, which branch protection counts as passing.
 
 ## release.yml (push -> main)
 

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -1,0 +1,48 @@
+name: Changeset
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: changeset-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect changeset
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      missing: ${{ steps.check.outputs.missing }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          added=$(git diff --name-only --diff-filter=AM "origin/$BASE...HEAD" -- '.changeset' \
+            | grep -E '/[^/]+\.md$' | grep -v 'README.md' || true)
+          if [ -n "$added" ]; then
+            echo "Changeset added by this PR - gate auto-satisfied:"
+            echo "$added"
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No changeset added by this PR - manual confirmation required."
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Runs only when no changeset was added; the `changeset` environment's required
+  # reviewer holds it as a pending approval until a human confirms none is needed.
+  # When a changeset exists this job is skipped, so the gate passes on its own.
+  confirm:
+    name: Confirm no changeset needed
+    needs: detect
+    if: needs.detect.outputs.missing == 'true'
+    runs-on: ubuntu-latest
+    environment: changeset
+    steps:
+      - run: echo "Confirmed - this PR intentionally needs no changeset."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ await expect(state).not.toHaveUpdated();
 - New features and non-trivial refactors begin with a root `BRANCH.md` as the branch's first commit, capturing agreed scope, key decisions, and approach before implementation.
 - Keep `BRANCH.md` current as the plan evolves - it stays in the PR as review context. Close to merge, run `bun run wrap`: it authors the changesets (migrate `BRANCH.md` content into them and the PR summary) and deletes the file. CI blocks a PR where `BRANCH.md` and changesets coexist - changesets are the plan's migrated form; warns (non-blocking) while the plan alone exists; and the release version step sweeps any that reach main.
 - Write a changeset (`bun run changeset`) when a change is user-facing: new feature, behavior change, API addition, breaking change.
-- No changeset for internal refactors, test-only changes, or fixes with no observable effect. PRs may legitimately carry zero changesets.
+- No changeset for internal refactors, test-only changes, or fixes with no observable effect. A zero-changeset PR is legitimate, but the `changeset` workflow holds it at a manual confirmation gate (a pending environment approval) until a reviewer confirms none is needed - so an accidental omission can't slip a user-facing change through unversioned. Adding a changeset auto-satisfies the gate.
 
 ### Releasing
 


### PR DESCRIPTION
## What

Adds a `changeset.yml` workflow that gates PRs lacking a changeset behind a **manual confirmation** (a pending environment approval), and **auto-satisfies** when a changeset is present. It is not a failure - no red X.

## Why

A PR with no changeset can silently merge a user-facing change unversioned - which happened, needing the follow-up #176. This makes the no-changeset case a deliberate, documented confirmation instead of an easy oversight.

## How

- **`detect` job** diffs `.changeset` against the base (`origin/$BASE...HEAD`), so changesets already queued on `main` don't count - only the PR's own.
- **Changeset present** → `confirm` job is skipped → gate passes on its own.
- **No changeset** → `confirm` runs against the `changeset` environment, whose required reviewer holds it as a pending approval until a human confirms none is needed.

## Repo setup done alongside

- Created the `changeset` environment with a required reviewer.
- **Branch protection on `main`**: requires `verify` + `Confirm no changeset needed`, admin-enforced, no force-push/deletion.

## Note

This PR carries no changeset (CI-only), so it dogfoods the gate: the `confirm` job should sit awaiting approval rather than failing.