### PR TITLE
feat(examples): emoji storefront app with cart & checkout

### DIFF
--- a/examples/content/apps/index.ts
+++ b/examples/content/apps/index.ts
@@ -1,1 +1,1 @@
-export default ['forms', 'tictactoe', 'stopwatch', 'router'];
+export default ['forms', 'tictactoe', 'stopwatch', 'router', 'store'];

--- a/examples/content/apps/store/App.css
+++ b/examples/content/apps/store/App.css
@@ -1,0 +1,330 @@
+/* Only this example's iframe loads this file, so these overrides of the shared
+   column are safely scoped to the store: widen it, and pin it to the top
+   (the base rule's `margin: auto` would otherwise center the header
+   vertically on short pages like the product view or an empty cart). */
+body.example #root {
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+.store {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s5);
+  width: 100%;
+}
+
+/* Header ------------------------------------------------------------------ */
+
+.store-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s4);
+  padding-bottom: var(--s4);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  font-size: var(--t-xl);
+  font-weight: 700;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+}
+
+.brand:hover {
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.cart-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--t-xl);
+  line-height: 1;
+  padding: var(--s2);
+  border-radius: var(--r);
+  border: 1px solid var(--border-2);
+}
+
+.cart-btn:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: grid;
+  place-items: center;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 999px;
+  font-size: var(--t-xs);
+  font-weight: 600;
+  font-family: var(--font-sans);
+}
+
+/* Category chips ---------------------------------------------------------- */
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2);
+  margin-bottom: var(--s5);
+}
+
+.chip {
+  padding: var(--s1) var(--s3);
+  border: 1px solid var(--border-2);
+  border-radius: 999px;
+  color: var(--fg-soft);
+  font-size: var(--t-sm);
+  font-weight: 500;
+}
+
+.chip:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.chip.on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+
+/* Product grid ------------------------------------------------------------ */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: var(--s3);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s1);
+  padding: var(--s4) var(--s3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--fg);
+  transition:
+    border-color 0.15s,
+    transform 0.15s;
+}
+
+.card:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.card-emoji {
+  font-size: 2.75rem;
+  line-height: 1.1;
+}
+
+.card-name {
+  font-weight: 600;
+}
+
+.card-price {
+  color: var(--muted);
+  font-size: var(--t-sm);
+  font-family: var(--font-mono);
+}
+
+/* Breadcrumbs ------------------------------------------------------------- */
+
+.crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s2);
+  font-size: var(--t-sm);
+  color: var(--muted);
+  margin-bottom: var(--s5);
+}
+
+.crumbs .sep {
+  color: var(--border-2);
+}
+
+.crumbs [aria-current='page'] {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Product page ------------------------------------------------------------ */
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s6);
+  align-items: center;
+}
+
+.hero-emoji {
+  font-size: 8rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.hero-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+  min-width: 12rem;
+  flex: 1;
+}
+
+.hero-price {
+  margin: 0;
+  font-size: var(--t-xl);
+  font-family: var(--font-mono);
+  color: var(--fg-soft);
+}
+
+/* Quantity stepper (shared by product page + cart lines) ------------------ */
+
+.qty {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s2);
+}
+
+.qty button {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  font-size: var(--t-lg);
+}
+
+.qty-val {
+  min-width: 1.5rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.primary:hover {
+  border-color: var(--accent);
+  filter: brightness(1.08);
+}
+
+/* Cart -------------------------------------------------------------------- */
+
+.cart {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s4);
+}
+
+.lines {
+  gap: var(--s2);
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: var(--s4);
+  padding: var(--s3);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  cursor: default;
+}
+
+.line:hover {
+  background: none;
+}
+
+.line-emoji {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.line-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 6rem;
+}
+
+.line-info a {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.line-sub {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  min-width: 5rem;
+  text-align: right;
+}
+
+.remove {
+  padding: var(--s1) var(--s2);
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.remove:hover {
+  color: var(--fg);
+  border-color: var(--border-2);
+}
+
+.summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: var(--s3);
+  border-top: 1px solid var(--border);
+  font-weight: 600;
+}
+
+.summary .total {
+  font-size: var(--t-xl);
+  font-family: var(--font-mono);
+}
+
+.checkout {
+  align-self: stretch;
+  text-align: center;
+  padding: var(--s3);
+  font-size: var(--t-lg);
+}
+
+/* Empty / confirmation / 404 states --------------------------------------- */
+
+.notice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  text-align: center;
+  padding: var(--s6) var(--s4);
+}
+
+.big-emoji {
+  font-size: 4rem;
+  line-height: 1;
+}

--- a/examples/content/apps/store/App.tsx
+++ b/examples/content/apps/store/App.tsx
@@ -1,6 +1,8 @@
 import './App.css';
 
-import { Component, Provider } from '@expressive/react';
+import { type ReactNode } from 'react';
+
+import { Provider } from '@expressive/react';
 import { Link, Route, Router } from '@expressive/router';
 
 import { CartPage } from './Cart';
@@ -8,28 +10,24 @@ import { ProductPage } from './Product';
 import { Cart } from './Store';
 import { Storefront } from './Storefront';
 
-// Persistent chrome: brand + cart button stay put while the matched page
-// arrives as `props.children`. Same instance across navigation, so the cart
-// badge updates in place.
-class Layout extends Component {
-  render() {
-    return (
-      <div className="store">
-        <header className="store-head">
-          <Link to="/" className="brand">
-            🛍️ Emoji Store
-          </Link>
-          <CartButton />
-        </header>
-        <div className="store-body">{this.props.children}</div>
-      </div>
-    );
-  }
-}
+// Persistent chrome: the brand + cart button stay put while the matched page
+// arrives as `children`. Purely presentational - it reads nothing reactive
+// itself, so a plain function (the badge subscribes inside CartButton).
+const Layout = ({ children }: { children?: ReactNode }) => (
+  <div className="store">
+    <header className="store-head">
+      <Link to="/" className="brand">
+        🛍️ Emoji Store
+      </Link>
+      <CartButton />
+    </header>
+    <div className="store-body">{children}</div>
+  </div>
+);
 
-// Reads just `count` off the shared cart, so it re-renders only when the
-// item count changes - not on every unrelated cart mutation.
-function CartButton() {
+// Reads just `count` off the shared cart, so it re-renders only when the item
+// count changes - not on every unrelated cart mutation.
+const CartButton = () => {
   const { count } = Cart.get();
 
   return (
@@ -38,17 +36,15 @@ function CartButton() {
       {count > 0 && <span className="badge">{count}</span>}
     </Link>
   );
-}
+};
 
-function NotFound() {
-  return (
-    <div className="notice">
-      <span className="big-emoji">🧭</span>
-      <h1>Nothing here</h1>
-      <Link to="/">Back to the store</Link>
-    </div>
-  );
-}
+const NotFound = () => (
+  <div className="notice">
+    <span className="big-emoji">🧭</span>
+    <h1>Nothing here</h1>
+    <Link to="/">Back to the store</Link>
+  </div>
+);
 
 // One in-memory Router; the Cart is provided above it so every page shares it.
 export default () => (

--- a/examples/content/apps/store/App.tsx
+++ b/examples/content/apps/store/App.tsx
@@ -1,0 +1,66 @@
+import './App.css';
+
+import { Component, Provider } from '@expressive/react';
+import { Link, Route, Router } from '@expressive/router';
+
+import { CartPage } from './Cart';
+import { ProductPage } from './Product';
+import { Cart } from './Store';
+import { Storefront } from './Storefront';
+
+// Persistent chrome: brand + cart button stay put while the matched page
+// arrives as `props.children`. Same instance across navigation, so the cart
+// badge updates in place.
+class Layout extends Component {
+  render() {
+    return (
+      <div className="store">
+        <header className="store-head">
+          <Link to="/" className="brand">
+            🛍️ Emoji Store
+          </Link>
+          <CartButton />
+        </header>
+        <div className="store-body">{this.props.children}</div>
+      </div>
+    );
+  }
+}
+
+// Reads just `count` off the shared cart, so it re-renders only when the
+// item count changes - not on every unrelated cart mutation.
+function CartButton() {
+  const { count } = Cart.get();
+
+  return (
+    <Link to="/cart" className="cart-btn" aria-label="Cart">
+      🛒
+      {count > 0 && <span className="badge">{count}</span>}
+    </Link>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="notice">
+      <span className="big-emoji">🧭</span>
+      <h1>Nothing here</h1>
+      <Link to="/">Back to the store</Link>
+    </div>
+  );
+}
+
+// One in-memory Router; the Cart is provided above it so every page shares it.
+export default () => (
+  <Provider for={Cart}>
+    <Router>
+      <Route as={Layout}>
+        <Route as={Storefront} />
+        <Route to="category/:cat" as={Storefront} />
+        <Route to="product/:id" as={ProductPage} />
+        <Route to="cart" as={CartPage} />
+        <Route default as={NotFound} />
+      </Route>
+    </Router>
+  </Provider>
+);

--- a/examples/content/apps/store/Breadcrumbs.tsx
+++ b/examples/content/apps/store/Breadcrumbs.tsx
@@ -1,0 +1,36 @@
+import { Link } from '@expressive/router';
+
+export interface Crumb {
+  label: string;
+  to?: string;
+}
+
+// A data-driven trail. The product page owns the hierarchy (Store > Category >
+// Product) and passes it in, because a flat `product/:id` route can't express
+// those ancestors lexically for the matcher to derive.
+export function Breadcrumbs({ trail }: { trail: Crumb[] }) {
+  return (
+    <nav className="crumbs" aria-label="Breadcrumb">
+      {trail.map((crumb, i) => {
+        const last = i === trail.length - 1;
+
+        return (
+          <span key={i} className="crumb">
+            {crumb.to && !last ? (
+              <Link to={crumb.to}>{crumb.label}</Link>
+            ) : (
+              <span aria-current={last ? 'page' : undefined}>
+                {crumb.label}
+              </span>
+            )}
+            {!last && (
+              <span className="sep" aria-hidden="true">
+                ›
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/examples/content/apps/store/Breadcrumbs.tsx
+++ b/examples/content/apps/store/Breadcrumbs.tsx
@@ -8,7 +8,7 @@ export interface Crumb {
 // A data-driven trail. The product page owns the hierarchy (Store > Category >
 // Product) and passes it in, because a flat `product/:id` route can't express
 // those ancestors lexically for the matcher to derive.
-export function Breadcrumbs({ trail }: { trail: Crumb[] }) {
+export const Breadcrumbs = ({ trail }: { trail: Crumb[] }) => {
   return (
     <nav className="crumbs" aria-label="Breadcrumb">
       {trail.map((crumb, i) => {
@@ -33,4 +33,4 @@ export function Breadcrumbs({ trail }: { trail: Crumb[] }) {
       })}
     </nav>
   );
-}
+};

--- a/examples/content/apps/store/Cart.tsx
+++ b/examples/content/apps/store/Cart.tsx
@@ -1,84 +1,117 @@
 import { Link } from '@expressive/router';
 
 import { usd } from './catalog';
-import { Cart } from './Store';
+import { Cart, type Line } from './Store';
 
-// Reads the shared cart and holds no state of its own, so a plain function
-// consuming Cart.get() - re-renders as lines/total/receipt change.
+// Each slice below does its own Cart.get() and subscribes only to what it
+// reads - the page just picks a branch. Receipt wins over Empty: checkout
+// clears the items, so both are true at once.
 export const CartPage = () => {
-  const { is: cart, lines, total, count, receipt } = Cart.get();
+  const { receipt, count } = Cart.get();
 
-  if (!count)
-    return (
-      <div className="notice">
-        <span className="big-emoji">🛒</span>
-        <h1>Your cart is empty</h1>
-        <Link to="/">Browse the store</Link>
-      </div>
-    );
-
-  // Post-checkout confirmation. `reset()` clears it back to the live cart.
-  if (receipt)
-    return (
-      <div className="notice">
-        <span className="big-emoji">✅</span>
-        <h1>Order placed!</h1>
-        <p>
-          {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
-          {usd(receipt.total)}
-        </p>
-        <Link to="/" onClick={() => cart.reset()}>
-          Continue shopping
-        </Link>
-      </div>
-    );
+  if (receipt) return <Receipt />;
+  if (!count) return <Empty />;
 
   return (
     <div className="cart">
       <h1>Your Cart</h1>
+      <Lines />
+      <Checkout />
+    </div>
+  );
+};
 
-      <ul className="lines">
-        {lines.map(({ product, qty, subtotal }) => (
-          <li key={product.id} className="line">
-            <Link to={`/product/${product.id}`} className="line-emoji">
-              {product.emoji}
-            </Link>
-            <div className="line-info">
-              <Link to={`/product/${product.id}`}>{product.name}</Link>
-              <small>{usd(product.price)} each</small>
-            </div>
-            <div className="qty">
-              <button
-                onClick={() => cart.setQty(product.id, qty - 1)}
-                aria-label="Decrease quantity">
-                −
-              </button>
-              <span className="qty-val">{qty}</span>
-              <button
-                onClick={() => cart.setQty(product.id, qty + 1)}
-                aria-label="Increase quantity">
-                +
-              </button>
-            </div>
-            <span className="line-sub">{usd(subtotal)}</span>
-            <button
-              className="remove"
-              onClick={() => cart.remove(product.id)}
-              aria-label={`Remove ${product.name}`}>
-              ✕
-            </button>
-          </li>
-        ))}
-      </ul>
+// Post-checkout confirmation. `reset()` clears it back to the live cart.
+const Receipt = () => {
+  const { is: cart, receipt } = Cart.get();
 
+  if (!receipt) return null;
+
+  return (
+    <div className="notice">
+      <span className="big-emoji">✅</span>
+      <h1>Order placed!</h1>
+      <p>
+        {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
+        {usd(receipt.total)}
+      </p>
+      <Link to="/" onClick={() => cart.reset()}>
+        Continue shopping
+      </Link>
+    </div>
+  );
+};
+
+const Empty = () => (
+  <div className="notice">
+    <span className="big-emoji">🛒</span>
+    <h1>Your cart is empty</h1>
+    <Link to="/">Browse the store</Link>
+  </div>
+);
+
+const Lines = () => {
+  const { lines } = Cart.get();
+
+  return (
+    <ul className="lines">
+      {lines.map((line) => (
+        <CartLine key={line.product.id} line={line} />
+      ))}
+    </ul>
+  );
+};
+
+// Reads no cart values - only methods via `is` - so rows render from props
+// alone, without a subscription of their own.
+const CartLine = ({ line: { product, qty, subtotal } }: { line: Line }) => {
+  const { is: cart } = Cart.get();
+
+  return (
+    <li className="line">
+      <Link to={`/product/${product.id}`} className="line-emoji">
+        {product.emoji}
+      </Link>
+      <div className="line-info">
+        <Link to={`/product/${product.id}`}>{product.name}</Link>
+        <small>{usd(product.price)} each</small>
+      </div>
+      <div className="qty">
+        <button
+          onClick={() => cart.setQty(product.id, qty - 1)}
+          aria-label="Decrease quantity">
+          −
+        </button>
+        <span className="qty-val">{qty}</span>
+        <button
+          onClick={() => cart.setQty(product.id, qty + 1)}
+          aria-label="Increase quantity">
+          +
+        </button>
+      </div>
+      <span className="line-sub">{usd(subtotal)}</span>
+      <button
+        className="remove"
+        onClick={() => cart.remove(product.id)}
+        aria-label={`Remove ${product.name}`}>
+        ✕
+      </button>
+    </li>
+  );
+};
+
+const Checkout = () => {
+  const { is: cart, total } = Cart.get();
+
+  return (
+    <>
       <div className="summary">
         <span>Total</span>
         <span className="total">{usd(total)}</span>
       </div>
-
       <button className="primary checkout" onClick={() => cart.checkout()}>
         Checkout · {usd(total)}
       </button>
-    </div>
+    </>
   );
 };

--- a/examples/content/apps/store/Cart.tsx
+++ b/examples/content/apps/store/Cart.tsx
@@ -1,95 +1,84 @@
-import { Component, get } from '@expressive/react';
 import { Link } from '@expressive/router';
 
 import { usd } from './catalog';
 import { Cart } from './Store';
 
-// NOTE: this reads the cart and holds no state of its own, so by the "keep it
-// lite" rule it *should* be a plain function calling Cart.get(). It is a class
-// only to work around a reactivity bug: an FC reading the `lines`/`total`
-// computed getters via Cart.get() re-renders once, then stops. A class
-// re-reads the getters in render() each time and updates reliably. See the
-// PR discussion; revert to an FC once the getter-subscription bug is fixed.
-export class CartPage extends Component {
-  cart = get(Cart);
+// Reads the shared cart and holds no state of its own, so a plain function
+// consuming Cart.get() - re-renders as lines/total/receipt change.
+export const CartPage = () => {
+  const { is: cart, lines, total, count, receipt } = Cart.get();
 
-  render() {
-    const { lines, total, count, receipt } = this.cart;
-
-    // Post-checkout confirmation. `reset()` clears it back to the live cart.
-    if (receipt)
-      return (
-        <div className="notice">
-          <span className="big-emoji">✅</span>
-          <h1>Order placed!</h1>
-          <p>
-            {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
-            {usd(receipt.total)}
-          </p>
-          <Link to="/" onClick={() => this.cart.reset()}>
-            Continue shopping
-          </Link>
-        </div>
-      );
-
-    if (!count)
-      return (
-        <div className="notice">
-          <span className="big-emoji">🛒</span>
-          <h1>Your cart is empty</h1>
-          <Link to="/">Browse the store</Link>
-        </div>
-      );
-
+  if (!count)
     return (
-      <div className="cart">
-        <h1>Your Cart</h1>
-
-        <ul className="lines">
-          {lines.map(({ product, qty, subtotal }) => (
-            <li key={product.id} className="line">
-              <Link to={`/product/${product.id}`} className="line-emoji">
-                {product.emoji}
-              </Link>
-              <div className="line-info">
-                <Link to={`/product/${product.id}`}>{product.name}</Link>
-                <small>{usd(product.price)} each</small>
-              </div>
-              <div className="qty">
-                <button
-                  onClick={() => this.cart.setQty(product.id, qty - 1)}
-                  aria-label="Decrease quantity">
-                  −
-                </button>
-                <span className="qty-val">{qty}</span>
-                <button
-                  onClick={() => this.cart.setQty(product.id, qty + 1)}
-                  aria-label="Increase quantity">
-                  +
-                </button>
-              </div>
-              <span className="line-sub">{usd(subtotal)}</span>
-              <button
-                className="remove"
-                onClick={() => this.cart.remove(product.id)}
-                aria-label={`Remove ${product.name}`}>
-                ✕
-              </button>
-            </li>
-          ))}
-        </ul>
-
-        <div className="summary">
-          <span>Total</span>
-          <span className="total">{usd(total)}</span>
-        </div>
-
-        <button
-          className="primary checkout"
-          onClick={() => this.cart.checkout()}>
-          Checkout · {usd(total)}
-        </button>
+      <div className="notice">
+        <span className="big-emoji">🛒</span>
+        <h1>Your cart is empty</h1>
+        <Link to="/">Browse the store</Link>
       </div>
     );
-  }
-}
+
+  // Post-checkout confirmation. `reset()` clears it back to the live cart.
+  if (receipt)
+    return (
+      <div className="notice">
+        <span className="big-emoji">✅</span>
+        <h1>Order placed!</h1>
+        <p>
+          {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
+          {usd(receipt.total)}
+        </p>
+        <Link to="/" onClick={() => cart.reset()}>
+          Continue shopping
+        </Link>
+      </div>
+    );
+
+  return (
+    <div className="cart">
+      <h1>Your Cart</h1>
+
+      <ul className="lines">
+        {lines.map(({ product, qty, subtotal }) => (
+          <li key={product.id} className="line">
+            <Link to={`/product/${product.id}`} className="line-emoji">
+              {product.emoji}
+            </Link>
+            <div className="line-info">
+              <Link to={`/product/${product.id}`}>{product.name}</Link>
+              <small>{usd(product.price)} each</small>
+            </div>
+            <div className="qty">
+              <button
+                onClick={() => cart.setQty(product.id, qty - 1)}
+                aria-label="Decrease quantity">
+                −
+              </button>
+              <span className="qty-val">{qty}</span>
+              <button
+                onClick={() => cart.setQty(product.id, qty + 1)}
+                aria-label="Increase quantity">
+                +
+              </button>
+            </div>
+            <span className="line-sub">{usd(subtotal)}</span>
+            <button
+              className="remove"
+              onClick={() => cart.remove(product.id)}
+              aria-label={`Remove ${product.name}`}>
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="summary">
+        <span>Total</span>
+        <span className="total">{usd(total)}</span>
+      </div>
+
+      <button className="primary checkout" onClick={() => cart.checkout()}>
+        Checkout · {usd(total)}
+      </button>
+    </div>
+  );
+};

--- a/examples/content/apps/store/Cart.tsx
+++ b/examples/content/apps/store/Cart.tsx
@@ -1,0 +1,89 @@
+import { Component, get } from '@expressive/react';
+import { Link } from '@expressive/router';
+
+import { usd } from './catalog';
+import { Cart } from './Store';
+
+export class CartPage extends Component {
+  cart = get(Cart);
+
+  render() {
+    const { lines, total, count, receipt } = this.cart;
+
+    // Post-checkout confirmation. `reset()` clears it back to the live cart.
+    if (receipt)
+      return (
+        <div className="notice">
+          <span className="big-emoji">✅</span>
+          <h1>Order placed!</h1>
+          <p>
+            {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
+            {usd(receipt.total)}
+          </p>
+          <Link to="/" onClick={() => this.cart.reset()}>
+            Continue shopping
+          </Link>
+        </div>
+      );
+
+    if (!count)
+      return (
+        <div className="notice">
+          <span className="big-emoji">🛒</span>
+          <h1>Your cart is empty</h1>
+          <Link to="/">Browse the store</Link>
+        </div>
+      );
+
+    return (
+      <div className="cart">
+        <h1>Your Cart</h1>
+
+        <ul className="lines">
+          {lines.map(({ product, qty, subtotal }) => (
+            <li key={product.id} className="line">
+              <Link to={`/product/${product.id}`} className="line-emoji">
+                {product.emoji}
+              </Link>
+              <div className="line-info">
+                <Link to={`/product/${product.id}`}>{product.name}</Link>
+                <small>{usd(product.price)} each</small>
+              </div>
+              <div className="qty">
+                <button
+                  onClick={() => this.cart.setQty(product.id, qty - 1)}
+                  aria-label="Decrease quantity">
+                  −
+                </button>
+                <span className="qty-val">{qty}</span>
+                <button
+                  onClick={() => this.cart.setQty(product.id, qty + 1)}
+                  aria-label="Increase quantity">
+                  +
+                </button>
+              </div>
+              <span className="line-sub">{usd(subtotal)}</span>
+              <button
+                className="remove"
+                onClick={() => this.cart.remove(product.id)}
+                aria-label={`Remove ${product.name}`}>
+                ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="summary">
+          <span>Total</span>
+          <span className="total">{usd(total)}</span>
+        </div>
+
+        <button
+          className="primary checkout"
+          onClick={() => this.cart.checkout()}>
+          Checkout · {usd(total)}
+        </button>
+      </div>
+    );
+  }
+}

--- a/examples/content/apps/store/Cart.tsx
+++ b/examples/content/apps/store/Cart.tsx
@@ -4,6 +4,12 @@ import { Link } from '@expressive/router';
 import { usd } from './catalog';
 import { Cart } from './Store';
 
+// NOTE: this reads the cart and holds no state of its own, so by the "keep it
+// lite" rule it *should* be a plain function calling Cart.get(). It is a class
+// only to work around a reactivity bug: an FC reading the `lines`/`total`
+// computed getters via Cart.get() re-renders once, then stops. A class
+// re-reads the getters in render() each time and updates reliably. See the
+// PR discussion; revert to an FC once the getter-subscription bug is fixed.
 export class CartPage extends Component {
   cart = get(Cart);
 

--- a/examples/content/apps/store/Product.tsx
+++ b/examples/content/apps/store/Product.tsx
@@ -24,7 +24,7 @@ export class ProductPage extends Component {
     return this.product ? this.product.price * this.qty : 0;
   }
 
-  quantity(by: number){
+  quantity(by: number) {
     this.qty = Math.max(1, this.qty + by);
   }
 
@@ -34,16 +34,9 @@ export class ProductPage extends Component {
   }
 
   render() {
-    const { product, qty, subtotal, quantity } = this;
+    const { product, qty, subtotal } = this;
 
-    if (!product)
-      return (
-        <div className="notice">
-          <span className="big-emoji">🫥</span>
-          <h1>Product not found</h1>
-          <Link to="/">Back to the store</Link>
-        </div>
-      );
+    if (!product) return <NotFound />;
 
     return (
       <div className="product">
@@ -64,19 +57,7 @@ export class ProductPage extends Component {
             <h1>{product.name}</h1>
             <p className="hero-price">{usd(product.price)}</p>
 
-            <div className="qty">
-              <button
-                onClick={() => quantity(-1)}
-                aria-label="Decrease quantity">
-                −
-              </button>
-              <span className="qty-val">{qty}</span>
-              <button
-                onClick={() => quantity(1)}
-                aria-label="Increase quantity">
-                +
-              </button>
-            </div>
+            <Stepper />
 
             <button className="primary" onClick={this.addToCart}>
               Add {qty} to cart · {usd(subtotal)}
@@ -87,3 +68,29 @@ export class ProductPage extends Component {
     );
   }
 }
+
+// A Component provides itself to context, so dumb slices under it pull state
+// the same way they would from any State - no props, no subclass seam.
+const Stepper = () => {
+  const { qty, quantity } = ProductPage.get();
+
+  return (
+    <div className="qty">
+      <button onClick={() => quantity(-1)} aria-label="Decrease quantity">
+        −
+      </button>
+      <span className="qty-val">{qty}</span>
+      <button onClick={() => quantity(1)} aria-label="Increase quantity">
+        +
+      </button>
+    </div>
+  );
+};
+
+const NotFound = () => (
+  <div className="notice">
+    <span className="big-emoji">🫥</span>
+    <h1>Product not found</h1>
+    <Link to="/">Back to the store</Link>
+  </div>
+);

--- a/examples/content/apps/store/Product.tsx
+++ b/examples/content/apps/store/Product.tsx
@@ -9,13 +9,28 @@ export class ProductPage extends Component {
   route = get(Route);
   cart = get(Cart);
 
-  // A reactive field on the component - the "buy N" stepper. Assigning it
+  // The "buy N" stepper - reactive field on the component itself. Assigning it
   // re-renders, no useState needed.
   qty = 1;
 
-  render() {
+  // Getters derive from route + qty and recompute only when those change -
+  // render() stays thin markup over them.
+  get product() {
     const id = this.route.match?.id;
-    const product = id ? getProduct(id) : undefined;
+    return id ? getProduct(id) : undefined;
+  }
+
+  get subtotal() {
+    return this.product ? this.product.price * this.qty : 0;
+  }
+
+  addToCart() {
+    this.cart.add(this.product!.id, this.qty);
+    this.qty = 1;
+  }
+
+  render() {
+    const { product, qty, subtotal } = this;
 
     if (!product)
       return (
@@ -25,8 +40,6 @@ export class ProductPage extends Component {
           <Link to="/">Back to the store</Link>
         </div>
       );
-
-    const { qty } = this;
 
     return (
       <div className="product">
@@ -61,13 +74,8 @@ export class ProductPage extends Component {
               </button>
             </div>
 
-            <button
-              className="primary"
-              onClick={() => {
-                this.cart.add(product.id, qty);
-                this.qty = 1;
-              }}>
-              Add {qty} to cart · {usd(product.price * qty)}
+            <button className="primary" onClick={this.addToCart}>
+              Add {qty} to cart · {usd(subtotal)}
             </button>
           </div>
         </div>

--- a/examples/content/apps/store/Product.tsx
+++ b/examples/content/apps/store/Product.tsx
@@ -1,0 +1,77 @@
+import { Component, get } from '@expressive/react';
+import { Link, Route } from '@expressive/router';
+
+import { Breadcrumbs } from './Breadcrumbs';
+import { categoryLabel, getProduct, usd } from './catalog';
+import { Cart } from './Store';
+
+export class ProductPage extends Component {
+  route = get(Route);
+  cart = get(Cart);
+
+  // A reactive field on the component - the "buy N" stepper. Assigning it
+  // re-renders, no useState needed.
+  qty = 1;
+
+  render() {
+    const id = this.route.match?.id;
+    const product = id ? getProduct(id) : undefined;
+
+    if (!product)
+      return (
+        <div className="notice">
+          <span className="big-emoji">🫥</span>
+          <h1>Product not found</h1>
+          <Link to="/">Back to the store</Link>
+        </div>
+      );
+
+    const { qty } = this;
+
+    return (
+      <div className="product">
+        <Breadcrumbs
+          trail={[
+            { label: 'Store', to: '/' },
+            {
+              label: categoryLabel(product.category),
+              to: `/category/${product.category}`
+            },
+            { label: product.name }
+          ]}
+        />
+
+        <div className="hero">
+          <span className="hero-emoji">{product.emoji}</span>
+          <div className="hero-info">
+            <h1>{product.name}</h1>
+            <p className="hero-price">{usd(product.price)}</p>
+
+            <div className="qty">
+              <button
+                onClick={() => (this.qty = Math.max(1, qty - 1))}
+                aria-label="Decrease quantity">
+                −
+              </button>
+              <span className="qty-val">{qty}</span>
+              <button
+                onClick={() => (this.qty = qty + 1)}
+                aria-label="Increase quantity">
+                +
+              </button>
+            </div>
+
+            <button
+              className="primary"
+              onClick={() => {
+                this.cart.add(product.id, qty);
+                this.qty = 1;
+              }}>
+              Add {qty} to cart · {usd(product.price * qty)}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/examples/content/apps/store/Product.tsx
+++ b/examples/content/apps/store/Product.tsx
@@ -24,13 +24,17 @@ export class ProductPage extends Component {
     return this.product ? this.product.price * this.qty : 0;
   }
 
+  quantity(by: number){
+    this.qty = Math.max(1, this.qty + by);
+  }
+
   addToCart() {
     this.cart.add(this.product!.id, this.qty);
     this.qty = 1;
   }
 
   render() {
-    const { product, qty, subtotal } = this;
+    const { product, qty, subtotal, quantity } = this;
 
     if (!product)
       return (
@@ -62,13 +66,13 @@ export class ProductPage extends Component {
 
             <div className="qty">
               <button
-                onClick={() => (this.qty = Math.max(1, qty - 1))}
+                onClick={() => quantity(-1)}
                 aria-label="Decrease quantity">
                 −
               </button>
               <span className="qty-val">{qty}</span>
               <button
-                onClick={() => (this.qty = qty + 1)}
+                onClick={() => quantity(1)}
                 aria-label="Increase quantity">
                 +
               </button>

--- a/examples/content/apps/store/Store.ts
+++ b/examples/content/apps/store/Store.ts
@@ -1,0 +1,60 @@
+import State from '@expressive/react';
+
+import { getProduct, Product } from './catalog';
+
+export interface Line {
+  product: Product;
+  qty: number;
+  subtotal: number;
+}
+
+// One cart, provided at the app root and read by every page via Cart.get().
+export class Cart extends State {
+  // id -> quantity. Reassigned (never mutated in place) so subscribers refresh.
+  items: Record<string, number> = {};
+
+  // After checkout we stash a receipt to show the confirmation, then empty.
+  receipt: null | { count: number; total: number } = null;
+
+  add(id: string, qty = 1) {
+    const now = (this.items[id] ?? 0) + qty;
+    this.items = { ...this.items, [id]: now };
+  }
+
+  setQty(id: string, qty: number) {
+    if (qty < 1) return this.remove(id);
+    this.items = { ...this.items, [id]: qty };
+  }
+
+  remove(id: string) {
+    const { [id]: _drop, ...rest } = this.items;
+    this.items = rest;
+  }
+
+  checkout() {
+    if (!this.count) return;
+    this.receipt = { count: this.count, total: this.total };
+    this.items = {};
+  }
+
+  reset() {
+    this.receipt = null;
+  }
+
+  // Getters are auto-memoized and dependency-tracked: they recompute only when
+  // `items` changes, and reading one subscribes the reading component to it.
+  get count() {
+    return Object.values(this.items).reduce((sum, qty) => sum + qty, 0);
+  }
+
+  get lines(): Line[] {
+    return Object.entries(this.items).flatMap(([id, qty]) => {
+      const product = getProduct(id);
+      return product ? [{ product, qty, subtotal: product.price * qty }] : [];
+    });
+  }
+
+  get total() {
+    return this.lines.reduce((sum, line) => sum + line.subtotal, 0);
+  }
+}

--- a/examples/content/apps/store/Store.ts
+++ b/examples/content/apps/store/Store.ts
@@ -17,18 +17,20 @@ export class Cart extends State {
   receipt: null | { count: number; total: number } = null;
 
   add(id: string, qty = 1) {
-    const now = (this.items[id] ?? 0) + qty;
-    this.items = { ...this.items, [id]: now };
+    this.setQty(id, (this.items[id] ?? 0) + qty);
   }
 
   setQty(id: string, qty: number) {
-    if (qty < 1) return this.remove(id);
-    this.items = { ...this.items, [id]: qty };
+    const next = { ...this.items };
+
+    if (qty > 0) next[id] = qty;
+    else delete next[id];
+
+    this.items = next;
   }
 
   remove(id: string) {
-    const { [id]: _drop, ...rest } = this.items;
-    this.items = rest;
+    this.setQty(id, 0);
   }
 
   checkout() {

--- a/examples/content/apps/store/Storefront.tsx
+++ b/examples/content/apps/store/Storefront.tsx
@@ -1,45 +1,42 @@
-import { Component, get } from '@expressive/react';
 import { Link, Route } from '@expressive/router';
 
 import { categories, inCategory, products, usd } from './catalog';
 
-// The grid does double duty: it's the index route (all products) AND the
-// `category/:cat` route (filtered). It reads its own Route to tell which.
-export class Storefront extends Component {
-  route = get(Route);
+// Reads its own Route to tell which listing to show; holds no state and
+// provides nothing, so a plain function that consumes Route.get(). It does
+// double duty: the index route (all products) AND `category/:cat` (filtered).
+export const Storefront = () => {
+  // `cat` is present on /category/:cat, absent on the index route. Same-pattern
+  // navigation (food -> animals) reconciles in place, re-reading match.
+  const { match } = Route.get();
+  const cat = match?.cat;
+  const shown = cat ? inCategory(cat) : products;
 
-  render() {
-    // `cat` is present on /category/:cat, absent on the index route. Same-
-    // pattern navigation (food -> animals) reconciles this page in place.
-    const cat = this.route.match?.cat;
-    const shown = cat ? inCategory(cat) : products;
-
-    return (
-      <div className="storefront">
-        <nav className="chips">
-          <Link to="/" className={cat ? 'chip' : 'chip on'}>
-            All
+  return (
+    <div className="storefront">
+      <nav className="chips">
+        <Link to="/" className={cat ? 'chip' : 'chip on'}>
+          All
+        </Link>
+        {categories.map((c) => (
+          <Link
+            key={c.slug}
+            to={`/category/${c.slug}`}
+            className={cat === c.slug ? 'chip on' : 'chip'}>
+            {c.label}
           </Link>
-          {categories.map((c) => (
-            <Link
-              key={c.slug}
-              to={`/category/${c.slug}`}
-              className={cat === c.slug ? 'chip on' : 'chip'}>
-              {c.label}
-            </Link>
-          ))}
-        </nav>
+        ))}
+      </nav>
 
-        <div className="grid">
-          {shown.map((p) => (
-            <Link key={p.id} to={`/product/${p.id}`} className="card">
-              <span className="card-emoji">{p.emoji}</span>
-              <span className="card-name">{p.name}</span>
-              <span className="card-price">{usd(p.price)}</span>
-            </Link>
-          ))}
-        </div>
+      <div className="grid">
+        {shown.map((p) => (
+          <Link key={p.id} to={`/product/${p.id}`} className="card">
+            <span className="card-emoji">{p.emoji}</span>
+            <span className="card-name">{p.name}</span>
+            <span className="card-price">{usd(p.price)}</span>
+          </Link>
+        ))}
       </div>
-    );
-  }
-}
+    </div>
+  );
+};

--- a/examples/content/apps/store/Storefront.tsx
+++ b/examples/content/apps/store/Storefront.tsx
@@ -1,0 +1,45 @@
+import { Component, get } from '@expressive/react';
+import { Link, Route } from '@expressive/router';
+
+import { categories, inCategory, products, usd } from './catalog';
+
+// The grid does double duty: it's the index route (all products) AND the
+// `category/:cat` route (filtered). It reads its own Route to tell which.
+export class Storefront extends Component {
+  route = get(Route);
+
+  render() {
+    // `cat` is present on /category/:cat, absent on the index route. Same-
+    // pattern navigation (food -> animals) reconciles this page in place.
+    const cat = this.route.match?.cat;
+    const shown = cat ? inCategory(cat) : products;
+
+    return (
+      <div className="storefront">
+        <nav className="chips">
+          <Link to="/" className={cat ? 'chip' : 'chip on'}>
+            All
+          </Link>
+          {categories.map((c) => (
+            <Link
+              key={c.slug}
+              to={`/category/${c.slug}`}
+              className={cat === c.slug ? 'chip on' : 'chip'}>
+              {c.label}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="grid">
+          {shown.map((p) => (
+            <Link key={p.id} to={`/product/${p.id}`} className="card">
+              <span className="card-emoji">{p.emoji}</span>
+              <span className="card-name">{p.name}</span>
+              <span className="card-price">{usd(p.price)}</span>
+            </Link>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}

--- a/examples/content/apps/store/catalog.ts
+++ b/examples/content/apps/store/catalog.ts
@@ -13,47 +13,44 @@ export interface Category {
 
 // The "inventory": emoji grouped by category. One source of truth that the
 // storefront grid, product page, and breadcrumbs all read from.
-const INVENTORY: Record<string, [emoji: string, name: string][]> = {
-  food: [
-    ['🍕', 'Pizza'],
-    ['🍔', 'Burger'],
-    ['🌮', 'Taco'],
-    ['🍣', 'Sushi'],
-    ['🍩', 'Donut'],
-    ['🍦', 'Ice Cream']
-  ],
-  animals: [
-    ['🐶', 'Dog'],
-    ['🐱', 'Cat'],
-    ['🦊', 'Fox'],
-    ['🐼', 'Panda'],
-    ['🦁', 'Lion'],
-    ['🐧', 'Penguin']
-  ],
-  faces: [
-    ['😀', 'Grinning'],
-    ['😎', 'Cool'],
-    ['🤖', 'Robot'],
-    ['👻', 'Ghost'],
-    ['🤠', 'Cowboy'],
-    ['🥳', 'Party']
-  ],
-  nature: [
-    ['🌵', 'Cactus'],
-    ['🌊', 'Wave'],
-    ['🔥', 'Fire'],
-    ['🌈', 'Rainbow'],
-    ['⭐', 'Star'],
-    ['🌙', 'Moon']
-  ]
+const INVENTORY = {
+  Food: {
+    Pizza: '🍕',
+    Burger: '🍔',
+    Taco: '🌮',
+    Sushi: '🍣',
+    Donut: '🍩',
+    IceCream: '🍦'
+  },
+  Animals: {
+    Dog: '🐶',
+    Cat: '🐱',
+    Fox: '🦊',
+    Panda: '🐼',
+    Lion: '🦁',
+    Penguin: '🐧'
+  },
+  Faces: {
+    Grinning: '😀',
+    Cool: '😎',
+    Robot: '🤖',
+    Ghost: '👻',
+    Cowboy: '🤠',
+    Party: '🥳'
+  },
+  Nature: {
+    Cactus: '🌵',
+    Wave: '🌊',
+    Fire: '🔥',
+    Rainbow: '🌈',
+    Star: '⭐',
+    Moon: '🌙'
+  }
 };
 
-const CATEGORY_LABEL: Record<string, string> = {
-  food: 'Food',
-  animals: 'Animals',
-  faces: 'Faces',
-  nature: 'Nature'
-};
+// Keys are PascalCase identifiers; split into words for display ("IceCream"
+// -> "Ice Cream"), then kebab for ids/urls ("ice-cream").
+const label = (key: string) => key.replace(/([a-z])([A-Z])/g, '$1 $2');
 
 const slug = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
 
@@ -61,20 +58,24 @@ const slug = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
 // stable while you browse but differ run-to-run.
 const roll = () => Math.round((2 + Math.random() * 48) * 100) / 100;
 
-export const categories: Category[] = Object.keys(INVENTORY).map((s) => ({
-  slug: s,
-  label: CATEGORY_LABEL[s]
+export const categories: Category[] = Object.keys(INVENTORY).map((key) => ({
+  slug: slug(key),
+  label: label(key)
 }));
 
 export const products: Product[] = Object.entries(INVENTORY).flatMap(
   ([category, items]) =>
-    items.map(([emoji, name]) => ({
-      id: slug(name),
-      emoji,
-      name,
-      category,
-      price: roll()
-    }))
+    Object.entries(items).map(([key, emoji]) => {
+      const name = label(key);
+
+      return {
+        id: slug(name),
+        emoji,
+        name,
+        category: slug(category),
+        price: roll()
+      };
+    })
 );
 
 const byId = new Map(products.map((p) => [p.id, p]));
@@ -84,7 +85,10 @@ export const getProduct = (id: string) => byId.get(id);
 export const inCategory = (cat: string) =>
   products.filter((p) => p.category === cat);
 
-export const categoryLabel = (cat: string) => CATEGORY_LABEL[cat] ?? cat;
+export const categoryLabel = (cat: string) => {
+  const found = categories.find((c) => c.slug === cat);
+  return found ? found.label : cat;
+};
 
 export const usd = (n: number) =>
   n.toLocaleString('en-US', { style: 'currency', currency: 'USD' });

--- a/examples/content/apps/store/catalog.ts
+++ b/examples/content/apps/store/catalog.ts
@@ -1,0 +1,90 @@
+export interface Product {
+  id: string;
+  emoji: string;
+  name: string;
+  category: string;
+  price: number;
+}
+
+export interface Category {
+  slug: string;
+  label: string;
+}
+
+// The "inventory": emoji grouped by category. One source of truth that the
+// storefront grid, product page, and breadcrumbs all read from.
+const INVENTORY: Record<string, [emoji: string, name: string][]> = {
+  food: [
+    ['🍕', 'Pizza'],
+    ['🍔', 'Burger'],
+    ['🌮', 'Taco'],
+    ['🍣', 'Sushi'],
+    ['🍩', 'Donut'],
+    ['🍦', 'Ice Cream']
+  ],
+  animals: [
+    ['🐶', 'Dog'],
+    ['🐱', 'Cat'],
+    ['🦊', 'Fox'],
+    ['🐼', 'Panda'],
+    ['🦁', 'Lion'],
+    ['🐧', 'Penguin']
+  ],
+  faces: [
+    ['😀', 'Grinning'],
+    ['😎', 'Cool'],
+    ['🤖', 'Robot'],
+    ['👻', 'Ghost'],
+    ['🤠', 'Cowboy'],
+    ['🥳', 'Party']
+  ],
+  nature: [
+    ['🌵', 'Cactus'],
+    ['🌊', 'Wave'],
+    ['🔥', 'Fire'],
+    ['🌈', 'Rainbow'],
+    ['⭐', 'Star'],
+    ['🌙', 'Moon']
+  ]
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+  food: 'Food',
+  animals: 'Animals',
+  faces: 'Faces',
+  nature: 'Nature'
+};
+
+const slug = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
+
+// Prices are rolled once, at module load, from a fixed range - so they stay
+// stable while you browse but differ run-to-run.
+const roll = () => Math.round((2 + Math.random() * 48) * 100) / 100;
+
+export const categories: Category[] = Object.keys(INVENTORY).map((s) => ({
+  slug: s,
+  label: CATEGORY_LABEL[s]
+}));
+
+export const products: Product[] = Object.entries(INVENTORY).flatMap(
+  ([category, items]) =>
+    items.map(([emoji, name]) => ({
+      id: slug(name),
+      emoji,
+      name,
+      category,
+      price: roll()
+    }))
+);
+
+const byId = new Map(products.map((p) => [p.id, p]));
+
+export const getProduct = (id: string) => byId.get(id);
+
+export const inCategory = (cat: string) =>
+  products.filter((p) => p.category === cat);
+
+export const categoryLabel = (cat: string) => CATEGORY_LABEL[cat] ?? cat;
+
+export const usd = (n: number) =>
+  n.toLocaleString('en-US', { style: 'currency', currency: 'USD' });

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -4,11 +4,13 @@
 
 ## When to use Component vs State vs function components
 
-- **Function components** are dumb - they receive data, render UI. Keep them simple.
+- **Function components** are the default and stay dumb - they receive props, read context via `Foo.get()`, and render. Keep them simple. Consuming a State/Component from context does *not* justify a class: `Foo.get()` inside a function already subscribes to the fields it reads.
 - **State** is display-agnostic - pure data and logic, no render method. Use with `State.use()` in function components to separate concerns.
 - **Component** is for **custom components/primitives** that own their display logic. They're _meant_ to render. Use when you need a reusable, extensible unit combining behavior + UI: form controls, media players, data grids, modals, layout shells.
 
 Rule of thumb: use `Component` when state is intrinsic to display logic. Usually that means defining `render()`.
+
+The inverse is the more common decision, and the default. Reach for `Component` only when the unit has something of its *own* to own or share: intrinsic reactive state, values to provide to descendants via context, or consolidation you'd otherwise write with hooks (`useState`/`useMemo`/`useEffect`). A component that merely *reads* context or state and renders has nothing to own - a class there just wraps an instance (and React's `props`/`state`/`context`/`setState`) around what a plain function calling `Foo.get()` already does. `Component` exists to *replace* the hooks that compute and consolidate that UI, not to wrap a consumer. If there is nothing to own or share, keep it lite. (Example: a page that only reads `Session.get()` to render the current user is a function; a quantity stepper that holds its own `count` is a `Component`.)
 
 A Component does not have to define `render()`: without one, it passes children through while still providing itself to context and acting as Suspense/ErrorBoundary placement. Use that headless form only when React tree placement is the feature: route controllers inserted throughout an app, progressive `Boundary` wrappers, or Suspense/ErrorBoundary placement.
 


### PR DESCRIPTION
## Scope

Adds an advanced example under `examples/content/apps/store` — a fake **emoji storefront** with a shopping cart. Registered in `content/apps/index.ts` as **Store**.

Demonstrates, in one app: nested/param routing, a context-provided `Cart` State shared across pages, and memoized computed totals.

## What it does

- **Grid** of 24 emoji products across 4 categories; prices rolled once from a $2–$50 range at module load (stable per session, varies run-to-run).
- **Category filter** — the grid component serves both the index route and `category/:cat`, branching on `route.match?.cat`.
- **Product page** with data-driven **breadcrumbs** (`Store › Category › Product`) and a **quantity stepper** for buying multiples.
- **Dedicated `/cart` route**: line items with per-line qty controls, per-line subtotals, running total, and **checkout → receipt** confirmation.
- Persistent header (brand + cart badge) via a `Layout` route; badge subscribes to `count` only.

## Key decisions

- **Categories** (not flat) so breadcrumbs have a meaningful hierarchy and the routing tree shows nested/param matching.
- **In-memory `Router`** (matches the existing router example) — navigation stays inside the iframe.
- `Cart` State reassigns `items` immutably; `count`/`lines`/`total` are memoized, dependency-tracked getters.
- Scoped `App.css` widens the shared example column to 52rem and overrides the base `margin: auto` so content pins to the top instead of centering vertically on short pages.

## Verification

Driven end-to-end in real Chromium via Playwright (grid, category filter, breadcrumbs, buying multiples, cart totals math, per-line qty, checkout receipt, cart reset) — **all assertions pass, zero console errors**, light + dark mode both render correctly. Type-checks clean (the one pre-existing `packages/router/src/route.tsx` error is unrelated and present on `main`); prettier-clean.

No changeset — the `@expressive/examples` package is private and unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)