### PR TITLE
fix(website): repair examples playground routing, navbar, and sandbox layout

### DIFF
--- a/examples/2-advanced/1-tictactoe/App.tsx
+++ b/examples/2-advanced/1-tictactoe/App.tsx
@@ -14,7 +14,7 @@ const LINES = [
 ];
 
 class Game extends Component {
-  board: string[] = hot(Array(9).fill(''));
+  readonly board: string[] = hot(Array(9).fill(''));
   turn: 'X' | 'O' = 'X';
 
   get winner() {
@@ -40,7 +40,7 @@ class Game extends Component {
   }
 
   reset() {
-    this.board = Array(9).fill("");
+    this.board.fill("");
     this.turn = 'X';
   }
 

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -11,8 +11,12 @@ import { useTheme } from 'next-themes';
 import type { MouseEvent as ReactMouseEvent } from 'react';
 
 class Panes extends State {
-  panel: 'preview' | 'code' = 'preview';
+  mode: 'preview' | 'code' = 'preview';
   ratio = 50; // editor width (%) when both panels are side by side
+
+  onSelect(is: typeof this.mode){
+    this.mode = is;
+  }
 
   grab(event: ReactMouseEvent) {
     event.preventDefault();
@@ -57,15 +61,22 @@ export default function Sandbox({
 }
 
 function Layout() {
-  const { dispatch } = useSandpack();
-  const panes = Panes.use();
-  const { panel, ratio, grab } = panes;
+  const { onSelect, mode, ratio, grab } = Panes.use();
+  const sandpack = useSandpack();
+  const refreshOnSave = {
+    key: 'Mod-s',
+    preventDefault: true,
+    run() {
+      sandpack.dispatch({ type: 'refresh' });
+      return true;
+    }
+  }
 
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
   const narrow = useMediaQuery('(max-width: 767px)');
-  const showEditor = !narrow || panel === 'code';
-  const showPreview = !narrow || panel === 'preview';
+  const showEditor = !narrow || mode === 'code';
+  const showPreview = !narrow || mode === 'preview';
 
   position: relative;
   height: '100%';
@@ -86,21 +97,12 @@ function Layout() {
     <SandpackLayout>
       <SandpackCodeEditor
         style={{ display: showEditor ? 'flex' : 'none', flex: narrow ? '1' : `0 0 ${ratio}%` }}
-        extensionsKeymap={[
-          {
-            key: 'Mod-s',
-            preventDefault: true,
-            run() {
-              dispatch({ type: 'refresh' });
-              return true;
-            }
-          }
-        ]}
+        extensionsKeymap={[refreshOnSave]}
       />
       {!narrow && <div _handle onMouseDown={grab} />}
       <SandpackPreview style={{ display: showPreview ? 'flex' : 'none', flex: '1 1 0%' }} />
       {narrow && (
-        <Switcher panel={panel} onSelect={(value) => (panes.panel = value)} />
+        <Switcher panel={mode} onSelect={onSelect} />
       )}
     </SandpackLayout>
   );

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -5,8 +5,32 @@ import {
   SandpackProvider,
   useSandpack
 } from '@codesandbox/sandpack-react';
+import State from '@expressive/react';
 import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+class Panes extends State {
+  panel: 'preview' | 'code' = 'preview';
+  ratio = 50; // editor width (%) when both panels are side by side
+
+  grab(event: ReactMouseEvent) {
+    event.preventDefault();
+    const rect = event.currentTarget.parentElement!.getBoundingClientRect();
+
+    const move = (e: globalThis.MouseEvent) => {
+      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+      this.ratio = Math.min(80, Math.max(20, pct));
+    };
+    const up = () => {
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseup', up);
+    };
+
+    document.addEventListener('mousemove', move);
+    document.addEventListener('mouseup', up);
+  }
+}
 
 export default function Sandbox({
   name,
@@ -34,22 +58,34 @@ export default function Sandbox({
 
 function Layout() {
   const { dispatch } = useSandpack();
-  const [view, setView] = useState<'preview' | 'code'>('preview');
+  const panes = Panes.use();
+  const { panel, ratio, grab } = panes;
 
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
   const narrow = useMediaQuery('(max-width: 767px)');
-  const showEditor = !narrow || view === 'code';
-  const showPreview = !narrow || view === 'preview';
+  const showEditor = !narrow || panel === 'code';
+  const showPreview = !narrow || panel === 'preview';
 
   position: relative;
   height: '100%';
   $spLayoutHeight: '100%';
 
+  handle: {
+    flexShrink: 0;
+    width: 6;
+    cursor: "col-resize";
+    background: $colorFdBorder;
+
+    $hover: {
+      background: $colorFdPrimary;
+    }
+  }
+
   return (
     <SandpackLayout>
       <SandpackCodeEditor
-        style={{ display: showEditor ? 'flex' : 'none' }}
+        style={{ display: showEditor ? 'flex' : 'none', flex: narrow ? '1' : `0 0 ${ratio}%` }}
         extensionsKeymap={[
           {
             key: 'Mod-s',
@@ -61,18 +97,21 @@ function Layout() {
           }
         ]}
       />
-      <SandpackPreview style={{ display: showPreview ? 'flex' : 'none' }} />
-      {narrow && <Switcher view={view} setView={setView} />}
+      {!narrow && <div _handle onMouseDown={grab} />}
+      <SandpackPreview style={{ display: showPreview ? 'flex' : 'none', flex: '1 1 0%' }} />
+      {narrow && (
+        <Switcher panel={panel} onSelect={(value) => (panes.panel = value)} />
+      )}
     </SandpackLayout>
   );
 }
 
 function Switcher({
-  view,
-  setView
+  panel,
+  onSelect
 }: {
-  view: 'preview' | 'code';
-  setView: (v: 'preview' | 'code') => void;
+  panel: 'preview' | 'code';
+  onSelect: (v: 'preview' | 'code') => void;
 }) {
   position: absolute;
   top: 8;
@@ -102,10 +141,10 @@ function Switcher({
 
   return (
     <div>
-      <button _button aria-pressed={view === 'code'} onClick={() => setView('code')}>
+      <button _button aria-pressed={panel === 'code'} onClick={() => onSelect('code')}>
         Code
       </button>
-      <button _button aria-pressed={view === 'preview'} onClick={() => setView('preview')}>
+      <button _button aria-pressed={panel === 'preview'} onClick={() => onSelect('preview')}>
         Preview
       </button>
     </div>

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -5,6 +5,7 @@ import {
   SandpackProvider,
   useSandpack
 } from '@codesandbox/sandpack-react';
+import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 
 export default function Sandbox({
@@ -33,13 +34,22 @@ export default function Sandbox({
 
 function Layout() {
   const { dispatch } = useSandpack();
+  const [view, setView] = useState<'preview' | 'code'>('preview');
 
-  $spLayoutHeight: '100%';
+  // Below the breakpoint the panels can't fit side by side; show one at a time
+  // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
+  const narrow = useMediaQuery('(max-width: 767px)');
+  const showEditor = !narrow || view === 'code';
+  const showPreview = !narrow || view === 'preview';
+
+  position: relative;
   height: '100%';
+  $spLayoutHeight: '100%';
 
   return (
     <SandpackLayout>
       <SandpackCodeEditor
+        style={{ display: showEditor ? 'flex' : 'none' }}
         extensionsKeymap={[
           {
             key: 'Mod-s',
@@ -51,7 +61,68 @@ function Layout() {
           }
         ]}
       />
-      <SandpackPreview />
+      <SandpackPreview style={{ display: showPreview ? 'flex' : 'none' }} />
+      {narrow && <Switcher view={view} setView={setView} />}
     </SandpackLayout>
   );
+}
+
+function Switcher({
+  view,
+  setView
+}: {
+  view: 'preview' | 'code';
+  setView: (v: 'preview' | 'code') => void;
+}) {
+  position: absolute;
+  top: 8;
+  right: 8;
+  zIndex: 10;
+  display: flex;
+  gap: 2;
+  padding: 2;
+  borderRadius: 6;
+  border: $colorFdBorder;
+  background: $colorFdBackground;
+
+  button: {
+    padding: 4, 10;
+    fontSize: 0.75;
+    borderRadius: 4;
+    border: none;
+    background: none;
+    color: $colorFdMutedForeground;
+    cursor: pointer;
+
+    if("[aria-pressed='true']") {
+      background: $colorFdMuted;
+      color: $colorFdForeground;
+    }
+  }
+
+  return (
+    <div>
+      <button _button aria-pressed={view === 'code'} onClick={() => setView('code')}>
+        Code
+      </button>
+      <button _button aria-pressed={view === 'preview'} onClick={() => setView('preview')}>
+        Preview
+      </button>
+    </div>
+  );
+}
+
+function useMediaQuery(query: string) {
+  const [match, setMatch] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const update = () => setMatch(media.matches);
+
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, [query]);
+
+  return match;
 }

--- a/website/app/routes.ts
+++ b/website/app/routes.ts
@@ -4,7 +4,7 @@ export default [
   index("routes/home/index.tsx"),
   route("docs/*", "routes/docs.tsx"),
   route("examples", "routes/examples/layout.tsx", [
-    route(":name?", "routes/examples/view.tsx"),
+    route("*", "routes/examples/view.tsx"),
   ]),
   route("api/search", "routes/search.ts"),
   route("*", "routes/not-found.tsx"),

--- a/website/app/routes.ts
+++ b/website/app/routes.ts
@@ -4,7 +4,8 @@ export default [
   index("routes/home/index.tsx"),
   route("docs/*", "routes/docs.tsx"),
   route("examples", "routes/examples/layout.tsx", [
-    route("*", "routes/examples/view.tsx"),
+    index("routes/examples/view.tsx"),
+    route("*", "routes/examples/view.tsx", { id: "example-view" }),
   ]),
   route("api/search", "routes/search.ts"),
   route("*", "routes/not-found.tsx"),

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -19,7 +19,7 @@ export default function ExamplesLayout() {
     display: flex;
     flexDirection: column;
     flex: 1;
-    padding: 12, 24, 24;
+    padding: 24;
     gap: 8;
     maxWidth: 1400;
     width: fill;
@@ -41,7 +41,7 @@ function Navigation() {
   alignItems: center;
   gap: 8;
   overflowX: auto;
-  paddingLeft: 12;
+  marginLeft: 12;
   paddingBottom: 12;
 
   group: {
@@ -84,7 +84,7 @@ function Navigation() {
       radius: 2;
       marginLeft: 12;
       marginRight: 5;
-      background: 0xe2e2e2;
+      background: $colorFdBorder;
     }
   }
 
@@ -103,9 +103,8 @@ function Navigation() {
     }
 
     if("[aria-current='page']") {
-      background: $colorFdPrimary;
-      color: $colorFdPrimaryForeground;
-      borderColor: $colorFdPrimary;
+      background: $colorFdMuted;
+      borderColor: $colorFdMutedForeground;
     }
   }
 

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -19,8 +19,8 @@ export default function ExamplesLayout() {
     display: flex;
     flexDirection: column;
     flex: 1;
-    padding: 24;
-    gap: 16;
+    padding: 12, 24, 24;
+    gap: 8;
     maxWidth: 1400;
     width: fill;
     margin: 0, auto;
@@ -41,6 +41,7 @@ function Navigation() {
   alignItems: center;
   gap: 8;
   overflowX: auto;
+  paddingLeft: 12;
   paddingBottom: 12;
 
   group: {

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -4,6 +4,12 @@ import { NavLink, Outlet } from 'react-router';
 import { layoutOptions } from '../home';
 import { NAMES } from './loader';
 
+const GROUPS = NAMES.reduce((acc, slug) => {
+  const [group, ...rest] = slug.split('/');
+  (acc[group] ??= []).push({ slug, leaf: rest.join('/') });
+  return acc;
+}, {} as Record<string, { slug: string; leaf: string }[]>);
+
 export function meta() {
   return [{ title: 'Examples - Expressive' }];
 }
@@ -32,8 +38,54 @@ export default function ExamplesLayout() {
 
 function Navigation() {
   display: flex;
-  flexWrap: wrap;
+  alignItems: center;
   gap: 8;
+  overflowX: auto;
+  paddingBottom: 12;
+
+  group: {
+    display: flex;
+    alignItems: center;
+    marginR: 1.2;
+    gap: 8;
+  }
+
+  label: {
+    display: flex;
+    alignItems: center;
+    alignSelf: stretch;
+    fontSize: 0.7;
+    fontWeight: 600;
+    textTransform: uppercase;
+    letterSpacing: '0.08em';
+    color: $colorFdMutedForeground;
+    whiteSpace: nowrap;
+    background: $colorFdBackground;
+    position: sticky;
+    left: 0;
+    zIndex: 1;
+
+    $after: {
+      content: "";
+      position: absolute;
+      left: "100%";
+      top: 0;
+      bottom: 0;
+      width: 12;
+      pointerEvents: none;
+      background: `linear-gradient(to right, var(--color-fd-background), transparent 70%)`;
+    }
+
+    separator: {
+      width: 2;
+      display: "inline-block";
+      height: 2.2;
+      radius: 2;
+      marginLeft: 12;
+      marginRight: 5;
+      background: 0xe2e2e2;
+    }
+  }
 
   NavLink: {
     padding: 6, 12;
@@ -43,6 +95,7 @@ function Navigation() {
     textDecoration: none;
     color: inherit;
     userSelect: none;
+    whiteSpace: nowrap;
 
     $hover: {
       borderColor: $colorFdPrimary;
@@ -57,10 +110,19 @@ function Navigation() {
 
   return (
     <nav>
-      {NAMES.map((name) => (
-        <NavLink key={name} to={`/examples/${name}`}>
-          {name}
-        </NavLink>
+      {Object.entries(GROUPS).map(([group, items]) => (
+        <div _group key={group}>
+          <span _label>
+            {group}
+            <span _separator />
+          </span>
+          
+          {items.map(({ slug, leaf }) => (
+            <NavLink key={slug} to={`/examples/${slug}`}>
+              {leaf}
+            </NavLink>
+          ))}
+        </div>
       ))}
     </nav>
   );

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -13,7 +13,7 @@ export default function CodeSample() {
   sandbox: {
     display: flex;
     flexDirection: column;
-    height: `calc(100vh - 167px)`;
+    height: `calc(100vh - 147px)`;
   }
 
   loading: {

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -5,7 +5,7 @@ import { examples, getFiles, NAMES } from './loader';
 const Sandbox = lazy(() => import('@/components/Sandbox'));
 
 export default function CodeSample() {
-  const { name } = useParams();
+  const name = useParams()['*'];
 
   if (!name || !examples[name])
     return <Navigate to={`/examples/${NAMES[0]}`} replace />;

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -13,7 +13,7 @@ export default function CodeSample() {
   sandbox: {
     display: flex;
     flexDirection: column;
-    height: `calc(100vh - 12rem)`;
+    height: `calc(100vh - 167px)`;
   }
 
   loading: {

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -13,7 +13,7 @@ export default function CodeSample() {
   sandbox: {
     display: flex;
     flexDirection: column;
-    height: `calc(100vh - 147px)`;
+    height: `calc(100vh - 159px)`;
   }
 
   loading: {

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -11,9 +11,15 @@ export default function CodeSample() {
     return <Navigate to={`/examples/${NAMES[0]}`} replace />;
 
   sandbox: {
+    flex: 1;
+    minHeight: 0;
+    position: relative;
+  }
+
+  inner: {
+    absolute: fill;
     display: flex;
     flexDirection: column;
-    height: `calc(100vh - 159px)`;
   }
 
   loading: {
@@ -22,9 +28,11 @@ export default function CodeSample() {
 
   return (
     <div _sandbox>
-      <Suspense fallback={<div _loading>Loading sandbox...</div>}>
-        <Sandbox name={name} files={getFiles(name)} />
-      </Suspense>
+      <div _inner>
+        <Suspense fallback={<div _loading>Loading sandbox...</div>}>
+          <Sandbox name={name} files={getFiles(name)} />
+        </Suspense>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the examples playground, which 404'd on every example, and reworks the navbar and sandbox layout. All website-only; no published-package surface changes (so no changeset).

## What changed

**Routing**
- Examples were reorganized into category folders, making loader slugs two segments (`simple/counter`). The `:name?` route matched only one segment, sending every example to the not-found page. Switched to a splat route reading the full path.
- `/examples` now redirects to the first example via an explicit `index` route (a splat-only child didn't match the layout's own path).

**Navbar**
- Grouped by category in a single horizontal scroll row, each group introduced by a sticky label that fully covers chips scrolling beneath it with a right-edge fade.
- Even 24px top/bottom margins, nav inset via margin (so sticky labels don't leak), softened active-link and separator contrast to theme tones.

**Sandbox layout**
- Replaced the brittle `calc(100vh - Npx)` height (which overflowed on browsers with a taller header) with `flex: 1` + an absolutely-positioned inner wrapper, so Sandpack's intrinsic height no longer fights the flex layout. Header-height independent.
- Added a `Code | Preview` switcher below 768px, where the panels can't fit side by side and the preview was clipping off-screen. Shows one panel at a time (preview default); unchanged side-by-side above the breakpoint.

**Example fix**
- Tic-tac-toe `reset()` reassigned a plain array, dropping the `hot()` proxy so post-reset cell writes fired no events and the game looked unwinnable. Made `board` readonly and clear it in place with `fill()`.

## Verification

Layout and switcher behavior verified in-browser across 600px–1200px viewports: no overflow, correct panel switching, breakpoint safe at the boundary.
