### PR TITLE
feat(form): headless form kernel (v0 investigation)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-state",
@@ -20,6 +19,7 @@
       "dependencies": {
         "@expressive/react": "workspace:*",
         "@expressive/router": "workspace:*",
+        "lucide-react": "^0.570.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
@@ -29,6 +29,13 @@
         "@vitejs/plugin-react": "^5.0.0",
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
+      },
+    },
+    "packages/form": {
+      "name": "@expressive/form",
+      "version": "0.0.0",
+      "dependencies": {
+        "@expressive/mvc": "^0.79.0",
       },
     },
     "packages/mvc": {
@@ -80,10 +87,10 @@
       "name": "@expressive/router",
       "version": "0.4.0",
       "dependencies": {
-        "@expressive/mvc": "^0.78.0",
+        "@expressive/mvc": "^0.79.0",
       },
       "devDependencies": {
-        "@expressive/react": "^0.78.0",
+        "@expressive/react": "^0.80.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -342,6 +349,8 @@
     "@expressive/css": ["@expressive/css@0.7.0", "", { "dependencies": { "chroma-js": "^2.0.3", "easing-coordinates": "^2.0.2" } }, "sha512-wbZAX1vHHkpZy9IueG2DLPicvoys9RRs/YQzvBhbZrdeNjjdyWsM/KI0OS1odfwN+FvDA+zZTzdhNnnT1UkbQg=="],
 
     "@expressive/examples": ["@expressive/examples@workspace:examples"],
+
+    "@expressive/form": ["@expressive/form@workspace:packages/form"],
 
     "@expressive/mvc": ["@expressive/mvc@workspace:packages/mvc"],
 

--- a/packages/form/bunfig.toml
+++ b/packages/form/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+preload = ["../mvc/test.setup.ts"]
+coverage = true
+coverageSkipTestFiles = true
+coverageThreshold = 1.0
+coveragePathIgnorePatterns = ["**/mvc/**", "**/test.setup.ts"]

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@expressive/form",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Headless form contract for Expressive MVC",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "test": "tsc --noEmit && bun test --coverage"
+  },
+  "dependencies": {
+    "@expressive/mvc": "^0.79.0"
+  }
+}

--- a/packages/form/src/Form.test.ts
+++ b/packages/form/src/Form.test.ts
@@ -1,0 +1,98 @@
+import { Context } from '@expressive/mvc';
+import { describe, expect, it } from 'bun:test';
+
+import { Form } from './Form';
+import { Input } from './Input';
+
+/**
+ * Mounts a form the way a render tree would: the form is a provider with its own
+ * context, and field components (Inputs) mount in a child context beneath it. A
+ * nested form is its own provider, mounted in the parent form's subtree - never
+ * a plain field (that would land it in the parent's own context).
+ */
+function provide<T extends Form>(form: T, within?: Context) {
+  const ctx = (within || new Context()).push();
+  ctx.set(form);
+  return {
+    form,
+    inputs(map: Record<string, Input>) {
+      ctx.push().set(map);
+      return this;
+    },
+    nest<N extends Form>(child: N) {
+      return provide(child, ctx);
+    }
+  };
+}
+
+describe('discovery', () => {
+  it('will collect inputs mounted downstream', async () => {
+    const { form } = provide(new Form()).inputs({ a: new Input(), b: new Input() });
+    await form.set();
+
+    expect(form.inputs.size).toBe(2);
+  });
+
+  it('will not collect inputs owned by a nested form', async () => {
+    const outer = provide(new Form()).inputs({ a: new Input() });
+    const inner = outer.nest(new Form()).inputs({ b: new Input() });
+    await outer.form.set();
+
+    expect(outer.form.inputs.size).toBe(1);
+    expect(outer.form.nested.has(inner.form)).toBe(true);
+    expect(inner.form.inputs.size).toBe(1);
+  });
+});
+
+describe('validation protocol', () => {
+  it('will reject when a required input is empty', async () => {
+    const required = new Input();
+    const { form } = provide(new Form()).inputs({ required });
+    await form.set();
+
+    const invalid = await form.invalid();
+    expect(invalid?.has(required)).toBe(true);
+    expect(required.warning).toBe(true);
+  });
+
+  it('will pass when optional or filled', async () => {
+    const filled = new Input();
+    filled.value = 'x';
+    const optional = new Input();
+    optional.optional = true;
+
+    const { form } = provide(new Form()).inputs({ filled, optional });
+    await form.set();
+
+    expect(await form.invalid()).toBeUndefined();
+  });
+
+  it('will recurse into nested forms', async () => {
+    const outer = provide(new Form()).inputs({});
+    const innerRequired = new Input();
+    outer.nest(new Form()).inputs({ innerRequired });
+    await outer.form.set();
+
+    const invalid = await outer.form.invalid();
+    expect(invalid?.has(innerRequired)).toBe(true);
+  });
+});
+
+describe('dirty tracking', () => {
+  it('will report changed fields against checkpoint', async () => {
+    class Profile extends Form {
+      name = 'Gabe';
+      age = 40;
+    }
+
+    const profile = Profile.new();
+    await profile.set();
+
+    expect(profile.changed()).toBeUndefined();
+
+    profile.age = 41;
+    await profile.set();
+
+    expect(profile.changed()).toEqual({ age: 41 });
+  });
+});

--- a/packages/form/src/Form.ts
+++ b/packages/form/src/Form.ts
@@ -1,0 +1,162 @@
+import { State, get } from '@expressive/mvc';
+
+import { Async, Input, input } from './Input';
+
+type Field<T extends Form> = Exclude<keyof T, keyof Form>;
+
+type Values<T extends Form> = {
+  [K in Field<T>]: T[K];
+};
+
+const exclude = new Set([
+  'checkpoint', 'invalid', 'for', 'inputs', 'nested', 'parent', 'form'
+]);
+
+declare namespace Form {
+  export { Input, Values };
+}
+
+class Form extends State {
+  constructor(...args: State.Args) {
+    super(...args, () => {
+      const source = this.for as Record<string, any> | undefined;
+
+      if (source && typeof source == 'object')
+        for (const key in this)
+          if (!exclude.has(key)) this[key] = source[key];
+
+      this.checkpoint = this.values();
+
+      // Discovery: flat downstream collection, scoped to direct ownership.
+      // `i.parent === this` filters out inputs owned by nested forms - the
+      // boundary downstream collection itself lacks (see issue #197).
+      this.get(Input, (i) => {
+        if (i.parent !== this) return;
+
+        this.inputs.add(i);
+        i.get(null, () => {
+          this.inputs.delete(i);
+        });
+      }, true);
+
+      this.get(Form, (f) => {
+        if (f === this || f.parent !== this) return;
+
+        this.nested.add(f);
+        f.get(null, () => {
+          this.nested.delete(f);
+        });
+      }, true);
+    });
+  }
+
+  checkpoint = {} as Values<this>;
+
+  form = input(this);
+
+  inputs = new Set<Input>();
+  nested = new Set<Form>();
+
+  /** Nearest enclosing Form (skips self), for nested-form ownership. */
+  parent?: Form = get(Form, false);
+
+  for?: unknown = undefined;
+
+  changed() {
+    const values = {} as Partial<Values<this>>;
+
+    for (const key in this) {
+      if (exclude.has(key)) continue;
+
+      let value = (this as any)[key];
+
+      if (value instanceof Form) {
+        value = value.changed();
+        if (!value) continue;
+      }
+
+      if (value !== (this.checkpoint as any)[key])
+        (values as any)[key] = value;
+    }
+
+    if (Object.keys(values).length) return values;
+  }
+
+  values() {
+    const values = {} as Values<this>;
+
+    for (const key in this) {
+      if (exclude.has(key)) continue;
+
+      let value = (this as any)[key];
+
+      if (value instanceof Form) value = value.values();
+
+      (values as any)[key] = value;
+    }
+
+    return values;
+  }
+
+  reset() {
+    Object.assign(this, this.checkpoint);
+  }
+
+  warn(i: Input) {
+    i.warning = true;
+    const off = i.set('value', () => {
+      i.warning = undefined;
+      off();
+    });
+  }
+
+  accept(values: Values<this>, self: this): Async<boolean | void> {
+    if (this.for && typeof this.for == 'object')
+      Object.assign(this.for, this.changed());
+
+    return true;
+  }
+
+  reject(invalid: Set<Input>): Async<boolean | void> {
+    return false;
+  }
+
+  async ready() {
+    const invalid = await this.invalid();
+    return invalid
+      ? (await this.reject(invalid)) !== false
+      : (await this.accept(this.values(), this)) !== true;
+  }
+
+  async valid(i: Input): Promise<boolean> {
+    try {
+      let isValid = await i.valid(i);
+
+      if (isValid === undefined) isValid = true;
+      if (isValid) i.warning = undefined;
+
+      return isValid;
+    } catch (e) {
+      this.warn(i);
+      return false;
+    }
+  }
+
+  async invalid() {
+    const invalid = new Set<Input>();
+
+    await Promise.all([
+      ...[...this.inputs].map(async (i) => {
+        if (!(await this.valid(i))) invalid.add(i);
+      }),
+      ...[...this.nested].map(async (form) => {
+        const rejected = await form.invalid();
+        if (rejected) for (const i of rejected) invalid.add(i);
+      })
+    ]);
+
+    if (invalid.size) return invalid;
+  }
+}
+
+export { Form };

--- a/packages/form/src/Input.ts
+++ b/packages/form/src/Input.ts
@@ -1,0 +1,52 @@
+import { State, get, ref } from '@expressive/mvc';
+
+import { Form } from './Form';
+
+export type Ref<T extends State = any> = (input?: Input) => readonly [T, keyof T];
+
+export type Async<T> = T | Promise<T>;
+
+/**
+ * Build a custom ref proxy keyed per field. `form.email` returns a binder that,
+ * when attached to an Input, wires two-way reactivity between form and input.
+ */
+export function input<T extends State>(from: T) {
+  function bind(input: Input, key: keyof T) {
+    input.name = key as string;
+    from.get((current) => {
+      input.value = current[key];
+    });
+    input.get((current) => {
+      from[key] = current.value;
+    });
+  }
+
+  function forEach(key: keyof T): Ref<T> {
+    return (input?: Input) => {
+      if (input) bind(input, key);
+      return [from, key];
+    };
+  }
+
+  return ref(from, forEach);
+}
+
+export class Input<T = any> extends State {
+  name = '';
+
+  disabled = false;
+  optional = false;
+  default?: T = undefined;
+  value: T | undefined = this.default;
+  warning?: string | boolean = undefined;
+
+  /** Nearest owning Form via the singular (shadowing) lookup path. */
+  parent?: Form = get(Form, false);
+
+  valid(self: this): Async<boolean | void> {
+    const { value, optional } = this;
+
+    if ((value == undefined || value === '') && !optional)
+      throw new Error('Required');
+  }
+}

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -1,0 +1,2 @@
+export { Form } from './Form';
+export { Input, input, type Ref } from './Input';

--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "esModuleInterop": true,
+    "lib": ["ES2020"],
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "sourceMap": true,
+    "strict": true,
+    "types": ["bun"],
+    "paths": {
+      "@expressive/mvc/*": ["../mvc/src/*"],
+      "@expressive/*": ["../*/src"]
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What

A v0 **headless form contract** for Expressive MVC, ported from a battle-tested system dogfooded extensively in a real app (pre-State-rename, pre-#100 Component refactor, on a custom jsxImportSource). New agnostic package `@expressive/form` (deps: only `@expressive/mvc`) — router-shaped: tightly coupled to mvc, framework-agnostic, no DOM/styling. Users bring their own field UI.

This is an **investigation/v0**, marked `private` and `0.0.0`. Not for release yet.

## Kernel

- **`Form`** — discovery of child inputs/nested forms, the `ready`/`accept`/`reject`/`valid`/`warn` orchestration protocol, and `checkpoint`/`changed`/`reset` dirty-tracking. `for`-binding writes `changed` back into an existing entity.
- **`Input`** — `value`/`optional`/`default`/`warning` + a default required `valid`, with auto-clearing warnings.
- **`input(this)`** — custom ref-proxy producing the `is={form.field}` two-way binder.

## The interesting finding (issue #197)

The old spine was `inputs = has(Input)` — collect every child Input. `has` is gone, consolidated into downstream collection `get(Input, cb, true)`. But that collection path is **flat — no same-type shadowing**: an outer form also collects a *nested* form's inputs, double-counting against the nested form's own validation recursion.

**Workaround (no core change):** each `Input` resolves its nearest owning form via the singular (shadowing) lookup `parent = get(Form, false)`; the form flat-collects then filters `i.parent === this`. The nearest-Form resolution supplies the ownership boundary the collection path lacks.

Logged as #197 — possibly intended-and-forgotten; downstream collection is also a pruning candidate pending further investigation.

## Old-adapter → modern divergences resolved

| Old | Modern reality | Resolution |
|---|---|---|
| `value = set(() => default!)` | set-factory forms are read-only, non-enumerable, suspend on undefined | plain writable `value` field |
| `checkpoint = set(() => values, true)` | eager set-factory is reactive (always == current) | one-shot snapshot at activation |
| `get values()` / `get changed()` | reactive getters suspend during activation | plain methods `values()` / `changed()` |
| `i.get('value', cb)` | — | `i.set('value', cb)` property subscribe |

The `values()`/`changed()` method conversion is an ergonomic regression vs the old property access — **open design question** whether a non-reactive getter is expressible.

## Tests

6/6 pass, clean `tsc`. Covers discovery, nested-form ownership filtering, the validation protocol (required/optional/filled, nested recursion), and dirty-tracking. Context tree is built manually to simulate the render-subtree placement.

## Not in this PR (deferred)

- Real `@expressive/react` render-path validation (raw `Context` used to simulate mounting).
- DOM field adapters (Masked/Select/Date/File) — app-specific, reference-only.
- Whether native `ref` two-way subsumes the hand-rolled `input()`.
- Final package-boundary decision.