### PR TITLE
fix(mvc): prevent stack overflow in get() snapshot on non-root cycles

### DIFF
--- a/.changeset/fix-values-cycle-overflow.md
+++ b/.changeset/fix-values-cycle-overflow.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix stack overflow in `get()` snapshots when the model graph has a cycle not passing through root state.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -3323,5 +3323,27 @@ describe('computed (getters)', () => {
       expect(didGetNewValue).toBeCalledWith(3);
       expect(didGetOldValue).toBeCalledTimes(2);
     });
+
+    it('will export cycle not involving root', () => {
+      class Node extends State {
+        name = 'x';
+        link?: Node = undefined;
+      }
+
+      const a = Node.new();
+      const b = Node.new();
+
+      a.link = b;
+      b.link = a;
+
+      class Root extends State {
+        child = a;
+      }
+
+      const root = Root.new();
+      const exported = root.get();
+
+      expect(exported.child.link).toBe(exported.child.link!.link!.link);
+    });
   });
 });

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -793,8 +793,10 @@ function values<T extends State>(state: T): State.Values<T> {
 
   if (!EXPORT) {
     notRecursive = true;
-    EXPORT = new Map([[state, values]]);
+    EXPORT = new Map();
   }
+
+  EXPORT.set(state, values);
 
   for (let [key, value] of state) {
     if (EXPORT.has(value)) value = EXPORT.get(value);
@@ -804,7 +806,7 @@ function values<T extends State>(state: T): State.Values<T> {
       'get' in value &&
       typeof value.get === 'function'
     )
-      EXPORT.set(value, (value = value.get()));
+      value = value.get();
 
     values[key] = value;
   }


### PR DESCRIPTION
## Problem

`State.get()` with no args (`values()`) builds a deep, recursive snapshot of the reachable model graph. Its `EXPORT` map is meant to be a cycle guard, but it registered **only the root state eagerly** — nested models were registered only *after* their own `.get()` returned.

As a result, a cycle that does **not** pass through the root (e.g. `root → A ⇄ B`) re-enters `A.get()` while A's first resolution is still on the stack and A isn't yet in `EXPORT`, recursing infinitely → `RangeError: Maximum call stack size exceeded`. A root-level cycle was already guarded, which masked the bug.

This surfaced downstream as overflows when cycling navigation in a router app (parent/child `Route` back-references one level below the snapshot root).

## Fix

Register **every** state in `EXPORT` before walking its properties (not just the root), and drop the now-redundant lazy registration on the exotic path. Back-references at any depth resolve to the in-progress snapshot object. Documented deep-flatten semantics and diamond-reference identity are preserved — no API change.

## Test

Added a regression test under the `circular` block: a cycle whose root is a separate parent. Asserts the snapshot resolves to stable shared objects rather than overflowing.