### PR TITLE
Move observable protocol to @expressive/mvc/observable subpath

### DIFF
--- a/.changeset/observable-subpath.md
+++ b/.changeset/observable-subpath.md
@@ -1,0 +1,12 @@
+---
+"@expressive/mvc": minor
+"@expressive/react": minor
+---
+
+Move the low-level observable protocol (`observer`, `touch`, `event`, `listener`, `watch`, `Observer`) off the main entry to a dedicated `@expressive/mvc/observable` subpath. This declutters the primary import surface, which is now the app-facing API (`State`, `Component`, `Context`, instructions). The protocol is power-user surface for building custom observables; import it explicitly:
+
+```ts
+import { watch, touch, event } from '@expressive/mvc/observable';
+```
+
+Breaking: these names are no longer exported from `@expressive/mvc`, and `@expressive/react` no longer re-exports `Observer` from its main entry. Update imports to the subpath.

--- a/packages/mvc/package.json
+++ b/packages/mvc/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./observable": {
+      "types": "./dist/observable.d.ts",
+      "default": "./dist/observable.js"
+    },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.ts",
       "default": "./dist/jsx-runtime.js"

--- a/packages/mvc/src/index.ts
+++ b/packages/mvc/src/index.ts
@@ -5,6 +5,5 @@ export { set } from './field/set';
 export { ref } from './field/ref';
 
 export { State, State as default, unbind } from './state';
-export { watch, listener, event, Observer, observer, touch } from './observable';
 export { Context } from './context';
 export { Component } from './component';

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -44,4 +44,4 @@ Object.assign(Runtime, {
 });
 
 export { State, State as default, Consumer, Provider, use } from '@expressive/react/adapter'
-export { Component, Context, Observer, def, get, ref, set, hot } from '@expressive/mvc';
+export { Component, Context, def, get, ref, set, hot } from '@expressive/mvc';

--- a/packages/preact/src/use.test.tsx
+++ b/packages/preact/src/use.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource preact */
 import { StrictMode } from 'preact/compat';
-import { event, observer, touch } from '@expressive/mvc';
+import { event, observer, touch } from '@expressive/mvc/observable';
 import { describe, expect, it, mock } from 'bun:test';
 
 import { use, State } from '.';

--- a/packages/react/src/boundary.test.tsx
+++ b/packages/react/src/boundary.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, act } from '@testing-library/react';
 import { mock, expect, it, describe } from 'bun:test';
 import React from 'react';
-import { observer } from '@expressive/mvc';
+import { observer } from '@expressive/mvc/observable';
 
 import { mockError, mockPromise } from '../test.setup';
 import { Component } from '.';

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -1,4 +1,5 @@
-import { Component, watch, unbind, observer } from '@expressive/mvc';
+import { Component, unbind } from '@expressive/mvc';
+import { watch, observer } from '@expressive/mvc/observable';
 import { provide, type Context } from './context';
 import { Runtime, useHook, useReady } from './runtime';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -37,4 +37,4 @@ Object.assign(Runtime, {
 });
 
 export { State, State as default, use, Consumer, Provider } from './adapter';
-export { Component, Context, Observer, def, get, ref, set, hot } from '@expressive/mvc';
+export { Component, Context, def, get, ref, set, hot } from '@expressive/mvc';

--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { State, event, observer, touch } from '@expressive/mvc';
+import { State } from '@expressive/mvc';
+import { event, observer, touch } from '@expressive/mvc/observable';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { Runtime, useHook, use } from './runtime';

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -1,4 +1,4 @@
-import { event, watch, observer } from '@expressive/mvc';
+import { event, watch, observer } from '@expressive/mvc/observable';
 import type { Component } from '@expressive/mvc';
 import type { Context } from './context';
 

--- a/packages/react/src/state.get.ts
+++ b/packages/react/src/state.get.ts
@@ -1,4 +1,5 @@
-import { State, Context, observer, watch } from '@expressive/mvc';
+import { State, Context } from '@expressive/mvc';
+import { observer, watch } from '@expressive/mvc/observable';
 import { Runtime, useFactory, useHook, useReady } from './runtime';
 
 /** Type may not be undefined - instead will be null.  */

--- a/packages/react/src/state.use.ts
+++ b/packages/react/src/state.use.ts
@@ -1,4 +1,5 @@
-import { State, Context, watch } from '@expressive/mvc';
+import { State, Context } from '@expressive/mvc';
+import { watch } from '@expressive/mvc/observable';
 import { useFactory, useHook, useReady } from './runtime';
 
 declare module '@expressive/mvc' {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,5 @@
-import { Component, hot, listener } from '@expressive/mvc';
+import { Component, hot } from '@expressive/mvc';
+import { listener } from '@expressive/mvc/observable';
 
 import { Route } from './route';
 import { Match, fillPath, fullPattern, matchPattern, patternSegment } from './url';


### PR DESCRIPTION
## What

Move the low-level observable protocol (`observer`, `touch`, `event`, `listener`, `watch`, `Observer`) off the `@expressive/mvc` main entry to a dedicated `@expressive/mvc/observable` subpath.

```ts
import { watch, touch, event } from '@expressive/mvc/observable';
```

## Why

The main entry mixed six power-user protocol exports in with the app-facing surface (`State`, `Component`, `Context`, instructions). These are library-authoring tools for building custom observables (the way `hot()` is built); a distinct import path declutters the primary autocomplete and signals "advanced" at the call site. Matches the existing subpath precedent (`jsx-runtime`).

## How

- `observable.ts` is unchanged and becomes the export scope directly (no barrel, no rename). `tsdown` already emits `dist/observable.js`; added the `./observable` entry to the `exports` map.
- Removed the six re-exports from `packages/mvc/src/index.ts`.
- Repointed adapter internals and tests (`react`, `preact`, `router`) that consumed these from `@expressive/mvc` to `@expressive/mvc/observable`.
- `react`/`preact` no longer re-export `Observer` from their main entry.
- Internal `mvc` modules are untouched (they already import the engine via relative `./observable`).

Resolution is consistent in and out of the repo: the `@expressive/mvc/*` → `../mvc/src/*` tsconfig path routes the subpath to `src/observable.ts` for tsc/bun, matching the published exports map.

## Breaking

`observer`/`touch`/`event`/`listener`/`watch`/`Observer` are no longer exported from `@expressive/mvc`, and `@expressive/react` no longer re-exports `Observer` from its main entry. Import them from `@expressive/mvc/observable`. (`@expressive/mvc` + `@expressive/react` minor per the 0.x convention; changeset included.)

## Notes / open follow-ups

- Because `observable.ts` is the entry directly, the two internal helpers it must export for cross-module use under `tsdown`'s unbundle - `capture` (effect scoping) and `pending` (the promise behind `state.set()`) - are also reachable on the subpath. Hiding them would require reinstating a barrel; left as-is since this is power-user surface.
- No `@expressive/react/observable` re-export added: react users reach `@expressive/mvc/observable` directly. Can add a react-side re-export if we'd rather not have them reach past the adapter.
- LLM docs (`skills/state/observable.md`, the `state.md` snippet) still import from `@expressive/mvc`; they'll be updated to `@expressive/mvc/observable` when the docs branch lands.

## Tests

All suites green, no threshold change: mvc 499, react 205, preact 138, router 210 (0 fail). mvc retains 100% coverage.
