### PR TITLE
feat(examples): 0-to-100 example ladder

### DIFF
--- a/examples/apps/forms/App.css
+++ b/examples/apps/forms/App.css
@@ -1,0 +1,22 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+  width: 100%;
+  max-width: 30rem;
+  margin: 0 auto;
+}
+
+.form h1 {
+  margin: 0 0 var(--s2);
+}
+
+/* Submit hugs its content rather than stretching to the column width. */
+.form button {
+  align-self: flex-start;
+}
+
+/* Live-preview panel sits a touch below the controls. */
+.form pre {
+  margin: var(--s3) 0 0;
+}

--- a/examples/apps/forms/App.tsx
+++ b/examples/apps/forms/App.tsx
@@ -1,0 +1,42 @@
+import './App.css';
+
+// Form is kept separate as a reusable base class.
+import { Form } from "./Form";
+import { Preview } from "./Preview";
+
+// Extending Form inherits the plumbing; can focus on values and layout.
+class MyForm extends Form {
+  firstname = '';
+  lastname = '';
+  email = '';
+
+  // Methods and behavior are entirely up to you.
+  submit(){
+    if(!this.firstname || !this.lastname || !this.email){
+      alert('Please fill out all fields');
+      return;
+    }
+
+    alert(`Submitting ${this.firstname} ${this.lastname} with email ${this.email}`);
+  }
+
+  // Optional: render makes this self-contained.
+  // Without it, children render in context of the form.
+  render(){
+    const { input, submit } = this;
+
+    return (
+      <div className="form">
+        <h1>Example Form</h1>
+        <input ref={input.firstname} placeholder="Firstname" />
+        <input ref={input.lastname} placeholder="Lastname" />
+        <input ref={input.email} placeholder="Email Address" />
+        <button onClick={submit}>Submit</button>
+        <Preview />
+      </div>
+    );
+  }
+}
+
+// And just like that, we have a form component!
+export default MyForm;

--- a/examples/apps/forms/Form.tsx
+++ b/examples/apps/forms/Form.tsx
@@ -1,0 +1,41 @@
+import { Component, ref } from '@expressive/react';
+
+// Base class: binds inputs and provides context to children.
+export class Form extends Component {
+
+  // Use `ref` instruction to map over known keys of `this`,
+  // running a factory per key. Returns land at `this.input[key]`
+  // - here, ref-functions that two-way bind each input.
+  input = ref(this, (key) => {
+    let reset: (() => void) | undefined;
+
+    return (el: HTMLInputElement | null) => {
+      if (reset) reset();
+      if (!el) return;
+      reset = this.bind(el, key);
+    }
+  })
+  
+  // Bind input to its matching property; set name from key.
+  // Separate method so subclasses could override.
+  public bind(input: HTMLInputElement, key: keyof this) {
+    if (!(key in this) || typeof key !== "string")
+      throw new Error(`${this} has no property "${String(key)}"`);
+
+    if(!input.name) input.name = key;
+
+    const onInput = () => {
+      (this as any)[key] = input.value;
+    };
+    const unwatch = this.set(key, () => {
+      input.value = this[key] as string;
+    });
+
+    input.addEventListener('input', onInput);
+
+    return () => {
+      input.removeEventListener('input', onInput);
+      unwatch();
+    };
+  }
+}

--- a/examples/apps/forms/Preview.tsx
+++ b/examples/apps/forms/Preview.tsx
@@ -1,0 +1,16 @@
+import { Form } from "./Form";
+
+// Simple component to show live values for any form.
+export function Preview() {
+  // Access the nearest Form instance - MyForm included.
+  const form = Form.get();
+  const values = {} as Record<string, any>;
+
+  for (const key in form)
+    // Accessed properties subscribe to updates.
+    values[key] = (form as any)[key];
+
+  return (
+    <pre>{JSON.stringify(values, null, 2)}</pre>
+  );
+}

--- a/examples/apps/index.ts
+++ b/examples/apps/index.ts
@@ -1,0 +1,1 @@
+export default ['forms', 'tictactoe', 'router'];

--- a/examples/apps/router/App.css
+++ b/examples/apps/router/App.css
@@ -1,0 +1,21 @@
+.nav {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--accent-soft);
+  padding-bottom: 0.75rem;
+}
+
+.nav a {
+  color: var(--accent);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.nav a:hover {
+  text-decoration: underline;
+}
+
+.view {
+  color: var(--fg);
+}

--- a/examples/apps/router/App.tsx
+++ b/examples/apps/router/App.tsx
@@ -1,0 +1,57 @@
+import './App.css';
+
+import { Component, get } from '@expressive/react';
+import { Link, Route, Router } from '@expressive/router';
+
+// Routes ARE Components. The layout renders the nav once; the matched
+// child arrives as `props.children`.
+class Layout extends Component {
+  render() {
+    return (
+      <div className="container">
+        <h1>Router</h1>
+        <nav className="nav">
+          <Link to="/">Home</Link>
+          <Link to="/about">About</Link>
+          <Link to="/user/ada">User</Link>
+        </nav>
+        <div className="view">{this.props.children}</div>
+      </div>
+    );
+  }
+}
+
+class Home extends Component {
+  render() {
+    return <p>Welcome. Pick a link - navigation is in-memory here.</p>;
+  }
+}
+
+class About extends Component {
+  render() {
+    return <p>Each view is its own Component, matched by its Route.</p>;
+  }
+}
+
+// A page reads its own Route from context for params, match, navigation.
+class User extends Component {
+  route = get(Route);
+
+  render() {
+    return (
+      <p>
+        Param <code>name</code> = <b>{this.route.match?.name}</b>
+      </p>
+    );
+  }
+}
+
+export default () => (
+  <Router>
+    <Route as={Layout}>
+      <Route as={Home} />
+      <Route to="about" as={About} />
+      <Route to="user/:name" as={User} />
+    </Route>
+  </Router>
+);

--- a/examples/apps/tictactoe/App.css
+++ b/examples/apps/tictactoe/App.css
@@ -1,0 +1,65 @@
+.status {
+  font-size: var(--t-lg);
+  color: var(--muted);
+  margin: 0;
+}
+
+/* Win highlight is local to this example - the only color it adds. */
+.board {
+  --win: #16a34a;
+  --win-soft: #16a34a18;
+  display: grid;
+  grid-template-columns: repeat(3, 4rem);
+  grid-template-rows: repeat(3, 4rem);
+  gap: 6px;
+  margin: 0;
+}
+
+.board > button {
+  margin: 0;
+  padding: 0;
+  width: 4rem;
+  height: 4rem;
+  font-size: var(--t-2xl);
+  font-weight: 700;
+  color: var(--fg-soft);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+/* Empty cells invite a move; decided cells don't react to hover. */
+.board > button:hover {
+  background-color: var(--accent-soft);
+}
+
+.board > button.X {
+  color: var(--accent);
+  background: var(--bg);
+  cursor: default;
+}
+
+.board > button.O {
+  color: var(--muted);
+  background: var(--bg);
+  cursor: default;
+}
+
+.board > button.wins {
+  background: var(--win-soft);
+  border-color: var(--win);
+  color: var(--win);
+  cursor: default;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .board {
+    --win: #22c55e;
+    --win-soft: #22c55e22;
+  }
+}
+
+:root[data-theme='dark'] .board {
+  --win: #22c55e;
+  --win-soft: #22c55e22;
+}

--- a/examples/apps/tictactoe/App.tsx
+++ b/examples/apps/tictactoe/App.tsx
@@ -1,0 +1,72 @@
+import './App.css';
+
+import { Component, hot } from '@expressive/react';
+
+const LINES = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6]
+];
+
+class Game extends Component {
+  readonly board: string[] = hot(Array(9).fill(''));
+  turn: 'X' | 'O' = 'X';
+
+  get winner() {
+    const { board } = this;
+    for (const line of LINES) {
+      const [a, b, c] = line.map((i) => board[i]);
+      if (a && a === b && b === c) {
+        for (const i of line) board[i] += ' wins';
+        return a;
+      }
+    }
+  }
+
+  get full() {
+    return this.board.every(Boolean);
+  }
+
+  play(i: number) {
+    if (this.board[i] || this.winner) return;
+
+    this.board[i] = this.turn;
+    this.turn = this.turn === 'X' ? 'O' : 'X';
+  }
+
+  reset() {
+    this.board.fill("");
+    this.turn = 'X';
+  }
+
+  render() {
+    const { board, turn, winner, full, play, reset } = this;
+
+    return (
+      <div className="container">
+        <h1>Tic Tac Toe</h1>
+        <p className="status">
+          {winner ? `${winner} wins!` : full ? 'Draw!' : `${turn}'s turn`}
+        </p>
+        <div className={`board ${winner && 'done'}`}>
+          {board.map((cell, i) => (
+            <button
+              key={i}
+              onClick={() => play(i)}
+              className={cell || ""}>
+              {cell[0]}
+            </button>
+          ))}
+        </div>
+        <button onClick={reset}>New game</button>
+      </div>
+    );
+  }
+}
+
+export default Game;

--- a/examples/composition/context/App.css
+++ b/examples/composition/context/App.css
@@ -1,0 +1,11 @@
+.context {
+  max-width: 28rem;
+}
+
+.context-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s3);
+  width: 100%;
+}

--- a/examples/composition/context/App.tsx
+++ b/examples/composition/context/App.tsx
@@ -1,0 +1,74 @@
+import './App.css';
+
+import State, { Component, get, Provider } from '@expressive/react';
+
+class FooBar extends State {
+  foo = 0;
+  bar = 0;
+}
+
+// A Component is a renderable State - it both reads upstream
+// context and provides itself to descendants.
+class BarBaz extends Component {
+  // The `get` instruction lets in-context State/Components
+  // find each other for direct access to state and methods.
+  foobar = get(FooBar);
+
+  announce(){
+    alert(`Foo is ${this.foobar.foo} and Bar is ${this.foobar.bar}`);
+  }
+}
+
+export default function App() {
+  return (
+    // Provider adds any State to context for descendants to access.
+    <div className="container context">
+      <h1>Context Example</h1>
+      <Provider for={FooBar}>
+        {/* Components add themselves to context. */}
+        <BarBaz>
+          <Foo />
+          <Bar />
+          <Baz />
+        </BarBaz>
+      </Provider>
+    </div>
+  );
+}
+
+function Foo() {
+  // `.get()` finds the nearest provided instance (unlike `.use()`
+  // which creates one). Destructured fields subscribe either way.
+  // `is` loops back to `this` for writes and silent reads.
+  const { is: foobar, bar } = FooBar.get();
+
+  return (
+    <div className="context-row">
+      <button onClick={() => foobar.foo++}>Foo</button>
+      <small>(Bar was clicked {bar} times)</small>
+    </div>
+  );
+}
+
+function Bar() {
+  // Dependencies are per-component, so this only
+  // refreshes when `foo` changes, not when `bar` does.
+  const { is: foobar, foo } = FooBar.get();
+
+  return (
+    <div className="context-row">
+      <button onClick={() => foobar.bar++}>Bar</button>
+      <small>(Foo was clicked {foo} times)</small>
+    </div>
+  );
+}
+
+function Baz() {
+  const { announce } = BarBaz.get();
+
+  return (
+    <div className="context-row">
+      <button onClick={announce}>Hello FooBar</button>
+    </div>
+  );
+}

--- a/examples/composition/extension/App.css
+++ b/examples/composition/extension/App.css
@@ -1,0 +1,18 @@
+.panel {
+  margin-bottom: 1rem;
+  border: 1px solid var(--accent-soft);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.panel header {
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+
+.panel .body {
+  padding: 0.75rem;
+  color: var(--fg);
+}

--- a/examples/composition/extension/App.tsx
+++ b/examples/composition/extension/App.tsx
@@ -1,0 +1,46 @@
+import './App.css';
+
+import { Component } from '@expressive/react';
+import type { ReactNode } from 'react';
+
+// A base that owns shared chrome. When a subclass overrides render(),
+// it COMPOSES with the base instead of replacing it: the base render
+// runs outermost, and the subclass's output arrives as `props.children`.
+// No super.render() call - just read children where content should slot.
+class Panel extends Component {
+  title = 'Panel';
+
+  render(props = {} as { children?: ReactNode }) {
+    return (
+      <section className="panel">
+        <header>{this.title}</header>
+        <div className="body">{props.children}</div>
+      </section>
+    );
+  }
+}
+
+// Each subclass authors only its content; the Panel chrome wraps it.
+class Welcome extends Panel {
+  title = 'Welcome';
+
+  render() {
+    return <p>This paragraph slots into the Panel chrome - defined once, above.</p>;
+  }
+}
+
+class Goodbye extends Panel {
+  title = 'Goodbye';
+
+  render() {
+    return <p>So does this one. Same base, different content.</p>;
+  }
+}
+
+export default () => (
+  <div className="container">
+    <h1>Render Composition</h1>
+    <Welcome />
+    <Goodbye />
+  </div>
+);

--- a/examples/composition/index.ts
+++ b/examples/composition/index.ts
@@ -1,0 +1,1 @@
+export default ['extension', 'subcomponents', 'context', 'singletons'];

--- a/examples/composition/singletons/App.css
+++ b/examples/composition/singletons/App.css
@@ -1,0 +1,6 @@
+.size {
+  font-size: var(--t-2xl);
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0;
+}

--- a/examples/composition/singletons/App.tsx
+++ b/examples/composition/singletons/App.tsx
@@ -1,0 +1,58 @@
+import './App.css';
+
+import { Session } from './Session';
+import { Theme } from './Theme';
+import { Viewport } from './Viewport';
+
+// Singletons: created once, right here, the way you would at your app's entry
+// point next to the root render. State.new() activates the instance and parks
+// it in the global context, so any component can reach it with State.get().
+Viewport.new();
+Session.new();
+Theme.new();
+
+export default function App() {
+  return (
+    <div className="container">
+      <h1>Singletons</h1>
+      <Size />
+      <Account />
+      <Appearance />
+      <small>Three singletons, each created once - components subscribe with `.get()`.</small>
+    </div>
+  );
+}
+
+// Each component fetches its singleton with .get() and re-renders only when the
+// fields it reads change - no props, no shared parent passing state down.
+function Size() {
+  const { width, compact } = Viewport.get();
+  return (
+    <>
+      <p className="size">{width}px</p>
+      <p>{compact ? 'Compact layout' : 'Wide layout'}</p>
+    </>
+  );
+}
+
+function Account() {
+  const { user, login, logout } = Session.get();
+  return user ? (
+    <p>
+      Signed in as {user} - <button onClick={logout}>Log out</button>
+    </p>
+  ) : (
+    <p>
+      Signed out - <button onClick={login}>Log in</button>
+    </p>
+  );
+}
+
+function Appearance() {
+  const { dark, toggle } = Theme.get();
+  return (
+    <p>
+      <button onClick={toggle}>{dark ? 'Dark' : 'Light'} theme</button>
+    </p>
+  );
+}

--- a/examples/composition/singletons/Session.ts
+++ b/examples/composition/singletons/Session.ts
@@ -1,0 +1,15 @@
+import State from '@expressive/react';
+
+// App-wide session. One instance for the whole app - login state lives in
+// exactly one place, and every component reads the same source of truth.
+export class Session extends State {
+  user: string | null = null;
+
+  login() {
+    this.user = 'Ada';
+  }
+
+  logout() {
+    this.user = null;
+  }
+}

--- a/examples/composition/singletons/Theme.ts
+++ b/examples/composition/singletons/Theme.ts
@@ -1,0 +1,17 @@
+import State from '@expressive/react';
+
+// Theme is global by nature - there is only one document to paint. The effect
+// in new() writes the active theme to the root element, retinting everything.
+export class Theme extends State {
+  dark = false;
+
+  toggle() {
+    this.dark = !this.dark;
+  }
+
+  protected new() {
+    return this.get(({ dark }) => {
+      document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+    });
+  }
+}

--- a/examples/composition/singletons/Viewport.ts
+++ b/examples/composition/singletons/Viewport.ts
@@ -1,0 +1,19 @@
+import State from '@expressive/react';
+
+// Display-agnostic logic with no render() of its own - a plain State that any
+// component can subscribe to. Mutable inputs are fields, derived values are
+// getters, and setup/teardown lives in new().
+export class Viewport extends State {
+  width = window.innerWidth;
+
+  get compact() {
+    return this.width < 600;
+  }
+
+  // Runs once when ready; the returned function runs on teardown.
+  protected new() {
+    const update = () => (this.width = window.innerWidth);
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }
+}

--- a/examples/composition/subcomponents/App.css
+++ b/examples/composition/subcomponents/App.css
@@ -1,0 +1,31 @@
+.picker {
+  margin-bottom: var(--s5);
+}
+
+.picker h2 {
+  font-size: var(--t-lg);
+  margin-bottom: var(--s3);
+}
+
+li.active {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+/* Palette variant: lay the items out as a horizontal row of swatches. */
+.palette ul {
+  flex-direction: row;
+  justify-content: center;
+}
+
+.palette .swatch {
+  display: block;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--r-sm);
+}
+
+.palette li.active {
+  background: none;
+  outline: 2px solid var(--accent);
+}

--- a/examples/composition/subcomponents/App.tsx
+++ b/examples/composition/subcomponents/App.tsx
@@ -1,0 +1,60 @@
+import './App.css';
+
+import Split from '@common/Split';
+
+// Picker is kept separate as a reusable, behavior-complete base.
+import { Picker } from './Picker';
+
+const COLORS: Record<string, string> = {
+  Coral: '#ff6f61',
+  Sky: '#4dabf7',
+  Mint: '#51cf66',
+};
+
+// A plain vertical list. Only Item is overridden - selection behavior
+// and the default Summary are inherited untouched.
+class FruitPicker extends Picker {
+  name = 'Fruit';
+  items = ['Apple', 'Banana', 'Cherry'];
+
+  Item({ index }: { index: number }) {
+    return (
+      <>
+        {index === this.selected ? '🍎 ' : '🍏 '}
+        {this.items[index]}
+      </>
+    );
+  }
+}
+
+// A very different UX from the same base: a horizontal row of color
+// swatches. It overrides Item AND Summary - the hex readout is a
+// feature the FruitPicker doesn't have.
+class PalettePicker extends Picker {
+  name = 'Color';
+  className = 'palette';
+  items = Object.keys(COLORS);
+
+  Item({ index }: { index: number }) {
+    return <span className="swatch" style={{ background: COLORS[this.items[index]] }} />;
+  }
+
+  Summary() {
+    const name = this.items[this.selected];
+    return (
+      <small>
+        {name} <code>{COLORS[name]}</code>
+      </small>
+    );
+  }
+}
+
+export default () => (
+  <div className="container">
+    <h1>Overrideable Subcomponents</h1>
+    <Split>
+      <FruitPicker />
+      <PalettePicker />
+    </Split>
+  </div>
+);

--- a/examples/composition/subcomponents/Picker.tsx
+++ b/examples/composition/subcomponents/Picker.tsx
@@ -1,0 +1,55 @@
+import { Component, set } from '@expressive/react';
+
+/**
+ * A generic, behavior-complete component: it owns the data and the
+ * selection logic, but leaves *appearance* to overrideable
+ * subcomponents. Think Table, Toast, Loader - defined behavior,
+ * undefined aesthetics. The PascalCase methods are the seams.
+ */
+export class Picker extends Component {
+  name = '';
+  items = [] as string[];
+  selected = 0;
+
+  /**
+   * Style pass-through so each consumer can class its own look.
+   * Defaults to name.
+   */
+  className = set(() => this.name.toLowerCase());
+
+  choose(index: number) {
+    this.selected = index;
+  }
+
+  /**
+   * Visual seam: how a single item looks. No behavior here, so an
+   * override can't touch the click-to-select wiring in render().
+   */
+  Item({ index }: { index: number }) {
+    return <>{this.items[index]}</>;
+  }
+
+  /** Visual seam: a readout of the current choice. */
+  Summary() {
+    return <small>Selected: {this.items[this.selected]}</small>;
+  }
+
+  render() {
+    return (
+      <div className={`picker ${this.className}`}>
+        {this.name && <h2>Choose {this.name}</h2>}
+        <ul>
+          {this.items.map((item, i) => (
+            <li
+              key={item}
+              className={i === this.selected ? 'active' : ''}
+              onClick={() => this.choose(i)}>
+              <this.Item index={i} />
+            </li>
+          ))}
+        </ul>
+        <this.Summary />
+      </div>
+    );
+  }
+}

--- a/examples/essentials/async/App.css
+++ b/examples/essentials/async/App.css
@@ -1,0 +1,31 @@
+.timer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 400px;
+  gap: var(--s3);
+}
+
+.seconds {
+  width: 1.2em;
+  display: inline-block;
+}
+
+.timer p {
+  margin: 0;
+}
+
+.timer button {
+  margin: 0 var(--s2);
+}
+
+.box {
+  margin: 0;
+  font-size: 4rem;
+  line-height: 1;
+}
+
+.emoji {
+  font-size: 2rem;
+  line-height: 1;
+}

--- a/examples/essentials/async/App.tsx
+++ b/examples/essentials/async/App.tsx
@@ -1,0 +1,47 @@
+import './App.css';
+
+import { Control } from './Control';
+
+const App = () => {
+  // Control is a State, separating concerns of this component.
+  // This focuses on presentation, while Control focuses on behavior.
+  const { agent, dead, getNewAgent, remaining } = Control.use();
+
+  if (dead === true)
+    return (
+      <div className="container">
+        <div className="emoji">🙀💥</div>
+        <h2>Unfortunately, the cat exploded.</h2>
+      </div>
+    );
+
+  if (dead === false)
+    return (
+      <div className="container">
+        <div className="emoji">😸👍</div>
+        <h2>Oh, the cat did not explode.</h2>
+      </div>
+    );
+
+  return (
+    <div className="container">
+      <h1>Async Example</h1>
+      <div className="timer">
+        <h1 className="box">📦</h1>
+        <p>
+          <b>Agent {agent}</b>, we need you to defuse the bomb!
+        </p>
+        <p>
+          If you can't do it in <span className='seconds'>{remaining}</span> seconds, Schrödinger's cat may or
+          may not die. But there's still time!
+        </p>
+        <p>
+          <button onClick={getNewAgent}>Tap another agent</button>
+          if you think they can do it.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/examples/essentials/async/Control.tsx
+++ b/examples/essentials/async/Control.tsx
@@ -1,0 +1,29 @@
+import State from '@expressive/react';
+
+export class Control extends State {
+  // Properties set starting values; assignments dispatch updates.
+  agent = 'Bond';
+  remaining = 30;
+  dead?: boolean = undefined;
+
+  // new() runs once when ready. The returned function runs on
+  // teardown - handy for clearing timers or subscriptions.
+  protected new() {
+    const timer = setInterval(() => {
+      if (--this.remaining > 0) return;
+
+      this.dead = Math.random() > 0.5;
+      clearInterval(timer);
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }
+
+  // Async methods assign to `this` - no thunks needed.
+  async getNewAgent() {
+    const res = await fetch('https://randomuser.me/api?nat=gb&results=1');
+    const data = await res.json();
+
+    this.agent = data.results[0].name.last;
+  }
+}

--- a/examples/essentials/boundary/App.css
+++ b/examples/essentials/boundary/App.css
@@ -1,0 +1,8 @@
+.error {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--accent);
+  color: var(--fg);
+  background: var(--accent-soft);
+}

--- a/examples/essentials/boundary/App.tsx
+++ b/examples/essentials/boundary/App.tsx
@@ -1,0 +1,52 @@
+import './App.css';
+
+import { Component } from '@expressive/react';
+
+// Owns the boundary: `catch()` handles a throw from anything it renders.
+class Guard extends Component {
+  failing = true;
+
+  // A subcomponent that throws during render until recovered.
+  Child() {
+    if (this.failing)
+      throw new Error('The child failed to render.');
+
+    return <p className="ok">Recovered - rendering normally now.</p>;
+  }
+
+  // Set `this.fallback` for the error UI; the returned promise keeps it up
+  // until the user retries. (A catch that resolves immediately would just
+  // re-render, throw again, and loop.)
+  catch(error: Error) {
+    this.fallback = (
+      <div className="error">
+        <p>Caught: {error.message}</p>
+        <button onClick={() => this.recover()}>Retry</button>
+      </div>
+    );
+
+    return new Promise<void>((resolve) => {
+      this.resume = resolve;
+    });
+  }
+
+  resume = () => {};
+
+  recover() {
+    this.failing = false;
+    this.resume(); // resolve catch -> boundary retries the render
+  }
+
+  render() {
+    return <this.Child />;
+  }
+}
+
+// Title lives outside the boundary, so only the Guard subtree swaps to
+// the fallback while the rest of the page stays put.
+export default () => (
+  <div className="container">
+    <h1>Error Boundary</h1>
+    <Guard />
+  </div>
+);

--- a/examples/essentials/counter/App.css
+++ b/examples/essentials/counter/App.css
@@ -1,0 +1,29 @@
+/* Counter is a minimal hero - center the title with its controls. */
+.container {
+  text-align: center;
+}
+
+.counter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.counter pre {
+  font-size: var(--t-2xl);
+  font-weight: 500;
+  width: 5rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: center;
+  cursor: pointer;
+  color: var(--fg);
+}
+
+.counter .button {
+  width: 56px;
+  height: 56px;
+  font-size: var(--t-xl);
+}

--- a/examples/essentials/counter/App.tsx
+++ b/examples/essentials/counter/App.tsx
@@ -1,0 +1,48 @@
+import './App.css';
+
+import Button from '@common/Button';
+import { Component } from '@expressive/react';
+
+// Yes, it's a class with render(). No, it's nothing like the class
+// components you were told to avoid: no setState, no lifecycle methods,
+// no useState/useCallback/useMemo, no dependency arrays.
+//
+// Fields are reactive - assign one and the view updates. Methods are
+// auto-bound, so you can pull them off `this` and they still work.
+// One class is the state AND the view.
+class Counter extends Component {
+  current = 1;
+
+  // Declared methods, not arrows - binding is intrinsic, not lexical.
+  // That's why destructuring them in render() below is safe.
+  increment() {
+    this.current++;
+  }
+
+  decrement() {
+    this.current--;
+  }
+
+  reset() {
+    this.current = 1;
+  }
+
+  render() {
+    const { current, increment, decrement, reset } = this;
+
+    return (
+      <div className="container">
+        <h1>Counter Example</h1>
+        <div className="counter">
+          <Button onClick={decrement}>{'−'}</Button>
+          {/* Click the number to reset. */}
+          <pre onClick={reset}>{current}</pre>
+          <Button onClick={increment}>{'+'}</Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+// It's the element and the state in one - no hook, no provider.
+export default () => <Counter />;

--- a/examples/essentials/fetch/App.css
+++ b/examples/essentials/fetch/App.css
@@ -1,0 +1,17 @@
+.fetch-action {
+  align-self: center;
+}
+
+.fetch-result {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s3);
+  margin: 0;
+  color: var(--fg-soft);
+}
+
+.fetch-status {
+  margin: 0;
+  color: var(--muted);
+}

--- a/examples/essentials/fetch/App.tsx
+++ b/examples/essentials/fetch/App.tsx
@@ -1,0 +1,51 @@
+import './App.css';
+
+import { Query } from './Query';
+
+// Extending Query gives us all the request bookkeeping for free.
+// We just supply `request()` - the actual endpoint-specific work -
+// and inherit waiting/error tracking, run, and reset.
+
+class HelloQuery extends Query {
+  async request() {
+    const res = await fetch('https://randomuser.me/api?nat=us&results=1');
+    const { first, last } = (await res.json()).results[0].name;
+    return `Hello ${first} ${last}`;
+  }
+}
+
+const Example = () => {
+  // `.use()` creates an instance scoped to App.
+  // Destructuring subscribes us to those fields.
+  const { response, error, waiting, reset, run } = HelloQuery.use();
+
+  if (response) 
+    return (
+      <p className="fetch-result">
+        <span>Server said: {response}</span>
+        <button onClick={reset}>Reset</button>
+      </p>
+    )
+
+  if (error) 
+    return (
+      <p className="fetch-result">
+        <span>Error: {error.message}</span>
+        <button onClick={reset}>Reset</button>
+      </p>
+    )
+
+  if (waiting) 
+    return <p className="fetch-status">Sent. Waiting on response...</p>
+
+  return (
+    <button className="fetch-action" onClick={run}>Say hello to server</button>
+  )
+};
+
+export default () => (
+  <div className="container">
+    <h1>Fetch Example</h1>
+    <Example />
+  </div>
+);

--- a/examples/essentials/fetch/Query.ts
+++ b/examples/essentials/fetch/Query.ts
@@ -1,0 +1,36 @@
+import State from '@expressive/react';
+
+// Most async work has the same shape - we wait for a response, get
+// something back, sometimes get an error. Query handles that scaffolding
+// so any specific endpoint only plugs in the part that's actually different.
+
+export abstract class Query extends State {
+  // Three flags covering the lifecycle of a request.
+  // A component reading any of these refreshes when it changes.
+  response?: any = undefined;
+  error?: Error = undefined;
+  waiting = false;
+
+  // Subclasses supply the actual fetch. Whatever you return
+  // becomes `response`; throw to populate `error`.
+  abstract request(): Promise<any>;
+
+  // Call `run()` to kick things off. Assignments to `this` along the
+  // way refresh anyone subscribed - no manual notify, no setState.
+  async run() {
+    this.waiting = true;
+
+    try {
+      this.response = await this.request();
+    } catch (error) {
+      if (error instanceof Error) this.error = error;
+    } finally {
+      this.waiting = false;
+    }
+  }
+
+  reset() {
+    this.response = undefined;
+    this.error = undefined;
+  }
+}

--- a/examples/essentials/index.ts
+++ b/examples/essentials/index.ts
@@ -1,0 +1,1 @@
+export default ['counter', 'reactivity', 'fetch', 'async', 'boundary'];

--- a/examples/essentials/reactivity/App.css
+++ b/examples/essentials/reactivity/App.css
@@ -1,0 +1,18 @@
+.container label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  color: var(--fg);
+}
+
+.container input[type='number'] {
+  width: 8rem;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+}
+
+.result {
+  font-size: var(--t-lg);
+  color: var(--fg);
+}

--- a/examples/essentials/reactivity/App.tsx
+++ b/examples/essentials/reactivity/App.tsx
@@ -1,0 +1,56 @@
+import './App.css';
+
+import { Component } from '@expressive/react';
+
+// Beyond single values: a getter is a *computed* property. It tracks
+// whatever it reads and recomputes only when those inputs change - no
+// useMemo, no dependency array. Getters may even read other getters.
+class TipCalculator extends Component {
+  bill = 50;
+  tipPercent = 18;
+
+  get tip() {
+    return (this.bill * this.tipPercent) / 100;
+  }
+
+  get total() {
+    return this.bill + this.tip; // depends on another computed
+  }
+
+  render() {
+    const { bill, tipPercent, tip, total } = this;
+
+    return (
+      <div className="container">
+        <h1>Reactivity</h1>
+
+        <label>
+          Bill
+          <input
+            type="number"
+            value={bill}
+            onChange={(e) => (this.bill = +e.target.value)}
+          />
+        </label>
+
+        <label>
+          Tip: {tipPercent}%
+          <input
+            type="range"
+            min={0}
+            max={30}
+            value={tipPercent}
+            onChange={(e) => (this.tipPercent = +e.target.value)}
+          />
+        </label>
+
+        {/* tip and total recompute on their own when either input changes */}
+        <p className="result">
+          Tip <b>${tip.toFixed(2)}</b> · Total <b>${total.toFixed(2)}</b>
+        </p>
+      </div>
+    );
+  }
+}
+
+export default () => <TipCalculator />;

--- a/examples/state/hot/App.css
+++ b/examples/state/hot/App.css
@@ -1,0 +1,4 @@
+li.done {
+  opacity: 0.55;
+  text-decoration: line-through;
+}

--- a/examples/state/hot/App.tsx
+++ b/examples/state/hot/App.tsx
@@ -1,0 +1,71 @@
+import './App.css';
+
+import State, { Component, use } from '@expressive/react';
+
+// Each item is its own State - a small reactive object with behavior.
+class Item extends State {
+  text = '';
+  done = false;
+
+  toggle() {
+    this.done = !this.done;
+  }
+}
+
+// A row subscribes to one item with use(), so toggling re-renders just
+// that row. (Reading a child's fields off a parent array does NOT
+// subscribe the parent - each child is observed where it's rendered.)
+const Row = ({ item }: { item: Item }) => {
+  const { text, done, toggle } = use(item);
+
+  return (
+    <li className={done ? 'done' : ''} onClick={toggle}>
+      {text}
+    </li>
+  );
+};
+
+// The list owns the collection. Adding reassigns `items`, so the list
+// re-renders to show the new row.
+class TodoList extends Component {
+  items = [Item.new({ text: 'Learn Expressive' })];
+  draft = '';
+
+  add() {
+    if (!this.draft) return;
+    this.items = [...this.items, Item.new({ text: this.draft })];
+    this.draft = '';
+  }
+
+  render() {
+    const { items, draft } = this;
+
+    return (
+      <div className="container">
+        <h1>Nested State</h1>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            this.add();
+          }}>
+          <input
+            value={draft}
+            placeholder="Add a todo, press Enter"
+            onChange={(e) => (this.draft = e.target.value)}
+          />
+        </form>
+
+        <ul>
+          {items.map((item) => (
+            <Row key={String(item)} item={item} />
+          ))}
+        </ul>
+
+        <small>{items.length} items</small>
+      </div>
+    );
+  }
+}
+
+export default () => <TodoList />;

--- a/examples/state/index.ts
+++ b/examples/state/index.ts
@@ -1,0 +1,1 @@
+export default ['refs', 'hot'];

--- a/examples/state/refs/App.css
+++ b/examples/state/refs/App.css
@@ -1,0 +1,7 @@
+.container input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  font: inherit;
+  margin-bottom: 1rem;
+}

--- a/examples/state/refs/App.tsx
+++ b/examples/state/refs/App.tsx
@@ -1,0 +1,26 @@
+import './App.css';
+
+import { Component, ref } from '@expressive/react';
+
+// The `ref` instruction is the useRef replacement: a slot for a value
+// outside the render data - here a DOM node. Pass it straight to `ref=`
+// (it's callable) and read `.current` to reach the element imperatively.
+class Field extends Component {
+  input = ref<HTMLInputElement>();
+
+  focus() {
+    this.input.current?.focus();
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <h1>Refs</h1>
+        <input ref={this.input} placeholder="Press the button to focus me" />
+        <button onClick={this.focus}>Focus the input</button>
+      </div>
+    );
+  }
+}
+
+export default () => <Field />;


### PR DESCRIPTION
The 0-to-100 example ladder, stacked on #205 (manifest routing regime + dev-shell harness). Targets `docs/examples-ladder`; rebase to `main` once #205 merges.

## Commits

One per example group, each a directory of bare-slug examples plus an `index.ts` manifest listing them in display order:

- **essentials** - counter, reactivity, fetch, async, boundary
- **composition** - extension, subcomponents, context, singletons
- **state** - refs, hot
- **apps** - forms, tictactoe, router

## Manifest convention (defined in #205)

- `examples/<group>/index.ts` - `export default string[]` of example slugs (order); optional `export const label` overrides the inferred titleCase.
- Directories are stable slugs; reordering edits one manifest line, never a rename.

## Verification

- SPA `vite build` clean (per-example code-split chunks).
- SPA runtime (Playwright): all groups render in manifest order, redirect lands on the first example, iframe loads.

examples are private (unpublished) - no changeset.