### PR TITLE
fix(mvc): skip read-only computeds during prop assignment

### DIFF
--- a/.changeset/assign-skip-readonly-computed.md
+++ b/.changeset/assign-skip-readonly-computed.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix prop assignment throwing when a prop shares the name of a read-only (getter-derived) computed. Such a key previously hit the computed's throwing setter and dropped the value; it is now skipped during assignment, leaving the computed to derive it.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -2184,6 +2184,42 @@ describe('set method', () => {
 
       expect(test.foo).toBe('bar');
     });
+
+    it('will ignore a key matching a read-only computed', async () => {
+      class Test extends State {
+        source = 'foo';
+        get value() {
+          return this.source;
+        }
+      }
+
+      const test = Test.new();
+
+      expect(() => {
+        test.set({ value: 'bar' });
+      }).not.toThrow();
+
+      await expect(test).not.toHaveUpdated();
+
+      expect(test.value).toBe('foo');
+    });
+
+    it('will leave a computed to derive when its name also arrives as data', async () => {
+      class Test extends State {
+        source = 'foo';
+        get value() {
+          return this.source.toUpperCase();
+        }
+      }
+
+      const test = Test.new();
+
+      test.set({ value: 'ignored', source: 'bar' });
+
+      await expect(test).toHaveUpdated('source');
+
+      expect(test.value).toBe('BAR');
+    });
   });
 
   it('will trigger normal setters', async () => {

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -856,11 +856,13 @@ function assign(state: State, data: State.Assign<State>, silent?: boolean) {
   if (!silent) event(state);
 
   const methods = METHODS.get(state.constructor)!;
+  const getters = GETTERS.get(state.constructor);
 
   for (const key in data) {
     const bind = methods.get(key);
 
     if (bind) bind.call(state, data[key]);
+    else if (getters?.has(key)) continue;
     else if (key in state && key !== 'is') {
       const desc = Object.getOwnPropertyDescriptor(state, key)!;
       const set = desc && (desc.set as (value: any, silent?: boolean) => void);


### PR DESCRIPTION
## Problem

When a prop shares the name of a getter-derived (read-only) computed, prop assignment hit the computed's throwing read-only setter and dropped the value. A property named the same as a computed could never be passed in.

This surfaced while exploring a `Route` subclass that overrides a `children` getter to generate its child route tree: `children` is both a managed computed and a JSX prop, and the two collided at assignment time.

## Fix

`assign` now skips any key that names a read-only computed (detected via the existing `GETTERS` registry), leaving the computed to derive its value instead of attempting a write that can only throw. General, not children-specific - any computed whose name collides with an incoming key is now safe.

## Tests

Two tests added under `state.test.ts` → `assign`:
- a key matching a read-only computed is ignored (no throw, no update, computed stays derived)
- a computed still derives from its real source when its name also arrives as data

Both verified to fail without the fix.

## Notes

- `@expressive/mvc` patch changeset included.
- Direct assignment (`state.computed = x`) still throws read-only as before - only bulk/prop assignment changes.