### PR TITLE
perf(router): drop Redirect's own suspense boundary

### DIFF
--- a/packages/router/src/redirect.ts
+++ b/packages/router/src/redirect.ts
@@ -6,6 +6,7 @@ export class Redirect extends Component {
   to = '';
   replace = false;
   when: boolean = true;
+  fallback = false;
 
   private route = get(Route);
 

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -628,14 +628,14 @@ describe('extends', () => {
     expect(found).toBeInstanceOf(Profile);
   });
 
-  it('see-through scope chrome shows only when a subclass descendant matches', () => {
+  it('see-through scope chrome shows only when a subclass descendant matches', async () => {
     class Page extends Route {}
     const Chrome = ({ children }: { children?: React.ReactNode }) => (
       <div>chrome:{children}</div>
     );
 
     location('/section/info');
-    const matched = render(
+    const matched = await renderAct(
       <Route>
         <Route to="section/*" as={Chrome}>
           <Page to="info" as={() => <span>info</span>} />
@@ -645,7 +645,7 @@ describe('extends', () => {
     expect(matched.container.textContent).toBe('chrome:info');
 
     location('/elsewhere');
-    const unmatched = render(
+    const unmatched = await renderAct(
       <Route>
         <Route to="section/*" as={Chrome}>
           <Page to="info" as={() => <span>info</span>} />


### PR DESCRIPTION
## What

Two small, independent router optimizations.

### `perf:` Redirect drops its own suspense boundary
`Redirect` renders `null` and ignores its children, so its inherited default
null-fallback Suspense boundary never has anything to catch. Setting
`fallback = false` removes that wrapper - one fewer fiber per redirect - and
lets any (theoretical) suspension bubble to the nearest real ancestor boundary.

**No observable behavior change**, so no dedicated test: a test couldn't fail
without the change (nothing downstream of Redirect ever suspends). The existing
`redirect.test.tsx` suite already pins the render/navigate contract.

### `test:` wrap see-through-chrome renders in act
The 'see-through scope chrome' test issued two bare `render()` calls whose
mvc microtask-batched updates settled outside `act`, emitting React act
warnings. Routed through the existing `renderAct` helper - the suite is now
warning-free.

## Changeset
None - internal optimization with no observable effect plus a test-only fix.
The changeset workflow will hold this at its manual confirmation gate per
AGENTS.md; a reviewer can confirm no changeset is needed.