### PR TITLE
feat(examples): playground & dev-shell UX

### DIFF
--- a/examples/app/Shell.module.css
+++ b/examples/app/Shell.module.css
@@ -5,7 +5,7 @@
   grid-template-areas:
     "header header"
     "nav example";
-  gap: var(--s5);
+  gap: var(--s4);
   width: min(100% - 2rem, 1400px);
   height: 100vh;
   overflow: hidden;
@@ -62,8 +62,8 @@
   gap: var(--s1);
   max-height: 100%;
   overflow-y: auto;
-  padding: var(--s3);
-  padding-right: 0;
+  padding-left: var(--s3);
+  margin-top: var(--s3);
 }
 
 .links {
@@ -76,17 +76,22 @@
   display: flex;
   flex-direction: column;
   gap: var(--s2);
-  margin-bottom: var(--s5);
 }
 
 .groupLabel {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   margin: 0;
-  padding: 0 var(--s2);
+  /* Top padding (not margin) so the background covers links scrolling up
+     behind the sticky header instead of showing through a transparent gap. */
+  padding: var(--s2) var(--s2) var(--s2);
   font-size: var(--t-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.07em;
   color: var(--muted);
+  background: var(--bg);
 }
 
 /* Example links nest under their section along a vertical guide line,
@@ -155,13 +160,21 @@
   .nav {
     position: static;
     max-height: none;
+    flex: 0.3;
   }
 
   .links {
     max-height: 16rem;
   }
 
+  /* Example fills the space left below the nav (rather than a fixed 70vh that
+     overflowed and pushed the centered content past the fold). */
+  .example {
+    flex: 1;
+  }
+
   .frame {
-    height: 70vh;
+    height: 100%;
+    min-height: 0;
   }
 }

--- a/examples/global.css
+++ b/examples/global.css
@@ -231,12 +231,11 @@ body.example {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   padding: var(--s6);
 }
 
 body.example #root {
   width: 100%;
   max-width: 32rem;
-  margin: 0;
+  margin: auto;
 }

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -6,7 +6,7 @@ import {
   useSandpack
 } from '@codesandbox/sandpack-react';
 import State from '@expressive/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTheme } from 'next-themes';
 import type { MouseEvent as ReactMouseEvent } from 'react';
 
@@ -43,14 +43,28 @@ export default function Sandbox({
   name: string;
   files: Record<string, string>;
 }) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === 'dark';
+
+  // The preview is a cross-origin Sandpack iframe, so we can't set its theme
+  // from here - bake it into the hidden entry, which global.css honors via
+  // :root[data-theme]. Keyed into the provider so a toggle re-applies it.
+  const themed = useMemo(() => {
+    const entry = files['/index.tsx'] as string | { code: string };
+    const line = `\ndocument.documentElement.dataset.theme = ${JSON.stringify(dark ? 'dark' : 'light')};`;
+
+    return {
+      ...files,
+      '/index.tsx': typeof entry === 'string' ? entry + line : { ...entry, code: entry.code + line }
+    };
+  }, [files, dark]);
 
   return (
     <SandpackProvider
-      key={name}
-      theme={theme === 'dark' ? 'dark' : 'light'}
+      key={`${name}:${dark ? 'dark' : 'light'}`}
+      theme={dark ? 'dark' : 'light'}
       template="react-ts"
-      files={files}
+      files={themed}
       customSetup={{
         dependencies: { '@expressive/react': 'latest' }
       }}

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -5,7 +5,7 @@ import {
   SandpackProvider,
   useSandpack
 } from '@codesandbox/sandpack-react';
-import State from '@expressive/react';
+import State, { ref } from '@expressive/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTheme } from 'next-themes';
 import type { MouseEvent as ReactMouseEvent } from 'react';
@@ -13,6 +13,19 @@ import type { MouseEvent as ReactMouseEvent } from 'react';
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
   ratio = 50; // editor width (%) when both panels are side by side
+
+  // Hold Ctrl and two-finger swipe to nudge split
+  layout = ref<HTMLDivElement>((el) => {
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      const delta = Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      this.ratio = Math.min(80, Math.max(20, this.ratio - delta * 0.05));
+    };
+
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  });
 
   onSelect(is: typeof this.mode){
     this.mode = is;
@@ -75,7 +88,7 @@ export default function Sandbox({
 }
 
 function Layout() {
-  const { onSelect, mode, ratio, grab } = Panes.use();
+  const { onSelect, mode, ratio, grab, layout } = Panes.use();
   const sandpack = useSandpack();
   const refreshOnSave = {
     key: 'Mod-s',
@@ -108,7 +121,7 @@ function Layout() {
   }
 
   return (
-    <SandpackLayout>
+    <SandpackLayout ref={layout}>
       <SandpackCodeEditor
         style={{ display: showEditor ? 'flex' : 'none', flex: narrow ? '1' : `0 0 ${ratio}%` }}
         extensionsKeymap={[refreshOnSave]}

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -100,15 +100,17 @@ function Navigation() {
     left: 0;
     zIndex: 1;
 
-    $after: {
-      content: "";
+    fade: {
       position: absolute;
       left: "100%";
       top: 0;
       bottom: 0;
-      width: 12;
+      width: 8;
       pointerEvents: none;
-      background: `linear-gradient(to right, var(--color-fd-background), transparent 70%)`;
+      background: `linear-gradient(to right, var(--color-fd-background), transparent)`;
+      // media nested inside the selector, not a selector inside the media
+      // block - the parser can't handle the latter (workaround).
+      $xl: { display: none; }
     }
 
     separator: {
@@ -119,6 +121,7 @@ function Navigation() {
       marginLeft: 12;
       marginRight: 5;
       background: $colorFdBorder;
+      $xl: { display: none; }
     }
 
     // In sidebar mode the row affordances (sticky pin, fade, dot) are noise;
@@ -129,9 +132,6 @@ function Navigation() {
       paddingLeft: 8;
       fontSize: 0.72;
       color: $colorFdMutedForeground;
-
-      $after: { display: none; }
-      separator: { display: none; }
     }
   }
 
@@ -165,9 +165,15 @@ function Navigation() {
     }
 
     if("[aria-current='page']") {
-      background: `color-mix(in srgb, var(--color-fd-primary) 12%, transparent)`;
-      borderColor: `color-mix(in srgb, var(--color-fd-primary) 30%, transparent)`;
-      color: $colorFdPrimary;
+      background: `color-mix(in srgb, var(--accent) 14%, transparent)`;
+      borderColor: `color-mix(in srgb, var(--accent) 45%, transparent)`;
+      color: $accent;
+
+      // Sidebar active: left bar instead of the pill border. Media nested in
+      // the selector (not the reverse) to dodge the parser bug.
+      $xl: {
+        borderLeftColor: $accent;
+      }
     }
 
     // Sidebar: flush links nested on the rail, marked by a left bar instead
@@ -182,11 +188,6 @@ function Navigation() {
         background: $colorFdMuted;
         borderLeftColor: $colorFdMutedForeground;
       }
-
-      if("[aria-current='page']") {
-        borderLeftColor: $colorFdPrimary;
-        fontWeight: 600;
-      }
     }
   }
 
@@ -197,6 +198,7 @@ function Navigation() {
           <span _label>
             {group}
             <span _separator />
+            <span _fade />
           </span>
 
           <div _items>

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -55,11 +55,11 @@ function Navigation() {
     display: flex;
     alignItems: center;
     alignSelf: stretch;
-    fontSize: 0.7;
+    fontSize: 0.78;
     fontWeight: 600;
     textTransform: uppercase;
     letterSpacing: '0.08em';
-    color: $colorFdMutedForeground;
+    color: $colorFdForeground;
     whiteSpace: nowrap;
     background: $colorFdBackground;
     position: sticky;
@@ -94,17 +94,19 @@ function Navigation() {
     border: $colorFdBorder;
     fontSize: 0.875;
     textDecoration: none;
-    color: inherit;
+    color: $colorFdMutedForeground;
     userSelect: none;
     whiteSpace: nowrap;
 
     $hover: {
-      borderColor: $colorFdPrimary;
+      color: $colorFdForeground;
+      borderColor: $colorFdMutedForeground;
     }
 
     if("[aria-current='page']") {
-      background: $colorFdMuted;
-      borderColor: $colorFdMutedForeground;
+      background: `color-mix(in srgb, var(--color-fd-primary) 12%, transparent)`;
+      borderColor: `color-mix(in srgb, var(--color-fd-primary) 30%, transparent)`;
+      color: $colorFdPrimary;
     }
   }
 

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -24,6 +24,13 @@ export default function ExamplesLayout() {
     maxWidth: 1400;
     width: fill;
     margin: 0, auto;
+
+    // Wide enough for a vertical sidebar beside the playground.
+    $xl: {
+      flexDirection: row;
+      alignItems: stretch;
+      gap: 24;
+    }
   }
 
   return (
@@ -44,11 +51,38 @@ function Navigation() {
   marginLeft: 12;
   paddingBottom: 12;
 
+  // Stacked vertical sidebar at wide widths. align-self:flex-start stops it
+  // from stretching the row to its own height; capped to the viewport and
+  // scrolled internally so a short window doesn't overflow the page.
+  $xl: {
+    flexDirection: column;
+    alignItems: stretch;
+    alignSelf: "flex-start";
+    overflowX: visible;
+    overflowY: auto;
+    minHeight: 0;
+    maxHeight: "calc(100vh - 7rem)";
+    position: sticky;
+    top: 24;
+    width: 150;
+    flexShrink: 0;
+    marginLeft: 0;
+    paddingBottom: 0;
+    gap: 20;
+  }
+
   group: {
     display: flex;
     alignItems: center;
     marginR: 1.2;
     gap: 8;
+
+    $xl: {
+      flexDirection: column;
+      alignItems: stretch;
+      marginR: 0;
+      gap: 4;
+    }
   }
 
   label: {
@@ -86,6 +120,33 @@ function Navigation() {
       marginRight: 5;
       background: $colorFdBorder;
     }
+
+    // In sidebar mode the row affordances (sticky pin, fade, dot) are noise;
+    // the label becomes a quiet section header above a railed list.
+    $xl: {
+      position: "static";
+      marginBottom: 6;
+      paddingLeft: 8;
+      fontSize: 0.72;
+      color: $colorFdMutedForeground;
+
+      $after: { display: none; }
+      separator: { display: none; }
+    }
+  }
+
+  // Wraps each group's links. Transparent in the horizontal bar; in the
+  // sidebar it becomes the railed list (vertical guide line) the links nest in.
+  items: {
+    display: "contents";
+
+    $xl: {
+      display: flex;
+      flexDirection: column;
+      gap: 2;
+      marginLeft: 10;
+      borderLeft: $colorFdBorder, 1;
+    }
   }
 
   NavLink: {
@@ -108,6 +169,25 @@ function Navigation() {
       borderColor: `color-mix(in srgb, var(--color-fd-primary) 30%, transparent)`;
       color: $colorFdPrimary;
     }
+
+    // Sidebar: flush links nested on the rail, marked by a left bar instead
+    // of a pill box.
+    $xl: {
+      border: none;
+      borderLeft: transparent, 2;
+      borderRadius: 0, 6, 6, 0;
+      marginLeft: -1;
+
+      $hover: {
+        background: $colorFdMuted;
+        borderLeftColor: $colorFdMutedForeground;
+      }
+
+      if("[aria-current='page']") {
+        borderLeftColor: $colorFdPrimary;
+        fontWeight: 600;
+      }
+    }
   }
 
   return (
@@ -118,12 +198,14 @@ function Navigation() {
             {group}
             <span _separator />
           </span>
-          
-          {items.map(({ slug, leaf }) => (
-            <NavLink key={slug} to={`/examples/${slug}`}>
-              {leaf}
-            </NavLink>
-          ))}
+
+          <div _items>
+            {items.map(({ slug, leaf }) => (
+              <NavLink key={slug} to={`/examples/${slug}`}>
+                {leaf}
+              </NavLink>
+            ))}
+          </div>
         </div>
       ))}
     </nav>


### PR DESCRIPTION
## Summary

UX improvements to the examples **playground** (website) and **dev shell** (examples app), split out from the example-ladder content (#202) so they can land independently. No example *content* here - purely the surrounding chrome.

Lands before the ladder; #202 will rebase onto `main` after this merges.

## Website playground (`website/app/routes/examples/`)

- **Nav hierarchy** - group labels anchor (size/weight); links are quieter bordered pills.
- **Vertical sidebar at `$xl`** - below the breakpoint the horizontal top-bar stays; at ≥1280px the nav restyles into a left sidebar (docs-rail: section labels + flush links on a guide line), capped to the viewport and scrolled internally.
- **Active link** - brand `--accent` (purple) tint/border, clearly distinct from the muted links.
- **Group-title occlusion gradient** - a real `_fade` element sized to the label gap: invisible at rest, fades links scrolling behind the sticky title (the old `$after` pseudo never rendered).
- **Example preview follows the site theme** - the cross-origin Sandpack preview can't be themed directly, so the resolved theme is baked into the hidden entry (`data-theme`, honored by `global.css`).
- **Ctrl+swipe to nudge the editor/preview split** - a `ref`-instruction wheel listener on `Panes` (non-passive, suppresses browser zoom; trackpad horizontal swipe via dominant-axis).

## Dev shell (`examples/app/`, `examples/global.css`)

- **Sticky sidebar group headers** - background covers links scrolling behind them.
- **Centered example content** - auto margins center when it fits and scroll from the top when taller; in the stacked layout the example fills the space below the nav instead of a fixed `70vh` that overflowed.

## Notes

- Works around an Expressive JSX parser bug (a selector nested inside a media block silently drops the rule) by nesting media inside the selector instead - filed as gabeklein/expressive-jsx#9.
- No changeset: examples are not published.