### PR TITLE
feat(examples): add stopwatch app example

### DIFF
--- a/examples/content/apps/index.ts
+++ b/examples/content/apps/index.ts
@@ -1,1 +1,1 @@
-export default ['forms', 'tictactoe', 'router'];
+export default ['forms', 'tictactoe', 'stopwatch', 'router'];

--- a/examples/content/apps/stopwatch/App.css
+++ b/examples/content/apps/stopwatch/App.css
@@ -1,0 +1,30 @@
+.stopwatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+}
+
+.stopwatch h1 {
+  margin: 0;
+}
+
+.time {
+  margin: 0;
+  font-size: var(--t-3xl, var(--t-2xl));
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.05em;
+  color: var(--fg-soft);
+  transition: color 0.2s;
+}
+
+/* A subtle cue that time is advancing. */
+.time.running {
+  color: var(--accent);
+}
+
+.controls {
+  display: flex;
+  gap: var(--s2);
+}

--- a/examples/content/apps/stopwatch/App.tsx
+++ b/examples/content/apps/stopwatch/App.tsx
@@ -1,0 +1,55 @@
+import './App.css';
+
+import { Component } from '@expressive/react';
+
+class Stopwatch extends Component {
+  elapsed = 0;
+  running = false;
+
+  // A single interval lives for the component's lifetime; it only
+  // accumulates while `running`. Returning a cleanup clears it on unmount.
+  protected new() {
+    const id = setInterval(() => {
+      if (this.running) this.elapsed += 10;
+    }, 10);
+
+    return () => clearInterval(id);
+  }
+
+  get display() {
+    const cs = Math.floor(this.elapsed / 10) % 100;
+    const s = Math.floor(this.elapsed / 1000) % 60;
+    const m = Math.floor(this.elapsed / 60000);
+    const pad = (n: number) => String(n).padStart(2, '0');
+
+    return `${pad(m)}:${pad(s)}.${pad(cs)}`;
+  }
+
+  toggle() {
+    this.running = !this.running;
+  }
+
+  reset() {
+    this.running = false;
+    this.elapsed = 0;
+  }
+
+  render() {
+    const { display, running, elapsed, toggle, reset } = this;
+
+    return (
+      <div className="stopwatch">
+        <h1>Stopwatch</h1>
+        <p className={`time ${running ? 'running' : ''}`}>{display}</p>
+        <div className="controls">
+          <button onClick={toggle}>{running ? 'Stop' : 'Start'}</button>
+          <button onClick={reset} disabled={!elapsed && !running}>
+            Reset
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Stopwatch;


### PR DESCRIPTION
## Scope

Adds a **Stopwatch** to the `apps` example group — a small self-contained mini-app alongside `forms`, `tictactoe`, and `router`.

## What & why

- New `examples/content/apps/stopwatch/{App.tsx,App.css}`, registered in the apps manifest (`index.ts`) between `tictactoe` and `router`.
- Chosen to fill a gap: `counter` lives in `essentials` and a todo already lives in `state/hot`, so this covers different ground.
- Demonstrates the **`new()` lifecycle hook returning a cleanup function** — a single `setInterval` lives for the component's lifetime, accumulates only while `running`, and is cleared on unmount (the pattern documented in `skills/react/component.md`).
- Also shows a **computed getter** (`display` formats elapsed ms as `mm:ss.cs`) and auto-bound `toggle`/`reset` methods.
- CSS uses the shared theme variables (`--s2`, `--s3`, `--accent`, …) for consistency with the other examples.

## Verification

- `tsc --noEmit` on the examples project: the new files introduce no type errors. (There is one pre-existing, unrelated error in `packages/router/src/route.tsx`, confirmed present with these changes stashed.)

## Changeset

None — example-only content with no change to library public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)