### PR TITLE
test: cleanup and matcher sweep

### DIFF
--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -32,7 +32,7 @@ it('will call is callback once with instance', () => {
   const foo = Component.new({ is });
 
   expect(is).toBeCalledWith(foo);
-  expect(is).toHaveBeenCalledTimes(1);
+  expect(is).toBeCalled();
 
   // ressigning props from another render.
   (foo as any).props = { is };

--- a/packages/mvc/src/context.test.ts
+++ b/packages/mvc/src/context.test.ts
@@ -108,7 +108,7 @@ it('child pop is safe to call before parent pop', () => {
 
   child.pop();
 
-  expect(destroyed).toBeCalledTimes(1);
+  expect(destroyed).toBeCalled();
 
   // parent.pop() cascades into already-popped child — must not double-destroy
   parent.pop();
@@ -166,7 +166,7 @@ it('will notify downstream subscriber when implicit child is replaced', () => {
   context.get(Foo, cb);
 
   // called immediately with existing instance
-  expect(cb).toBeCalledTimes(1);
+  expect(cb).toBeCalled();
   expect(cb).toBeCalledWith(foo1, false);
 
   parent.child = foo2;
@@ -296,7 +296,7 @@ describe('has method', () => {
     const cancel = context.get(DownstreamState, cb, true);
     context.push(DownstreamState);
 
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
 
     cancel();
     context.push(DownstreamState);
@@ -314,7 +314,7 @@ describe('has method', () => {
 
     const child = context.push(DownstreamState);
 
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
 
     child.pop();
 
@@ -329,7 +329,7 @@ describe('has method', () => {
     const cancel = context.get(DownstreamState, cb, true);
     context.push(DownstreamState);
 
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
     cancel();
 
     context.push(DownstreamState);
@@ -358,7 +358,7 @@ describe('has method', () => {
     context.get(DownstreamState, cb, true);
 
     // existing downstream
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
     expect(cb).toBeCalledWith(expect.any(DownstreamState), true);
 
     // new downstream addition

--- a/packages/mvc/src/field/get.test.ts
+++ b/packages/mvc/src/field/get.test.ts
@@ -337,7 +337,7 @@ describe('fetch mode', () => {
       const first = consumer.remote;
       const effect = mock();
 
-      expect(callback).toBeCalledTimes(1);
+      expect(callback).toBeCalled();
       expect(callback).toBeCalledWith(first, consumer);
 
       consumer.get((it) => {
@@ -754,7 +754,7 @@ describe('lifecycle callbacks', () => {
 
     new Context({ remote, test });
 
-    expect(remoteCallback).toBeCalledTimes(1);
+    expect(remoteCallback).toBeCalled();
 
     // Change should NOT trigger callback again
     remote.value = 'bar';
@@ -828,7 +828,7 @@ describe('lifecycle callbacks', () => {
 
     context.push(Parent).push(Child);
 
-    expect(didNotify).toBeCalledTimes(1);
+    expect(didNotify).toBeCalled();
     expect(didRemove).not.toBeCalled();
 
     context.pop();
@@ -854,7 +854,7 @@ describe('lifecycle callbacks', () => {
     const context = new Context(Parent);
     const inner = context.push(Child);
 
-    expect(didNotify).toBeCalledTimes(1);
+    expect(didNotify).toBeCalled();
     expect(didRemove).not.toBeCalled();
 
     inner.pop();

--- a/packages/mvc/src/field/hot.test.ts
+++ b/packages/mvc/src/field/hot.test.ts
@@ -2,8 +2,7 @@ import { mock, describe, it, expect } from 'bun:test';
 import { observer, watch } from '../observable';
 import { State } from '../state';
 import { hot } from './hot';
-
-const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+import { flushMicrotasks as flush } from '../../test.setup';
 
 describe('factory', () => {
   it('wraps an array', () => {
@@ -507,7 +506,7 @@ describe('as State field', () => {
     expect(cb).toBeCalledWith('');
 
     game.board[0] = 'X';
-    await new Promise<void>((r) => setTimeout(r, 0));
+    await flush();
 
     expect(cb).toBeCalledWith('X');
     expect(cb).toHaveBeenCalledTimes(2);
@@ -527,7 +526,7 @@ describe('as State field', () => {
 
     cb.mockClear();
     game.board[5] = 'X';
-    await new Promise<void>((r) => setTimeout(r, 0));
+    await flush();
 
     expect(cb).not.toBeCalled();
   });

--- a/packages/mvc/src/field/set.test.ts
+++ b/packages/mvc/src/field/set.test.ts
@@ -1,5 +1,5 @@
 import { mock, describe, it, expect } from 'bun:test';
-import { mockPromise, mockWarn } from '../../test.setup';
+import { mockPromise, mockWarn, flushMicrotasks } from '../../test.setup';
 import { State } from '../state';
 import { set } from './set';
 
@@ -835,7 +835,7 @@ describe('suspense', () => {
     expect(didAttemptSum).toBeCalledTimes(3);
     expect(test.sum).toBe('Answer is 30.');
 
-    await new Promise<void>((r) => setTimeout(r, 0));
+    await flushMicrotasks();
     expect(didAttemptEffect).toBeCalledTimes(2);
     expect(didCompleteEffect).toBeCalledWith('Answer is 30.');
   });

--- a/packages/mvc/src/field/set.test.ts
+++ b/packages/mvc/src/field/set.test.ts
@@ -103,7 +103,7 @@ describe('placeholder', () => {
 
     instance.get(mockEffect);
 
-    expect(mockEffect).toBeCalledTimes(1);
+    expect(mockEffect).toBeCalled();
 
     instance.foobar = 'foo!';
 
@@ -122,7 +122,7 @@ describe('placeholder', () => {
 
     test.get(effect);
 
-    expect(effect).toBeCalledTimes(1);
+    expect(effect).toBeCalled();
     expect(foobar).not.toBeCalled();
 
     test.foobar = 'foo';
@@ -485,7 +485,7 @@ describe('compute', () => {
     const test = Test.new();
 
     void test.double;
-    expect(factory).toBeCalledTimes(1);
+    expect(factory).toBeCalled();
 
     test.other = 'bar';
     await expect(test).toHaveUpdated('other');
@@ -539,7 +539,7 @@ describe('suspense', () => {
 
     const test = Test.new();
     expect(() => test.greet).toThrow(expect.any(Promise));
-    expect(didEvaluate).toBeCalledTimes(1);
+    expect(didEvaluate).toBeCalled();
 
     await test.set({ value: 'hello' });
 
@@ -560,7 +560,7 @@ describe('suspense', () => {
 
     const test = Test.new();
     expect(() => test.greet).toThrow(expect.any(Promise));
-    expect(didEvaluate).toBeCalledTimes(1);
+    expect(didEvaluate).toBeCalled();
 
     promise.resolve('hello');
     await expect(test).toHaveUpdated();
@@ -716,7 +716,7 @@ describe('suspense', () => {
 
     test.get(effect);
 
-    expect(effect).toBeCalledTimes(1);
+    expect(effect).toBeCalled();
     expect(effect).not.toHaveReturned();
 
     promise.resolve('hello');
@@ -769,7 +769,7 @@ describe('suspense', () => {
 
     expect(effect).toBeCalled();
     expect(effect).not.toHaveReturned();
-    expect(compute).toBeCalledTimes(1);
+    expect(compute).toBeCalled();
 
     pending.resolve();
     pending = mockPromise();
@@ -826,7 +826,7 @@ describe('suspense', () => {
     await expect(test).toHaveUpdated();
 
     expect(didAttemptSum).toBeCalledTimes(2);
-    expect(didAttemptEffect).toBeCalledTimes(1);
+    expect(didAttemptEffect).toBeCalled();
     expect(didCompleteEffect).not.toBeCalled();
 
     promise2.resolve(20);

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -179,7 +179,7 @@ describe('effect', () => {
       });
     });
 
-    expect(didInvoke).toBeCalledTimes(1);
+    expect(didInvoke).toBeCalled();
     expect(didInvoke).toBeCalledWith({ foo: 1, bar: 2 });
 
     await test.set({ bar: 3 });
@@ -243,7 +243,7 @@ describe('effect', () => {
       test.bar = foo;
     });
 
-    expect(didUpdate).toBeCalledTimes(1);
+    expect(didUpdate).toBeCalled();
     expect(didUpdate).toBeCalledWith(1, undefined);
 
     // is syncronously 1 after effect did run.
@@ -281,7 +281,7 @@ describe('effect', () => {
       test.bar = foo;
     });
 
-    expect(didUpdate).toBeCalledTimes(1);
+    expect(didUpdate).toBeCalled();
     expect(didUpdate).toBeCalledWith(1, undefined);
 
     // is syncronously 1 after effect did run.
@@ -363,7 +363,7 @@ describe('effect', () => {
       const effect = mock(($: Test) => void $.foo);
 
       test.get(effect);
-      expect(effect).toBeCalledTimes(1);
+      expect(effect).toBeCalled();
 
       test.foo = 2;
       test.set(null);
@@ -483,7 +483,7 @@ describe('observable', () => {
     });
 
     expect(cb).toBeCalledWith(0);
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
 
     proxy.bump();
     await new Promise((r) => setTimeout(r, 5));

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -2,7 +2,7 @@ import { event, listener, touch, watch, observer } from './observable';
 import { set } from './field/set';
 import { def } from './field/def';
 import { mock, describe, it, expect } from 'bun:test';
-import { mockError, mockPromise } from '../test.setup';
+import { mockError, mockPromise, flushMicrotasks } from '../test.setup';
 import { State } from './state';
 
 describe('effect', () => {
@@ -368,7 +368,7 @@ describe('effect', () => {
       test.foo = 2;
       test.set(null);
 
-      await new Promise((res) => setTimeout(res, 0));
+      await flushMicrotasks();
 
       expect(effect).toBeCalledTimes(1);
       expect(error).not.toBeCalled();

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -899,7 +899,7 @@ describe('get method', () => {
 
       test.get(effect);
 
-      expect(effect).toBeCalledTimes(1);
+      expect(effect).toBeCalled();
       test.child.value = 'bar';
 
       await expect(test.child).toHaveUpdated();
@@ -1027,7 +1027,7 @@ describe('get method', () => {
       });
 
       test.get(effect);
-      expect(effect).toBeCalledTimes(1);
+      expect(effect).toBeCalled();
 
       test.nested.value++;
       await expect(test.nested).toHaveUpdated();
@@ -1345,12 +1345,12 @@ describe('get method', () => {
           didUpdate(state.value);
         });
 
-        expect(willUpdate).toBeCalledTimes(1);
+        expect(willUpdate).toBeCalled();
 
         test.other = 'bar';
 
         await expect(test).toHaveUpdated();
-        expect(willUpdate).toBeCalledTimes(1);
+        expect(willUpdate).toBeCalled();
 
         test.value = 'foo';
 
@@ -3162,7 +3162,7 @@ describe('computed (getters)', () => {
       const test = Test.new();
 
       expect(test.value).toBe('AX');
-      expect(didCompute).toBeCalledTimes(1);
+      expect(didCompute).toBeCalled();
 
       test.tracked = 'B';
       await expect(test).toHaveUpdated();

--- a/packages/mvc/test.setup.ts
+++ b/packages/mvc/test.setup.ts
@@ -22,8 +22,13 @@ expect.extend({ toHaveUpdated, toHaveText });
 
 afterEach(() => Context.root.pop());
 
-export { mockError, mockPromise, mockWarn };
+export { mockError, mockPromise, mockWarn, flushMicrotasks };
 export type { MockPromise };
+
+/** Resolve after the task queue drains - flush pending dispatch/effects. */
+function flushMicrotasks() {
+  return new Promise<void>((r) => setTimeout(r, 0));
+}
 
 async function toHaveUpdated(
   received: unknown,

--- a/packages/mvc/test.setup.ts
+++ b/packages/mvc/test.setup.ts
@@ -5,6 +5,12 @@ import { listener } from './src/observable';
 interface CustomMatchers<R = unknown> {
   /** Flush pending updates, optionally asserting specific keys were updated. */
   toHaveUpdated(...keys: (string | symbol | number)[]): Promise<R>;
+  /** Assert a queryable (screen or bound element) has rendered the given text. */
+  toHaveText(text: string): R;
+}
+
+interface Queryable {
+  queryAllByText(text: string): unknown[];
 }
 
 declare module 'bun:test' {
@@ -12,7 +18,7 @@ declare module 'bun:test' {
   interface AsymmetricMatchers extends CustomMatchers { }
 }
 
-expect.extend({ toHaveUpdated });
+expect.extend({ toHaveUpdated, toHaveText });
 
 afterEach(() => Context.root.pop());
 
@@ -83,6 +89,27 @@ async function toHaveUpdated(
       `Expected ${received} not to have updated keys [${keys
         .map(String)
         .join(', ')}].`
+  };
+}
+
+function toHaveText(received: unknown, text: string) {
+  const query = (received as Queryable)?.queryAllByText;
+
+  if (typeof query != 'function')
+    return {
+      pass: false,
+      message: () =>
+        `Expected a queryable (screen or bound element) but got ${received}.`
+    };
+
+  const found = query.call(received, text);
+
+  return {
+    pass: found.length > 0,
+    message: () =>
+      found.length
+        ? `Expected not to find text "${text}" but found ${found.length}.`
+        : `Expected to find text "${text}" but found none.`
   };
 }
 

--- a/packages/preact/src/boundary.test.tsx
+++ b/packages/preact/src/boundary.test.tsx
@@ -2,7 +2,7 @@
 import { render, screen, act } from '@testing-library/preact';
 import { mock, expect, it, describe } from 'bun:test';
 
-import { mockError, mockPromise } from '../test.setup';
+import { mockError, mockPromise, flushMicrotasks } from '../test.setup';
 import { Component } from '.';
 
 describe('error boundary', () => {
@@ -13,7 +13,7 @@ describe('error boundary', () => {
   const settle = () =>
     act(async () => {
       for (let i = 0; i < 5; i++)
-        await new Promise((r) => setTimeout(r, 0));
+        await flushMicrotasks();
     });
 
   it('will show fallback when child throws', async () => {

--- a/packages/preact/src/boundary.test.tsx
+++ b/packages/preact/src/boundary.test.tsx
@@ -36,7 +36,7 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
   });
 
   it('will recover when catch resolves', async () => {
@@ -65,12 +65,12 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     await act(async () => resolve());
     await settle();
 
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
   });
 
   it('will restore fallback after catch resolves', async () => {
@@ -102,13 +102,13 @@ describe('error boundary', () => {
     await settle();
 
     // error boundary shows error-specific fallback
-    screen.getByText('Error Fallback');
+    expect(screen).toHaveText('Error Fallback');
 
     await act(async () => resolve());
     await settle();
 
     // error recovered, render works again
-    screen.getByText('initial');
+    expect(screen).toHaveText('initial');
 
     // suspend from render - fallback was restored so suspense uses default
     await act(async () => {
@@ -116,7 +116,7 @@ describe('error boundary', () => {
       instance.value = 'trigger';
     });
 
-    screen.getByText('Default Loading');
+    expect(screen).toHaveText('Default Loading');
   });
 
   it('will propagate if render throws after recovery', async () => {
@@ -154,14 +154,14 @@ describe('error boundary', () => {
 
     render(<Parent />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     // resolve catch but render will throw again
     await act(async () => resolve());
     await settle();
 
     // error propagated to parent boundary
-    screen.getByText('Parent Caught');
+    expect(screen).toHaveText('Parent Caught');
     expect(parentCatch).toBeCalledWith('boom');
   });
 
@@ -201,7 +201,7 @@ describe('error boundary', () => {
 
     await settle();
 
-    screen.getByText('Parent Caught');
+    expect(screen).toHaveText('Parent Caught');
     expect(parentCatch).toBeCalledWith('recovery failed');
   });
 
@@ -237,7 +237,7 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
     expect(catchCount).toBe(1);
 
     // fix the error, then resolve catch
@@ -246,7 +246,7 @@ describe('error boundary', () => {
     await settle();
 
     // successful recovery
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
 
     // new error occurs later
     await act(async () => {
@@ -257,7 +257,7 @@ describe('error boundary', () => {
 
     // catch runs again for the new error
     expect(catchCount).toBe(2);
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
   });
 
   it('will pass error to catch', async () => {
@@ -310,7 +310,7 @@ describe('error boundary', () => {
 
     await settle();
 
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
   });
 
   it('will restore fallback after sync catch', async () => {
@@ -339,14 +339,14 @@ describe('error boundary', () => {
     render(<Boundary />);
     await settle();
 
-    screen.getByText('initial');
+    expect(screen).toHaveText('initial');
 
     await act(async () => {
       throwing = new Promise(() => {});
       instance.value = 'trigger';
     });
 
-    screen.getByText('Default Loading');
+    expect(screen).toHaveText('Default Loading');
   });
 
   it('will call catch exactly once per thrown error', async () => {
@@ -400,7 +400,7 @@ describe('error boundary', () => {
 
     render(<Outer />);
 
-    screen.getByText('Caught by outer');
+    expect(screen).toHaveText('Caught by outer');
   });
 
   it('will not error if unmounted during catch', async () => {
@@ -428,7 +428,7 @@ describe('error boundary', () => {
 
     const element = render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     await act(async () => void element.unmount());
 
@@ -472,7 +472,7 @@ describe('error boundary', () => {
 
     const element = render(<Control />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
     expect(didDispose).not.toBeCalled();
 
     element.unmount();

--- a/packages/preact/src/component.test.tsx
+++ b/packages/preact/src/component.test.tsx
@@ -52,7 +52,7 @@ it('will create instance only once', () => {
   const didConstruct = mock();
   const { rerender } = render(<Control />);
 
-  expect(didConstruct).toBeCalledTimes(1);
+  expect(didConstruct).toBeCalled();
 
   rerender(<Control />);
 
@@ -85,7 +85,7 @@ describe('ref prop', () => {
     const cb = mock();
     const screen = render(<Control ref={cb} />);
 
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
     expect(cb.mock.calls[0][0]).toBeInstanceOf(Control);
 
     act(() => void screen.unmount());

--- a/packages/preact/src/component.test.tsx
+++ b/packages/preact/src/component.test.tsx
@@ -5,6 +5,7 @@ import { ComponentChildren, createRef } from 'preact';
 import { StrictMode } from 'preact/compat';
 
 import { Component, Consumer, set } from '.';
+import { flushMicrotasks } from '../test.setup';
 
 it('will create and provide instance', () => {
   class Control extends Component {
@@ -494,14 +495,14 @@ describe('suspense', () => {
 
     await act(async () => {
       foo.fallback = <span>Loading...</span>;
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
     });
 
     expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
     });
 
     expect(element).toHaveText('Hello World');
@@ -801,7 +802,7 @@ describe('subcomponents', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('Hello');
 
@@ -921,7 +922,7 @@ describe('strict mode', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(didCreate).toBeCalledTimes(1);
     expect(didDestroy).not.toBeCalled();
@@ -954,7 +955,7 @@ describe('strict mode', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('bar');
 
@@ -993,7 +994,7 @@ describe('strict mode', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('bar');
     didRender.mockClear();
@@ -1004,7 +1005,7 @@ describe('strict mode', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
@@ -1030,7 +1031,7 @@ describe('strict mode', () => {
       </StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(order).toEqual(['construct', 'init']);
 

--- a/packages/preact/src/component.test.tsx
+++ b/packages/preact/src/component.test.tsx
@@ -17,7 +17,7 @@ it('will create and provide instance', () => {
     </Control>
   );
 
-  screen.getByText('bar');
+  expect(screen).toHaveText('bar');
 });
 
 it('will expose a base render for class detection', () => {
@@ -156,10 +156,10 @@ describe('element props', () => {
     }
 
     const element = render(<Test callback={() => 'bar'} />);
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     element.rerender(<Test callback={() => 'baz'} />);
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
   });
 
   it('will not assign foreign values', () => {
@@ -190,8 +190,8 @@ describe('element children', () => {
       </Control>
     );
 
-    screen.getByText('Hello');
-    screen.getByText('World');
+    expect(screen).toHaveText('Hello');
+    expect(screen).toHaveText('World');
   });
 
   it('will notify parent', async () => {
@@ -202,7 +202,7 @@ describe('element children', () => {
     const didUpdate = mock();
     const screen = render(<Control>Hello</Control>);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
     expect(didUpdate).toBeCalled();
   });
 
@@ -218,7 +218,7 @@ describe('element children', () => {
 
     const screen = render(<Control>{symbol}</Control>);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
   });
 });
 
@@ -231,10 +231,10 @@ describe('props property', () => {
     }
 
     const { rerender } = render(<Control value="foo" />);
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
 
     rerender(<Control value="bar" />);
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
   });
 
   it('will be observable', async () => {
@@ -325,8 +325,8 @@ describe('render method', () => {
 
     const screen = render(<Control bar="foo" />);
 
-    screen.getByText('foo');
-    screen.getByText('bar');
+    expect(screen).toHaveText('foo');
+    expect(screen).toHaveText('bar');
   });
 
   it('will accept function component', async () => {
@@ -348,11 +348,11 @@ describe('render method', () => {
 
     const screen = render(<ClassComponent name="World" />);
 
-    screen.getByText('Hello World');
+    expect(screen).toHaveText('Hello World');
 
     screen.rerender(<ClassComponent salutation="Bonjour" name="Preact" />);
 
-    screen.getByText('Bonjour Preact');
+    expect(screen).toHaveText('Bonjour Preact');
   });
 
   it('will handle children if managed by this', () => {
@@ -371,8 +371,8 @@ describe('render method', () => {
 
     const screen = render(<Control value="Hello">World</Control>);
 
-    screen.getByText('Hello');
-    screen.getByText('World');
+    expect(screen).toHaveText('Hello');
+    expect(screen).toHaveText('World');
   });
 
   it('will refresh on update', async () => {
@@ -387,14 +387,14 @@ describe('render method', () => {
     let control: Control;
     const screen = render(<Control is={(x) => (control = x)} />);
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     await act(async () => {
       control.value = 'foo';
       await control.set();
     });
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
   });
 });
 
@@ -414,11 +414,11 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => void (foo.value = 'Hello World'));
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('will fallback when own render suspends', async () => {
@@ -434,13 +434,13 @@ describe('suspense', () => {
 
     const element = render(<Foo is={(x) => (foo = x)} />);
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     await act(async () => {
       foo.value = 'Hello World';
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('will use fallback property first', async () => {
@@ -458,7 +458,7 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     element.rerender(
       <Foo fallback={<span>Loading...</span>}>
@@ -466,13 +466,13 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('will update with new fallback', async () => {
@@ -490,21 +490,21 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     await act(async () => {
       foo.fallback = <span>Loading...</span>;
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 });
 
@@ -540,11 +540,11 @@ describe('state props on rerender', () => {
 
     const element = render(<Control value="first" />);
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     element.rerender(<Control value="second" />);
 
-    screen.getByText('second');
+    expect(screen).toHaveText('second');
   });
 
   it('will clear omitted instance value', () => {
@@ -558,11 +558,11 @@ describe('state props on rerender', () => {
 
     const element = render(<Control value="first" />);
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     element.rerender(<Control />);
 
-    screen.getByText('empty');
+    expect(screen).toHaveText('empty');
   });
 });
 
@@ -576,7 +576,7 @@ describe('default render', () => {
       </Control>
     );
 
-    screen.getByText('Hello World');
+    expect(screen).toHaveText('Hello World');
   });
 
   it('will provide instance created', () => {
@@ -591,7 +591,7 @@ describe('default render', () => {
       </Parent>
     );
 
-    element.getByText('foobar');
+    expect(element).toHaveText('foobar');
   });
 });
 
@@ -650,8 +650,8 @@ describe('render chain', () => {
     let instance!: Page;
     render(<Page is={(x) => (instance = x)} />);
 
-    screen.getByText('Base');
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Base');
+    expect(screen).toHaveText('Hello');
 
     // Both the super's and the subclass's reactive reads drive updates.
     await act(async () => {
@@ -659,8 +659,8 @@ describe('render chain', () => {
       instance.body = 'World';
     });
 
-    screen.getByText('Updated');
-    screen.getByText('World');
+    expect(screen).toHaveText('Updated');
+    expect(screen).toHaveText('World');
   });
 
   it('will drop derived content if wrapper omits children', () => {
@@ -680,8 +680,8 @@ describe('render chain', () => {
 
     const element = render(<Lost />);
 
-    element.getByText('Shell only');
-    expect(element.queryByText('Never seen')).toBeNull();
+    expect(element).toHaveText('Shell only');
+    expect(element).not.toHaveText('Never seen');
   });
 
 });
@@ -703,13 +703,13 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
 
     await act(async () => {
       instance.label = 'Updated';
     });
 
-    screen.getByText('Updated');
+    expect(screen).toHaveText('Updated');
   });
 
   it('will be accessible via context get', () => {
@@ -734,7 +734,7 @@ describe('subcomponents', () => {
       </Dashboard>
     );
 
-    screen.getByText('Sidebar Content');
+    expect(screen).toHaveText('Sidebar Content');
   });
 
   it('will allow override via setter', async () => {
@@ -753,7 +753,7 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('Original');
+    expect(screen).toHaveText('Original');
 
     await act(async () => {
       instance.Sidebar = function (this: Dashboard) {
@@ -762,7 +762,7 @@ describe('subcomponents', () => {
       instance.value = 'yes';
     });
 
-    screen.getByText('Replaced: yes');
+    expect(screen).toHaveText('Replaced: yes');
   });
 
   it('will accept props', () => {
@@ -778,7 +778,7 @@ describe('subcomponents', () => {
 
     render(<Dashboard />);
 
-    screen.getByText('Dynamic Label');
+    expect(screen).toHaveText('Dynamic Label');
   });
 
   it('will work in strict mode', async () => {
@@ -803,13 +803,13 @@ describe('subcomponents', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
 
     await act(async () => {
       instance.label = 'Updated';
     });
 
-    screen.getByText('Updated');
+    expect(screen).toHaveText('Updated');
 
     element.unmount();
   });
@@ -842,15 +842,15 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('a: Hello');
-    screen.getByText('b: Hello');
+    expect(screen).toHaveText('a: Hello');
+    expect(screen).toHaveText('b: Hello');
 
     await act(async () => {
       instance.label = 'World';
     });
 
-    screen.getByText('a: World');
-    screen.getByText('b: World');
+    expect(screen).toHaveText('a: World');
+    expect(screen).toHaveText('b: World');
     expect(renders.a).toBeGreaterThan(1);
     expect(renders.b).toBeGreaterThan(1);
   });
@@ -880,8 +880,8 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('x');
-    screen.getByText('y');
+    expect(screen).toHaveText('x');
+    expect(screen).toHaveText('y');
 
     const before = { ...renders };
 
@@ -889,8 +889,8 @@ describe('subcomponents', () => {
       instance.x = 'x2';
     });
 
-    screen.getByText('x2');
-    screen.getByText('y');
+    expect(screen).toHaveText('x2');
+    expect(screen).toHaveText('y');
 
     // only the "a" instance should have re-rendered
     expect(renders.a).toBe(before.a + 1);
@@ -956,20 +956,20 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     await act(async () => {
       instance.foo = 'baz';
     });
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
 
     await act(async () => {
       instance.foo = 'qux';
     });
 
-    screen.getByText('qux');
+    expect(screen).toHaveText('qux');
     expect(didRender).toBeCalledWith('qux');
 
     element.unmount();
@@ -995,7 +995,7 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
     didRender.mockClear();
 
     rerender(
@@ -1006,7 +1006,7 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
   });
 

--- a/packages/preact/src/context.test.tsx
+++ b/packages/preact/src/context.test.tsx
@@ -102,7 +102,7 @@ describe('Provider', () => {
       </Provider>
     );
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     act(() => {
       element.rerender(
@@ -112,7 +112,7 @@ describe('Provider', () => {
       );
     });
 
-    screen.getByText('second');
+    expect(screen).toHaveText('second');
   });
 
   it('will provide children of given model', () => {
@@ -257,14 +257,14 @@ describe('Provider', () => {
         </Provider>
       );
 
-      element.getByText('Loading...');
+      expect(element).toHaveText('Loading...');
 
       await act(async () => {
         foo.value = 'Hello World';
       });
 
-      element.getByText('Hello World');
-      expect(element.queryByText('Loading...')).toBeNull();
+      expect(element).toHaveText('Hello World');
+      expect(element).not.toHaveText('Loading...');
     });
 
     // Differs from React here: after the outer boundary suspends, a
@@ -289,14 +289,14 @@ describe('Provider', () => {
       );
 
       // no Provider-level boundary - outer Suspense catches
-      element.getByText('Foo');
+      expect(element).toHaveText('Foo');
 
       await act(async () => {
         foo.value = 'Hello World';
       });
 
-      element.getByText('Hello World');
-      expect(element.queryByText('Foo')).toBeNull();
+      expect(element).toHaveText('Hello World');
+      expect(element).not.toHaveText('Foo');
     });
   });
 
@@ -378,7 +378,7 @@ describe('Consumer', () => {
 
     expect(didRender).toBeCalledWith('foo');
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
 
     await act(async () => {
       await instance.set({ value: 'bar' });
@@ -386,7 +386,7 @@ describe('Consumer', () => {
 
     expect(didRender).toBeCalledWith('bar');
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
   });
 
   it('will throw if not found', () => {
@@ -533,7 +533,7 @@ describe('get instruction', () => {
       </Provider>
     );
 
-    screen.getByText('foobar');
+    expect(screen).toHaveText('foobar');
   });
 });
 
@@ -613,7 +613,7 @@ describe('suspense', () => {
 
     render(<TestComponent />);
 
-    screen.getByText('Loading...');
+    expect(screen).toHaveText('Loading...');
 
     await act(async () => {
       resolve('hello!');
@@ -644,7 +644,7 @@ describe('HMR', () => {
       </Provider>
     );
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     Control = class Control2 extends Test {
       value = 'baz';
@@ -656,7 +656,7 @@ describe('HMR', () => {
       </Provider>
     );
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
 
     element.unmount();
   });

--- a/packages/preact/src/context.test.tsx
+++ b/packages/preact/src/context.test.tsx
@@ -4,6 +4,7 @@ import { mock, spyOn, afterAll, expect, it, describe } from 'bun:test';
 
 import { act, render, screen } from '@testing-library/preact';
 import { State, Consumer, Context, get, Provider, set } from '.';
+import { flushMicrotasks } from '../test.setup';
 
 const error = spyOn(console, 'error').mockImplementation(() => {});
 
@@ -321,7 +322,7 @@ describe('Provider', () => {
         </StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didCreate).toBeCalledTimes(1);
       expect(didDestroy).not.toBeCalled();
@@ -346,7 +347,7 @@ describe('Provider', () => {
         </StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(element.container.textContent).toBe('hello');
 

--- a/packages/preact/src/state.test.tsx
+++ b/packages/preact/src/state.test.tsx
@@ -35,7 +35,7 @@ describe('State.use', () => {
       });
 
       expect(result.current.value).toBe('foo');
-      expect(willRender).toBeCalledTimes(1);
+      expect(willRender).toBeCalled();
 
       result.current.value = 'bar';
 
@@ -116,7 +116,7 @@ describe('State.use', () => {
 
       const element = renderHook(() => Test.use());
 
-      expect(didUse).toBeCalledTimes(1);
+      expect(didUse).toBeCalled();
 
       element.rerender();
 
@@ -135,7 +135,7 @@ describe('State.use', () => {
       const callback = mock();
       const hook = renderHook(() => Test.use(callback));
 
-      expect(callback).toBeCalledTimes(1);
+      expect(callback).toBeCalled();
 
       hook.rerender(() => Test.use(callback));
 
@@ -433,8 +433,8 @@ describe('State.get', () => {
         });
       });
 
-      expect(didEvaluate).toBeCalledTimes(1);
-      expect(didRender).toBeCalledTimes(1);
+      expect(didEvaluate).toBeCalled();
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         forceUpdate();
@@ -464,7 +464,7 @@ describe('State.get', () => {
         });
       });
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(hook.result.current).toBeNull();
 
       await act(async () => {
@@ -537,7 +537,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(element.container.textContent).toBe('first');
 
       current = test2;
@@ -576,7 +576,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(element.container.textContent).toBe('first');
 
       current = test2;
@@ -666,7 +666,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       // remove Test from context, keep Other
       current = { other };
@@ -707,7 +707,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         parent.child = new Child({ value: 'replaced' });
@@ -746,7 +746,7 @@ describe('State.get', () => {
       );
 
       expect(element.container.textContent).toBe('original');
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       // replace child implicitly
       await act(async () => {
@@ -793,7 +793,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didCompute).toBeCalledTimes(1);
+      expect(didCompute).toBeCalled();
 
       current = test2;
 

--- a/packages/preact/src/state.test.tsx
+++ b/packages/preact/src/state.test.tsx
@@ -3,7 +3,7 @@ import { StrictMode, Suspense } from 'preact/compat';
 import { get, State, Provider, set } from '.';
 import { mock, spyOn, expect, it, describe, afterEach, afterAll } from 'bun:test';
 import { act, render, renderHook, waitFor } from '@testing-library/preact';
-import { mockPromise } from '../test.setup';
+import { mockPromise, flushMicrotasks } from '../test.setup';
 
 function renderWith<T>(Type: State.Type | State, hook: () => T) {
   return renderHook(hook, {
@@ -250,7 +250,7 @@ describe('State.use', () => {
         </StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didCreate).toBeCalledTimes(1);
       expect(didDestroy).not.toBeCalled();
@@ -285,7 +285,7 @@ describe('State.use', () => {
         </StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didRender).toBeCalledWith('foo');
 
@@ -867,7 +867,7 @@ describe('State.get', () => {
         </StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(element.container.textContent).toBe('foo');
 

--- a/packages/preact/src/use.test.tsx
+++ b/packages/preact/src/use.test.tsx
@@ -94,7 +94,7 @@ describe('use', () => {
       return use(test).foo;
     });
 
-    expect(didRender).toHaveBeenCalledTimes(1);
+    expect(didRender).toBeCalled();
 
     const before = didRender.mock.calls.length;
 
@@ -140,7 +140,7 @@ describe('use', () => {
     });
 
     expect(hook.result.current).toBe('first');
-    expect(didRender).toHaveBeenCalledTimes(1);
+    expect(didRender).toBeCalled();
 
     current = second;
 

--- a/packages/preact/test.setup.ts
+++ b/packages/preact/test.setup.ts
@@ -8,4 +8,4 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-export { mockError, mockPromise, mockWarn } from '../mvc/test.setup';
+export { mockError, mockPromise, mockWarn, flushMicrotasks } from '../mvc/test.setup';

--- a/packages/react/src/boundary.test.tsx
+++ b/packages/react/src/boundary.test.tsx
@@ -29,7 +29,7 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
   });
 
   it('will recover when catch resolves', async () => {
@@ -58,11 +58,11 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     await act(async () => resolve());
 
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
   });
 
   it('will restore fallback after catch resolves', async () => {
@@ -94,12 +94,12 @@ describe('error boundary', () => {
     await act(async () => {});
 
     // error boundary shows error-specific fallback
-    screen.getByText('Error Fallback');
+    expect(screen).toHaveText('Error Fallback');
 
     await act(async () => resolve());
 
     // error recovered, render works again
-    screen.getByText('initial');
+    expect(screen).toHaveText('initial');
 
     // suspend from render - fallback was restored so suspense uses default
     await act(async () => {
@@ -107,7 +107,7 @@ describe('error boundary', () => {
       instance.value = 'trigger';
     });
 
-    screen.getByText('Default Loading');
+    expect(screen).toHaveText('Default Loading');
   });
 
   it('will propagate if render throws after recovery', async () => {
@@ -145,13 +145,13 @@ describe('error boundary', () => {
 
     render(<Parent />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     // resolve catch but render will throw again
     await act(async () => resolve());
 
     // error propagated to parent boundary
-    screen.getByText('Parent Caught');
+    expect(screen).toHaveText('Parent Caught');
     expect(parentCatch).toBeCalledWith('boom');
   });
 
@@ -191,7 +191,7 @@ describe('error boundary', () => {
 
     await act(async () => {});
 
-    screen.getByText('Parent Caught');
+    expect(screen).toHaveText('Parent Caught');
     expect(parentCatch).toBeCalledWith('recovery failed');
   });
 
@@ -227,7 +227,7 @@ describe('error boundary', () => {
 
     render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
     expect(catchCount).toBe(1);
 
     // fix the error, then resolve catch
@@ -235,7 +235,7 @@ describe('error boundary', () => {
     await act(async () => resolve());
 
     // successful recovery
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
 
     // new error occurs later
     await act(async () => {
@@ -245,7 +245,7 @@ describe('error boundary', () => {
 
     // catch runs again for the new error
     expect(catchCount).toBe(2);
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
   });
 
   it('will pass error to catch', async () => {
@@ -298,7 +298,7 @@ describe('error boundary', () => {
 
     await act(async () => {});
 
-    screen.getByText('Recovered');
+    expect(screen).toHaveText('Recovered');
   });
 
   it('will restore fallback after sync catch', async () => {
@@ -327,14 +327,14 @@ describe('error boundary', () => {
     render(<Boundary />);
     await act(async () => {});
 
-    screen.getByText('initial');
+    expect(screen).toHaveText('initial');
 
     await act(async () => {
       throwing = new Promise(() => {});
       instance.value = 'trigger';
     });
 
-    screen.getByText('Default Loading');
+    expect(screen).toHaveText('Default Loading');
   });
 
   it('will call catch exactly once per thrown error', async () => {
@@ -388,7 +388,7 @@ describe('error boundary', () => {
 
     render(<Outer />);
 
-    screen.getByText('Caught by outer');
+    expect(screen).toHaveText('Caught by outer');
   });
 
   it('will not error if unmounted during catch', async () => {
@@ -416,7 +416,7 @@ describe('error boundary', () => {
 
     const element = render(<Boundary />);
 
-    screen.getByText('Oops');
+    expect(screen).toHaveText('Oops');
 
     await act(async () => element.unmount());
 
@@ -466,7 +466,7 @@ describe('error boundary', () => {
 
       const element = render(<Control />, { reactStrictMode });
 
-      screen.getByText('Oops');
+      expect(screen).toHaveText('Oops');
 
       const live = made.filter((c) => !disposed.has(c));
       expect(live).toHaveLength(1);
@@ -552,7 +552,7 @@ describe('discarded render (issue #118)', () => {
       );
     });
 
-    screen.getByText('loading');
+    expect(screen).toHaveText('loading');
     await act(async () => { pending.resolve(); });
 
     expect(observer(instance)!.listeners.size).toBe(baseline);

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -16,7 +16,7 @@ it('will create and provide instance', () => {
     </Control>
   );
 
-  screen.getByText('bar');
+  expect(screen).toHaveText('bar');
 });
 
 it('will not enumerate react internals on instance', () => {
@@ -185,10 +185,10 @@ describe('element props', () => {
     }
 
     const element = render(<Test callback={() => 'bar'} />);
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     element.rerender(<Test callback={() => 'baz'} />);
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
   });
 
   it('will not assign foreign values', () => {
@@ -219,8 +219,8 @@ describe('element children', () => {
       </Control>
     );
 
-    screen.getByText('Hello');
-    screen.getByText('World');
+    expect(screen).toHaveText('Hello');
+    expect(screen).toHaveText('World');
   });
 
   it('will notify parent', async () => {
@@ -231,7 +231,7 @@ describe('element children', () => {
     const didUpdate = mock();
     const screen = render(<Control>Hello</Control>);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
     expect(didUpdate).toBeCalled();
   });
 
@@ -247,7 +247,7 @@ describe('element children', () => {
 
     const screen = render(<Control>{symbol}</Control>);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
   });
 });
 
@@ -260,10 +260,10 @@ describe('props property', () => {
     }
 
     const { rerender } = render(<Control value="foo" />);
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
 
     rerender(<Control value="bar" />);
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
   });
 
   it('will be observable', async () => {
@@ -337,8 +337,8 @@ describe('render method', () => {
 
     const screen = render(<Control bar="foo" />);
 
-    screen.getByText('foo');
-    screen.getByText('bar');
+    expect(screen).toHaveText('foo');
+    expect(screen).toHaveText('bar');
   });
 
   it('will accept function component', async () => {
@@ -360,11 +360,11 @@ describe('render method', () => {
 
     const screen = render(<ClassComponent name="World" />);
 
-    screen.getByText('Hello World');
+    expect(screen).toHaveText('Hello World');
 
     screen.rerender(<ClassComponent salutation="Bonjour" name="React" />);
 
-    screen.getByText('Bonjour React');
+    expect(screen).toHaveText('Bonjour React');
   });
 
   it('will ignore children not handled', () => {
@@ -380,8 +380,8 @@ describe('render method', () => {
       <Control value="Goodbye">Hello</Control>
     );
 
-    screen.getByText('Goodbye');
-    expect(screen.queryByText('Hello')).toBe(null);
+    expect(screen).toHaveText('Goodbye');
+    expect(screen).not.toHaveText('Hello');
   });
 
   it('will accept all-optional render props', () => {
@@ -398,7 +398,7 @@ describe('render method', () => {
 
     const screen = render(<Control base="home" />);
 
-    screen.getByText('home');
+    expect(screen).toHaveText('home');
   });
 
   it('will handle children if managed by this', () => {
@@ -417,8 +417,8 @@ describe('render method', () => {
 
     const screen = render(<Control value="Hello">World</Control>);
 
-    screen.getByText('Hello');
-    screen.getByText('World');
+    expect(screen).toHaveText('Hello');
+    expect(screen).toHaveText('World');
   });
 
   it('will refresh on update', async () => {
@@ -433,14 +433,14 @@ describe('render method', () => {
     let control: Control;
     const screen = render(<Control is={(x) => (control = x)} />);
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     await act(async () => {
       control.value = 'foo';
       await control.set();
     });
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
   });
 });
 
@@ -460,11 +460,11 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => (foo.value = 'Hello World'));
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('will fallback when own render suspends', async () => {
@@ -480,13 +480,13 @@ describe('suspense', () => {
 
     const element = render(<Foo is={(x) => (foo = x)} />);
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     await act(async () => {
       foo.value = 'Hello World';
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('will use fallback property first', async () => {
@@ -504,7 +504,7 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     element.rerender(
       <Foo fallback={<span>Loading...</span>}>
@@ -512,13 +512,13 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('fallback === false opts out of the boundary, bubbling to an ancestor', async () => {
@@ -543,11 +543,11 @@ describe('suspense', () => {
     );
 
     // own boundary opted out -> child suspension bubbles to the ancestor
-    element.getByText('OUTER');
+    expect(element).toHaveText('OUTER');
 
     await act(async () => { ready.resolve(); });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 
   it('default boundary catches its own subtree (control for opt-out)', () => {
@@ -566,7 +566,7 @@ describe('suspense', () => {
     );
 
     // own boundary catches - never reaches OUTER
-    element.getByText('INNER');
+    expect(element).toHaveText('INNER');
   });
 
   it('will update with new fallback', async () => {
@@ -584,21 +584,21 @@ describe('suspense', () => {
       </Foo>
     );
 
-    element.getByText('Loading!');
+    expect(element).toHaveText('Loading!');
 
     await act(async () => {
       foo.fallback = <span>Loading...</span>;
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    element.getByText('Loading...');
+    expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    element.getByText('Hello World');
+    expect(element).toHaveText('Hello World');
   });
 });
 
@@ -635,11 +635,11 @@ describe('state props on rerender', () => {
 
     const element = render(<Control value="first" />);
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     element.rerender(<Control value="second" />);
 
-    screen.getByText('second');
+    expect(screen).toHaveText('second');
   });
 
   it('will clear omitted instance value', () => {
@@ -653,11 +653,11 @@ describe('state props on rerender', () => {
 
     const element = render(<Control value="first" />);
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     element.rerender(<Control />);
 
-    screen.getByText('empty');
+    expect(screen).toHaveText('empty');
   });
 
   it('will ignore update after instance destroyed', async () => {
@@ -672,13 +672,13 @@ describe('state props on rerender', () => {
     let instance!: Control;
     const view = render(<Control value="bar" is={(c) => (instance = c)} />);
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     await act(async () => instance.set(null));
 
     view.rerender(<Control value="baz" />);
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
   });
 });
 
@@ -692,7 +692,7 @@ describe('default render', () => {
       </Control>
     );
 
-    screen.getByText('Hello World');
+    expect(screen).toHaveText('Hello World');
   });
 
   it('will provide instance created', () => {
@@ -707,7 +707,7 @@ describe('default render', () => {
       </Parent>
     );
 
-    element.getByText('foobar');
+    expect(element).toHaveText('foobar');
   });
 });
 
@@ -795,8 +795,8 @@ describe('render chain', () => {
     let instance!: Page;
     render(<Page is={(x) => (instance = x)} />);
 
-    screen.getByText('Base');
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Base');
+    expect(screen).toHaveText('Hello');
 
     // Both the super's and the subclass's reactive reads drive updates.
     await act(async () => {
@@ -804,8 +804,8 @@ describe('render chain', () => {
       instance.body = 'World';
     });
 
-    screen.getByText('Updated');
-    screen.getByText('World');
+    expect(screen).toHaveText('Updated');
+    expect(screen).toHaveText('World');
   });
 
   it('will drop derived content if wrapper omits children', () => {
@@ -825,8 +825,8 @@ describe('render chain', () => {
 
     const element = render(<Lost />);
 
-    element.getByText('Shell only');
-    expect(element.queryByText('Never seen')).toBeNull();
+    expect(element).toHaveText('Shell only');
+    expect(element).not.toHaveText('Never seen');
   });
 
   it('will preserve identity for single-level override', () => {
@@ -863,13 +863,13 @@ describe('subcomponents', () => {
     let instance!: Control;
     const view = render(<Control is={(c) => (instance = c)} />);
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
 
     await act(async () => instance.set(null));
 
     view.rerender(<Control />);
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
     expect(error).not.toBeCalled();
   });
 
@@ -889,13 +889,13 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
 
     await act(async () => {
       instance.label = 'Updated';
     });
 
-    screen.getByText('Updated');
+    expect(screen).toHaveText('Updated');
   });
 
   it('will be accessible via context get', () => {
@@ -920,7 +920,7 @@ describe('subcomponents', () => {
       </Dashboard>
     );
 
-    screen.getByText('Sidebar Content');
+    expect(screen).toHaveText('Sidebar Content');
   });
 
   it('will work with assigned function', async () => {
@@ -954,13 +954,13 @@ describe('subcomponents', () => {
 
     render(<MyDashboard />);
 
-    screen.getByText('Sidebar value');
+    expect(screen).toHaveText('Sidebar value');
 
     await act(async () => {
       dashboard.content = 'updated';
     });
 
-    screen.getByText('Sidebar updated');
+    expect(screen).toHaveText('Sidebar updated');
   });
 
   it('will allow override via setter', async () => {
@@ -979,7 +979,7 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('Original');
+    expect(screen).toHaveText('Original');
 
     await act(async () => {
       instance.Sidebar = function (this: Dashboard) {
@@ -988,7 +988,7 @@ describe('subcomponents', () => {
       instance.value = 'yes';
     });
 
-    screen.getByText('Replaced: yes');
+    expect(screen).toHaveText('Replaced: yes');
   });
 
   it('will inherit from parent class', () => {
@@ -1006,7 +1006,7 @@ describe('subcomponents', () => {
 
     render(<Page />);
 
-    screen.getByText('Header');
+    expect(screen).toHaveText('Header');
   });
 
   it('will compose elements from subclass', () => {
@@ -1042,9 +1042,9 @@ describe('subcomponents', () => {
 
     const element = render(<Page />);
 
-    element.getByText('Header');
-    element.getByText('Main');
-    element.getByText('Footer');
+    expect(element).toHaveText('Header');
+    expect(element).toHaveText('Main');
+    expect(element).toHaveText('Footer');
   });
 
   it('will accept props', () => {
@@ -1060,7 +1060,7 @@ describe('subcomponents', () => {
 
     render(<Dashboard />);
 
-    screen.getByText('Dynamic Label');
+    expect(screen).toHaveText('Dynamic Label');
   });
 
   it('will work in strict mode', async () => {
@@ -1085,13 +1085,13 @@ describe('subcomponents', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('Hello');
+    expect(screen).toHaveText('Hello');
 
     await act(async () => {
       instance.label = 'Updated';
     });
 
-    screen.getByText('Updated');
+    expect(screen).toHaveText('Updated');
 
     element.unmount();
   });
@@ -1124,15 +1124,15 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('a: Hello');
-    screen.getByText('b: Hello');
+    expect(screen).toHaveText('a: Hello');
+    expect(screen).toHaveText('b: Hello');
 
     await act(async () => {
       instance.label = 'World';
     });
 
-    screen.getByText('a: World');
-    screen.getByText('b: World');
+    expect(screen).toHaveText('a: World');
+    expect(screen).toHaveText('b: World');
     expect(renders.a).toBeGreaterThan(1);
     expect(renders.b).toBeGreaterThan(1);
   });
@@ -1162,8 +1162,8 @@ describe('subcomponents', () => {
     let instance!: Dashboard;
     render(<Dashboard is={(x) => (instance = x)} />);
 
-    screen.getByText('x');
-    screen.getByText('y');
+    expect(screen).toHaveText('x');
+    expect(screen).toHaveText('y');
 
     const before = { ...renders };
 
@@ -1171,8 +1171,8 @@ describe('subcomponents', () => {
       instance.x = 'x2';
     });
 
-    screen.getByText('x2');
-    screen.getByText('y');
+    expect(screen).toHaveText('x2');
+    expect(screen).toHaveText('y');
 
     // only the "a" instance should have re-rendered
     expect(renders.a).toBe(before.a + 1);
@@ -1235,20 +1235,20 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     await act(async () => {
       instance.foo = 'baz';
     });
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
 
     await act(async () => {
       instance.foo = 'qux';
     });
 
-    screen.getByText('qux');
+    expect(screen).toHaveText('qux');
     expect(didRender).toBeCalledWith('qux');
 
     element.unmount();
@@ -1274,7 +1274,7 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
     didRender.mockClear();
 
     rerender(
@@ -1285,7 +1285,7 @@ describe('strict mode', () => {
 
     await new Promise((r) => setTimeout(r, 0));
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
   });
 

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import { mock, expect, it, describe } from 'bun:test';
 import React from 'react';
 
-import { mockError, mockPromise } from '../test.setup';
+import { mockError, mockPromise, flushMicrotasks } from '../test.setup';
 import { Component, Consumer, set } from '.';
 
 it('will create and provide instance', () => {
@@ -588,14 +588,14 @@ describe('suspense', () => {
 
     await act(async () => {
       foo.fallback = <span>Loading...</span>;
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
     });
 
     expect(element).toHaveText('Loading...');
 
     await act(async () => {
       foo.value = 'Hello World';
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
     });
 
     expect(element).toHaveText('Hello World');
@@ -1083,7 +1083,7 @@ describe('subcomponents', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('Hello');
 
@@ -1200,7 +1200,7 @@ describe('strict mode', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(didCreate).toBeCalledTimes(1);
     expect(didDestroy).not.toBeCalled();
@@ -1233,7 +1233,7 @@ describe('strict mode', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('bar');
 
@@ -1272,7 +1272,7 @@ describe('strict mode', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('bar');
     didRender.mockClear();
@@ -1283,7 +1283,7 @@ describe('strict mode', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(screen).toHaveText('baz');
     expect(didRender).toBeCalledWith('baz');
@@ -1345,7 +1345,7 @@ describe('strict mode', () => {
       </React.StrictMode>
     );
 
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMicrotasks();
 
     expect(order).toEqual(['construct', 'construct', 'init']);
 

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -41,7 +41,7 @@ it('will create instance only once', () => {
   const didConstruct = mock();
   const { rerender } = render(<Control />);
 
-  expect(didConstruct).toBeCalledTimes(1);
+  expect(didConstruct).toBeCalled();
 
   rerender(<Control />);
 
@@ -55,7 +55,7 @@ it('will call is method on creation', () => {
 
   const screen = render(<Control is={didCreate} />);
 
-  expect(didCreate).toBeCalledTimes(1);
+  expect(didCreate).toBeCalled();
 
   screen.rerender(<Control is={didCreate} />);
   expect(didCreate).toBeCalledTimes(1);
@@ -85,7 +85,7 @@ describe('ref prop', () => {
     const cb = mock();
     const screen = render(<Control ref={cb} />);
 
-    expect(cb).toBeCalledTimes(1);
+    expect(cb).toBeCalled();
     expect(cb.mock.calls[0][0]).toBeInstanceOf(Control);
 
     act(screen.unmount);
@@ -310,7 +310,7 @@ describe('props property', () => {
 
     const { rerender } = render(<Control value="foo" />);
 
-    expect(didRender).toBeCalledTimes(1);
+    expect(didRender).toBeCalled();
 
     rerender(<Control value="bar" />);
 

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -136,7 +136,7 @@ describe('Provider', () => {
       </Provider>
     );
 
-    screen.getByText('first');
+    expect(screen).toHaveText('first');
 
     act(() => {
       element.rerender(
@@ -146,7 +146,7 @@ describe('Provider', () => {
       );
     });
 
-    screen.getByText('second');
+    expect(screen).toHaveText('second');
   });
 
   it('will pass props to instance', () => {
@@ -331,14 +331,14 @@ describe('Provider', () => {
         </Provider>
       );
 
-      element.getByText('Loading...');
+      expect(element).toHaveText('Loading...');
 
       await act(async () => {
         foo.value = 'Hello World';
       });
 
-      element.getByText('Hello World');
-      expect(element.queryByText('Loading...')).toBeNull();
+      expect(element).toHaveText('Hello World');
+      expect(element).not.toHaveText('Loading...');
     });
 
     it('will ignore suspense if undefined', () => {
@@ -367,8 +367,8 @@ describe('Provider', () => {
         </Suspense>
       );
 
-      element.getByText('Bar');
-      expect(element.queryByText('Foo')).toBeNull();
+      expect(element).toHaveText('Bar');
+      expect(element).not.toHaveText('Foo');
     });
   });
 
@@ -447,7 +447,7 @@ describe('Consumer', () => {
 
     expect(didRender).toBeCalledWith('foo');
 
-    screen.getByText('foo');
+    expect(screen).toHaveText('foo');
 
     await act(async () => {
       return instance.set({ value: 'bar' });
@@ -455,7 +455,7 @@ describe('Consumer', () => {
 
     expect(didRender).toBeCalledWith('bar');
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
   });
 
   it('will throw if not found', () => {
@@ -679,7 +679,7 @@ describe('get instruction', () => {
       </Provider>
     );
 
-    screen.getByText('foobar');
+    expect(screen).toHaveText('foobar');
   });
 });
 
@@ -759,7 +759,7 @@ describe('suspense', () => {
 
     render(<TestComponent />);
 
-    screen.getByText('Loading...');
+    expect(screen).toHaveText('Loading...');
 
     await act(async () => {
       resolve('hello!');
@@ -790,7 +790,7 @@ describe('HMR', () => {
       </Provider>
     );
 
-    screen.getByText('bar');
+    expect(screen).toHaveText('bar');
 
     Control = class Control2 extends Test {
       value = 'baz';
@@ -802,7 +802,7 @@ describe('HMR', () => {
       </Provider>
     );
 
-    screen.getByText('baz');
+    expect(screen).toHaveText('baz');
 
     element.unmount();
   });

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -3,6 +3,7 @@ import { mock, spyOn, afterAll, expect, it, describe } from 'bun:test';
 
 import { act, render, screen } from '@testing-library/react';
 import { State, Consumer, Context, get, Provider, set } from '.';
+import { flushMicrotasks } from '../test.setup';
 
 const error = spyOn(console, 'error').mockImplementation(() => {});
 
@@ -390,7 +391,7 @@ describe('Provider', () => {
         </React.StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didCreate).toBeCalledTimes(1);
       expect(didDestroy).not.toBeCalled();
@@ -415,7 +416,7 @@ describe('Provider', () => {
         </React.StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(element.container.textContent).toBe('hello');
 

--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -192,7 +192,7 @@ describe('use', () => {
       return use(test).foo;
     });
 
-    expect(didRender).toHaveBeenCalledTimes(1);
+    expect(didRender).toBeCalled();
 
     const before = didRender.mock.calls.length;
 
@@ -238,7 +238,7 @@ describe('use', () => {
     });
 
     expect(hook.result.current).toBe('first');
-    expect(didRender).toHaveBeenCalledTimes(1);
+    expect(didRender).toBeCalled();
 
     current = second;
 

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -284,7 +284,7 @@ describe('State.get', () => {
       const test = Test.new();
       const hook = renderWith(test, didRender);
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(hook.result.current).toBeNull();
 
       test.foo = 2;
@@ -355,8 +355,8 @@ describe('State.get', () => {
         });
       });
 
-      expect(didEvaluate).toBeCalledTimes(1);
-      expect(didRender).toBeCalledTimes(1);
+      expect(didEvaluate).toBeCalled();
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         forceUpdate();
@@ -381,8 +381,8 @@ describe('State.get', () => {
         });
       });
 
-      expect(didEvaluate).toBeCalledTimes(1);
-      expect(didRender).toBeCalledTimes(1);
+      expect(didEvaluate).toBeCalled();
+      expect(didRender).toBeCalled();
 
       act(forceUpdate);
 
@@ -405,7 +405,7 @@ describe('State.get', () => {
       });
 
       expect<null>(result.current).toBe(null);
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         forceUpdate(promise);
@@ -434,7 +434,7 @@ describe('State.get', () => {
         });
       });
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         forceUpdate(() => promise);
@@ -480,7 +480,7 @@ describe('State.get', () => {
         });
       });
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(hook.result.current).toBeNull();
 
       await act(async () => {
@@ -547,7 +547,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(element.container.textContent).toBe('first');
 
       current = test2;
@@ -586,7 +586,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
       expect(element.container.textContent).toBe('first');
 
       current = test2;
@@ -676,7 +676,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       // remove Test from context, keep Other
       current = { other };
@@ -717,7 +717,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       await act(async () => {
         parent.child = new Child({ value: 'replaced' });
@@ -756,7 +756,7 @@ describe('State.get', () => {
       );
 
       expect(element.container.textContent).toBe('original');
-      expect(didRender).toBeCalledTimes(1);
+      expect(didRender).toBeCalled();
 
       // replace child implicitly
       await act(async () => {
@@ -799,7 +799,7 @@ describe('State.get', () => {
         </Provider>
       );
 
-      expect(didCompute).toBeCalledTimes(1);
+      expect(didCompute).toBeCalled();
 
       current = test2;
 

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { Component, get, State, Provider, set } from '.';
 import { mock, spyOn, expect, it, describe, afterEach, afterAll } from 'bun:test';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
-import { mockPromise } from '../test.setup';
+import { mockPromise, flushMicrotasks } from '../test.setup';
 
 function renderWith<T>(Type: State.Type | State, hook: () => T) {
   return renderHook(hook, {
@@ -968,7 +968,7 @@ describe('State.get', () => {
         </React.StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(element.container.textContent).toBe('foo');
 

--- a/packages/react/src/state.use.test.tsx
+++ b/packages/react/src/state.use.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, expect, it, mock } from 'bun:test';
 import { State, Provider, get, set } from '.';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
+import { flushMicrotasks } from '../test.setup';
 
 describe('State.use', () => {
   class Test extends State {
@@ -420,7 +421,7 @@ describe('State.use', () => {
         </React.StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didCreate).toBeCalledTimes(1);
       expect(didDestroy).not.toBeCalled();
@@ -455,7 +456,7 @@ describe('State.use', () => {
         </React.StrictMode>
       );
 
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMicrotasks();
 
       expect(didRender).toBeCalledWith('foo');
 

--- a/packages/react/src/state.use.test.tsx
+++ b/packages/react/src/state.use.test.tsx
@@ -23,7 +23,7 @@ describe('State.use', () => {
       });
 
       expect(result.current.value).toBe('foo');
-      expect(willRender).toBeCalledTimes(1);
+      expect(willRender).toBeCalled();
 
       result.current.value = 'bar';
 
@@ -149,7 +149,7 @@ describe('State.use', () => {
 
       const element = renderHook(() => Test.use());
 
-      expect(didUse).toBeCalledTimes(1);
+      expect(didUse).toBeCalled();
 
       element.rerender();
 
@@ -214,7 +214,7 @@ describe('State.use', () => {
       const callback = mock();
       const hook = renderHook(() => Test.use(callback));
 
-      expect(callback).toBeCalledTimes(1);
+      expect(callback).toBeCalled();
 
       hook.rerender(() => Test.use(callback));
 

--- a/packages/react/test.setup.ts
+++ b/packages/react/test.setup.ts
@@ -8,4 +8,4 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-export { mockError, mockPromise, mockWarn } from '../mvc/test.setup';
+export { mockError, mockPromise, mockWarn, flushMicrotasks } from '../mvc/test.setup';


### PR DESCRIPTION
Test-only cleanup. No production code or behavior changes; no changeset.

- Add `toHaveText` matcher and sweep `getByText` assertions over to it
- Relax brittle initial-fire `toBeCalledTimes(1)` assertions to `toBeCalled`
- Extract a `flushMicrotasks` helper for queue-drain waits

All packages green.