### PR TITLE
fix(router): clear stale redirect-guard verdict on route cede

### DIFF
--- a/.changeset/fix-redirect-guard-cache-stale.md
+++ b/.changeset/fix-redirect-guard-cache-stale.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": patch
+---
+
+Fix stale redirect-guard verdict when a guarded route is reused across out-and-in navigation. A route that cedes to a sibling under a persistent parent now clears its cached guard verdict, so re-entry re-runs the guard instead of reusing a stale result or hanging on a settled async promise.

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -925,6 +925,62 @@ describe('Route', () => {
           expect(screen.getByText('secret')).toBeDefined();
           expect(ran).toBe(2);
         });
+
+        it('re-runs the redirect on re-entry under a persistent parent', async () => {
+          location('/admin/secret');
+          let ran = 0;
+          const redirect = () => { ran++; return undefined; };
+          const Layout = (props: { children?: React.ReactNode }) => <main>{props.children}</main>;
+          await act(async () => {
+            render(
+              <Route to="/admin/*" as={Layout}>
+                <Route to="secret" redirect={redirect} as={() => <h1>secret</h1>} />
+                <Route to="open" as={() => <h1>open</h1>} />
+              </Route>
+            );
+          });
+          expect(ran).toBe(1);
+          expect(screen.getByText('secret')).toBeDefined();
+
+          await act(async () => router.current.goto('/admin/open'));
+          expect(screen.getByText('open')).toBeDefined();
+
+          await act(async () => router.current.goto('/admin/secret'));
+          expect(screen.getByText('secret')).toBeDefined();
+          expect(ran).toBe(2);
+        });
+
+        it('re-runs an async redirect on re-entry under a persistent parent', async () => {
+          location('/admin/secret');
+          let ran = 0;
+          let gate = mockPromise<string | void>();
+          const redirect = () => { ran++; return gate; };
+          const Layout = (props: { children?: React.ReactNode }) => <main>{props.children}</main>;
+          await act(async () => {
+            render(
+              <Route to="/admin/*" as={Layout}>
+                <Route to="secret" fallback={<h1>checking</h1>} redirect={redirect} as={() => <h1>secret</h1>} />
+                <Route to="open" as={() => <h1>open</h1>} />
+              </Route>
+            );
+          });
+          expect(screen.getByText('checking')).toBeDefined();
+
+          await act(async () => gate.resolve(undefined));
+          expect(screen.getByText('secret')).toBeDefined();
+          expect(ran).toBe(1);
+
+          await act(async () => router.current.goto('/admin/open'));
+          expect(screen.getByText('open')).toBeDefined();
+
+          gate = mockPromise<string | void>();
+          await act(async () => router.current.goto('/admin/secret'));
+          expect(screen.getByText('checking')).toBeDefined();
+          expect(ran).toBe(2);
+
+          await act(async () => gate.resolve(undefined));
+          expect(screen.getByText('secret')).toBeDefined();
+        });
       });
 
       describe('force-404 (null verdict)', () => {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -219,6 +219,9 @@ export class Route extends Component {
   render(props = {} as { children?: Component.Node }): Component.Node {
     const { as: Component, is: self, matched, parent, redirect, router } = this;
 
+    if (!matched && typeof redirect === 'function')
+      GUARD.delete(self);
+
     if (parent) {
       register(parent.is, self);
 


### PR DESCRIPTION
## Problem

An async (or sync-redirecting) `redirect` guard reused across out-and-in navigation went stale, with two symptoms:
- the guard didn't re-run on re-entry (stale verdict reused, e.g. no re-prompt)
- the route hung blank on re-entry (a settled async promise re-thrown to Suspense)

## Root cause

`GUARD` (the per-route verdict cache) was only invalidated **inside** `guard()` (`route.tsx`). But `render()` has earlier exit paths that never reach that call — specifically the **cede** branch, where a route returns `null` because a sibling claimed the path. A guarded route nested under a parent that stays mounted cedes on out-and-in navigation *without unmounting*, so its WeakMap entry was never cleared. On re-entry `guard()` saw a stale `g`: a settled `g.to` (returned without re-running) or a settled `g.promise` (re-thrown, never resolves → blank hang).

This requires **instance reuse** — a fresh-mount path creates a new Route instance with an empty WeakMap, which is why it only surfaced under a persistent parent.

## Fix

One line at the top of `render()`, before any early return: clear the cache whenever the route is unmatched and has a function guard. Reliable regardless of which exit path render takes — no longer dependent on render *reaching* the guard call.

`guard()`'s own `!matched` check stays — it's load-bearing (prevents *running* the guard while unmatched), not redundant with the new clear.

### Why not drop caching entirely

The cache is structurally required for the async path: when a thrown promise resolves, React re-renders and calls the guard again; without remembering the settled verdict the re-render re-runs `redirect()`, throws a new promise, and suspends forever.

## Tests

Two new cases under `redirect prop > functional guard > caching`, both failing before the fix, both under a persistent parent (so the child Route instance is reused on out-and-in nav):
- sync guard re-runs on re-entry (`ran` was stuck at 1)
- async guard re-runs on re-entry with no hang

The existing "re-runs the guard on re-entry" test passed pre-fix only because it fully unmounts the route.
