### PR TITLE
refactor(router)!: rename Route.nested seam to children

### DIFF
--- a/.changeset/route-children-seam.md
+++ b/.changeset/route-children-seam.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+Rename the `Route` child-contribution seam from `protected get nested()` to `protected get children()`. The getter reads more naturally as the scope's effective children (its default is `props.children`), and now coexists cleanly with the `children` prop thanks to the read-only-computed assignment fix in `@expressive/mvc`. Subclasses overriding the seam must rename `get nested()` to `get children()` and `super.nested` to `super.children`.

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -1189,11 +1189,11 @@ describe('extends', () => {
     expect(view.container.textContent).toBe('About');
   });
 
-  describe('nested seam', () => {
+  describe('children seam', () => {
     class Page extends Route {
       Default: () => any = () => <span>fallback</span>;
-      protected get nested(): Component.Node {
-        return (<>{super.nested}<Route default as={this.Default} /></>) as any;
+      protected get children(): Component.Node {
+        return (<>{super.children}<Route default as={this.Default} /></>) as any;
       }
     }
 
@@ -1247,9 +1247,9 @@ describe('extends', () => {
     it('does not run subclass content when unmatched', () => {
       let ran = 0;
       class Tracked extends Route {
-        protected get nested(): Component.Node {
+        protected get children(): Component.Node {
           return (
-            <>{super.nested}<Route default as={() => { ran++; return <span>x</span>; }} /></>
+            <>{super.children}<Route default as={() => { ran++; return <span>x</span>; }} /></>
           ) as any;
         }
       }
@@ -1555,13 +1555,13 @@ describe('a Route passed as another Route', () => {
     expect(resolved).toBe(innerInst);
   });
 
-  it('sees the outer Route\'s computed nested (outer-injected child matches)', async () => {
+  it('sees the outer Route\'s computed children (outer-injected child matches)', async () => {
     location('/sub/extra');
     class Outer extends Route {
-      protected get nested() {
+      protected get children() {
         return (
           <>
-            {super.nested}
+            {super.children}
             <Route to="extra" as={Leaf('EXTRA')} />
           </>
         );

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -100,10 +100,10 @@ export class Route extends Component {
 
     if (isRoot(this)) return true;
 
-    const { nested } = this;
+    const { children } = this;
 
-    if (allRoutes(nested))
-      return scopeResolves(this, nested, this.router.path);
+    if (allRoutes(children))
+      return scopeResolves(this, children, this.router.path);
 
     return !!this.match;
   }
@@ -124,7 +124,7 @@ export class Route extends Component {
     const scan = (routes: Route[]): boolean => {
       for (const route of routes) {
         if (exempt(route)) continue;
-        if (allRoutes(route.nested)) {
+        if (allRoutes(route.children)) {
           if (scan(route.inner)) return true;
           continue;
         }
@@ -147,7 +147,7 @@ export class Route extends Component {
     const collect = (routes: Route[]): string[] =>
       routes.flatMap((route) => {
         if (exempt(route)) return [];
-        if (!allRoutes(route.nested))
+        if (!allRoutes(route.children))
           return match(route.base, route.to) && rejected !== path ? [route.path] : [];
 
         // A scope counts via a matched descendant, or its own section default.
@@ -181,12 +181,16 @@ export class Route extends Component {
    * This scope's child routes - the effective set matching and render consult.
    * Defaults to the children declared via JSX. Override this getter (a subclass
    * extension seam) to opine on them - add, remove, or reorder - composing on
-   * `super.nested`; both matching and render read the result, so contributed
+   * `super.children`; both matching and render read the result, so contributed
    * routes participate in this scope's control flow as if declared. Memoized by
    * the framework (recomputes when `props` change), so contributed routes have
    * stable identity within a render pass.
+   *
+   * Distinct from `this.props.children` (the raw JSX prop, the default here):
+   * this getter is the *effective* child set the router consults, which an
+   * override may augment or replace.
    */
-  protected get nested(): Component.Node {
+  protected get children(): Component.Node {
     return (this.props as { children?: Component.Node }).children;
   }
 
@@ -244,7 +248,7 @@ export class Route extends Component {
     if (Object.getOwnPropertyDescriptor(props, 'children')?.get)
       return matched ? props.children : null;
 
-    const children = this.nested;
+    const children = this.children;
 
     return matched
       ? Component ? <Component>{children}</Component> : children

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -254,9 +254,9 @@ Navigates to `to` when mounted, gated on `when` (default `true`). Pushes by defa
 ## Extending Route: contributing child routes
 
 A `Route` subclass can opine on its own scope's children before matching and
-registration by overriding the `protected get nested()` seam. It defaults to the
+registration by overriding the `protected get children()` seam. It defaults to the
 children declared in JSX; override it to return the effective set - add, remove,
-or reorder - composing on `super.nested`. Both matching and render read the
+or reorder - composing on `super.children`. Both matching and render read the
 result, so contributed routes participate in this scope's control flow
 (matching, `inner` registration, default-resolution, `matches`, and render)
 exactly as if declared in JSX.
@@ -265,27 +265,27 @@ exactly as if declared in JSX.
 class Page extends Route {
   Default = NotFound;
 
-  protected get nested(): Component.Node {
-    return <>{super.nested}<Route default as={this.Default} /></>;
+  protected get children(): Component.Node {
+    return <>{super.children}<Route default as={this.Default} /></>;
   }
 }
 ```
 
 `<Page to="docs/*">…</Page>` now resolves to `Default` whenever no child of the
 scope matches - a section fallback the caller never had to write. `Default` is
-the subclass's own surface; `Route` exposes only the `nested` seam.
+the subclass's own surface; `Route` exposes only the `children` seam.
 
 Scope and caveats:
 - **Own scope only.** Contributed routes are first-class *within this Route*.
   They are invisible to walks that inspect this Route as a bare JSX element from
   the outside - sibling `as`-slot arbitration and a parent scope recursing into
-  this element's lexical children - which have no instance to read `nested` from.
+  this element's lexical children - which have no instance to read `children` from.
   Same blind spot as class-field `to` (see below).
 - **Classification follows effective children.** Contributing a default to a
   `to`-leaf turns it into a see-through scope (matched by prefix rather than
   exact pattern). Intended - the leaf/scope distinction reflects what the scope
   effectively contains.
-- Contribute via `nested`, not `render()`: it is pure analysis (returns nodes,
+- Contribute via `children`, not `render()`: it is pure analysis (returns nodes,
   never runs a page render), so matching can consult it without the circularity
   and lazy-gate problems of deciding matches from render output.
 

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -275,6 +275,36 @@ class Page extends Route {
 scope matches - a section fallback the caller never had to write. `Default` is
 the subclass's own surface; `Route` exposes only the `children` seam.
 
+The same seam is how you build a **component that generates routes from data** -
+map a source to `Route` elements in `children`, and use the subclass like any
+other route:
+
+```tsx
+class Examples extends Route {
+  modules = set<Modules>();
+
+  protected get children(): Component.Node {
+    return <>
+      {organize(this.modules).map((group) => (
+        <Route key={group.slug} to={group.slug} label={group.label}>
+          {group.items.map((item) => (
+            <Route key={item.slug} to={item.slug} as={item.page} />
+          ))}
+        </Route>
+      ))}
+      {super.children}
+    </>;
+  }
+}
+
+<BrowserRouter><Examples modules={modules} as={Shell} /></BrowserRouter>
+```
+
+The generated routes match, register, and render exactly as if written in JSX.
+`super.children` splices in whatever the caller passed (e.g. a `<Route default>`),
+so the component stays composable. Caller-passed children are otherwise dropped
+unless you compose `super.children` - the seam fully owns the scope.
+
 Scope and caveats:
 - **Own scope only.** Contributed routes are first-class *within this Route*.
   They are invisible to walks that inspect this Route as a bare JSX element from


### PR DESCRIPTION
## What

Renames the `Route` child-contribution extension seam:

- `protected get nested()` → `protected get children()`
- `super.nested` → `super.children`

The getter is the scope's *effective* child set, defaulting to `props.children`; `children` reads more naturally at the override site (`super.children` = "the children I was handed"). It now coexists cleanly with the `children` prop thanks to the read-only-computed assignment fix in #199 - without that, a `children` computed collided with prop application and threw.

## Scope (audited)

**Code:**
- `route.tsx`: getter definition, the four matching reads (`matched`, `active`, `matches`, `render`), and JSDoc
- `route.test.tsx`: the seam overrides + cosmetic describe/test names

**Docs:**
- `skills/router/router.md` "Extending Route" section

**Deliberately untouched** (prose or unrelated identifiers): "nested route/scope" wording throughout, `state.test.ts`/`hot.md` fixtures named `nested`, and the historical `CHANGELOG.md` entry.

## Notes

- Depends on #199 (merged) - rebased on top.
- Breaking rename of a documented `protected` seam; pre-1.0, no compat alias. `@expressive/router` minor changeset included.
- The examples-ladder branch consumes the new `children` name and will rebase onto main after this lands.