### PR TITLE
fix(mvc): rerun same-tick re-enqueued dispatch handlers

### DIFF
--- a/.changeset/tidy-dispatch-rerun.md
+++ b/.changeset/tidy-dispatch-rerun.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix a dropped refresh when an observer is re-notified within the same dispatch tick. The batched event queue coalesced handlers by identity and drained with `Set.forEach`, so a handler re-enqueued after it had already run in the current tick was silently skipped. This stranded a `.get()` subscription that observed both a field and a computed derived from that field (the field's change and the computed's recompute land in one tick): the component refreshed once, then froze. The queue now removes each handler before invoking it, so a same-tick re-enqueue runs again.

--- a/examples/content/apps/store/Cart.tsx
+++ b/examples/content/apps/store/Cart.tsx
@@ -1,96 +1,85 @@
-import { Component, get } from '@expressive/react';
 import { Link } from '@expressive/router';
 
 import { usd } from './catalog';
 import { Cart } from './Store';
 
-// NOTE: this reads the cart and holds no state of its own, so by the "keep it
-// lite" rule it *should* be a plain function calling Cart.get(). It is a class
-// only to work around a reactivity bug: an FC that observes both `lines` and
-// `total` (where `total` derives from `lines`) via Cart.get() refreshes once,
-// then freezes. A class re-reads the getters in render() each time and updates
-// reliably. Repro: packages/react state.get.test.tsx, "State.get - known bug".
-// Revert to an FC once fixed.
-export class CartPage extends Component {
-  cart = get(Cart);
+// Reads the cart and holds no state of its own, so by the "keep it lite" rule
+// a plain function consuming Cart.get().
+export const CartPage = () => {
+  const cart = Cart.get();
+  const { lines, total, count, receipt } = cart;
 
-  render() {
-    const { lines, total, count, receipt } = this.cart;
-
-    // Post-checkout confirmation. `reset()` clears it back to the live cart.
-    if (receipt)
-      return (
-        <div className="notice">
-          <span className="big-emoji">✅</span>
-          <h1>Order placed!</h1>
-          <p>
-            {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
-            {usd(receipt.total)}
-          </p>
-          <Link to="/" onClick={() => this.cart.reset()}>
-            Continue shopping
-          </Link>
-        </div>
-      );
-
-    if (!count)
-      return (
-        <div className="notice">
-          <span className="big-emoji">🛒</span>
-          <h1>Your cart is empty</h1>
-          <Link to="/">Browse the store</Link>
-        </div>
-      );
-
+  // Post-checkout confirmation. `reset()` clears it back to the live cart.
+  if (receipt)
     return (
-      <div className="cart">
-        <h1>Your Cart</h1>
-
-        <ul className="lines">
-          {lines.map(({ product, qty, subtotal }) => (
-            <li key={product.id} className="line">
-              <Link to={`/product/${product.id}`} className="line-emoji">
-                {product.emoji}
-              </Link>
-              <div className="line-info">
-                <Link to={`/product/${product.id}`}>{product.name}</Link>
-                <small>{usd(product.price)} each</small>
-              </div>
-              <div className="qty">
-                <button
-                  onClick={() => this.cart.setQty(product.id, qty - 1)}
-                  aria-label="Decrease quantity">
-                  −
-                </button>
-                <span className="qty-val">{qty}</span>
-                <button
-                  onClick={() => this.cart.setQty(product.id, qty + 1)}
-                  aria-label="Increase quantity">
-                  +
-                </button>
-              </div>
-              <span className="line-sub">{usd(subtotal)}</span>
-              <button
-                className="remove"
-                onClick={() => this.cart.remove(product.id)}
-                aria-label={`Remove ${product.name}`}>
-                ✕
-              </button>
-            </li>
-          ))}
-        </ul>
-
-        <div className="summary">
-          <span>Total</span>
-          <span className="total">{usd(total)}</span>
-        </div>
-
-        <button
-          className="primary checkout"
-          onClick={() => this.cart.checkout()}>
-          Checkout · {usd(total)}
-        </button>
+      <div className="notice">
+        <span className="big-emoji">✅</span>
+        <h1>Order placed!</h1>
+        <p>
+          {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
+          {usd(receipt.total)}
+        </p>
+        <Link to="/" onClick={() => cart.reset()}>
+          Continue shopping
+        </Link>
       </div>
     );
-  }
-}
+
+  if (!count)
+    return (
+      <div className="notice">
+        <span className="big-emoji">🛒</span>
+        <h1>Your cart is empty</h1>
+        <Link to="/">Browse the store</Link>
+      </div>
+    );
+
+  return (
+    <div className="cart">
+      <h1>Your Cart</h1>
+
+      <ul className="lines">
+        {lines.map(({ product, qty, subtotal }) => (
+          <li key={product.id} className="line">
+            <Link to={`/product/${product.id}`} className="line-emoji">
+              {product.emoji}
+            </Link>
+            <div className="line-info">
+              <Link to={`/product/${product.id}`}>{product.name}</Link>
+              <small>{usd(product.price)} each</small>
+            </div>
+            <div className="qty">
+              <button
+                onClick={() => cart.setQty(product.id, qty - 1)}
+                aria-label="Decrease quantity">
+                −
+              </button>
+              <span className="qty-val">{qty}</span>
+              <button
+                onClick={() => cart.setQty(product.id, qty + 1)}
+                aria-label="Increase quantity">
+                +
+              </button>
+            </div>
+            <span className="line-sub">{usd(subtotal)}</span>
+            <button
+              className="remove"
+              onClick={() => cart.remove(product.id)}
+              aria-label={`Remove ${product.name}`}>
+              ✕
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="summary">
+        <span>Total</span>
+        <span className="total">{usd(total)}</span>
+      </div>
+
+      <button className="primary checkout" onClick={() => cart.checkout()}>
+        Checkout · {usd(total)}
+      </button>
+    </div>
+  );
+};

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -218,14 +218,14 @@ function emit(o: Observer, key: Observer.Signal): void {
 function enqueue(eventHandler: () => void) {
   if (!DISPATCH.size)
     queueMicrotask(() => {
-      DISPATCH.forEach((event) => {
+      for (const event of DISPATCH) {
+        DISPATCH.delete(event);
         try {
           event();
         } catch (err) {
           console.error(err);
         }
-      });
-      DISPATCH.clear();
+      }
     });
 
   DISPATCH.add(eventHandler);

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -1067,16 +1067,14 @@ describe('State.get', () => {
   });
 });
 
-describe('State.get - known bug', () => {
+describe('State.get - computed dependency', () => {
   // A component that observes BOTH a field and a computed getter derived from
-  // that field (in either order) refreshes once, then stops - it freezes on
-  // the value from its first update. Observing either member alone works, and
-  // the core `state.get(effect)` subscription refreshes correctly for the same
-  // access pattern, so the fault is in the React `.get()` hook's per-render
-  // key tracking when the observed set contains a computed and its own
-  // dependency. Discovered via the store example (CartPage read `lines` +
-  // `total`, where `total` derives from `lines`). Unskip when fixed.
-  it.skip('will refresh when observing a field and a computed derived from it', async () => {
+  // that field used to refresh once, then freeze on its first-update value:
+  // the field's change and the computed's recompute land in one dispatch tick,
+  // and the batched queue dropped the second, same-tick refresh request.
+  // Discovered via the store example (CartPage read `lines` + `total`, where
+  // `total` derives from `lines`).
+  it('will refresh when observing a field and a computed derived from it', async () => {
     class Test extends State {
       n = 1;
       get double() {
@@ -1102,7 +1100,6 @@ describe('State.get - known bug', () => {
       test.n = 3;
     });
 
-    // BUG: freezes at '2/4' (the value from the first update).
     expect(hook.result.current).toBe('3/6');
   });
 });


### PR DESCRIPTION
## Summary

Fixes a dropped refresh when an observer is re-notified within the same batched dispatch tick.

`enqueue()` in `packages/mvc/src/observable.ts` coalesced handlers by identity in a `Set` and drained with `Set.forEach` + `.clear()`. A single field change emits **two** sequential events in one tick — the field's own event, and the recompute event of any computed getter deriving from it. The observer's stable handler runs on the first event, so its `Set` slot has already been visited; the second event re-adds the same handler, but `Set.add` is a no-op for a member `forEach` has already passed, so the second refresh is silently dropped.

This stranded a React `.get()` subscription observing **both** a field and a computed derived from it (no-factory form stores the proxy and reads during render): the component refreshed exactly once, then froze on its first-update value. `state.get(effect)` masked the bug because an effect re-reads inside its callback and doesn't depend on the dropped re-run.

## Fix

Drain the queue by removing each handler *before* invoking it, so a same-tick re-enqueue runs again in the same tick.

## Discovery & regression coverage

- Surfaced via the store example: `CartPage` read `lines` + `total`, where `total` derives from `lines`, and froze after one update.
- Unskips the regression test in `packages/react/src/state.get.test.tsx` (`State.get - computed dependency`).
- Reverts the `CartPage` class workaround back to a lite FC per the Component-vs-FC rule.

## Verification

- `packages/mvc`: 501 pass, 0 fail, 100% coverage on `observable.ts`.
- `packages/react`: `state.get.test.tsx` 44 pass, 0 fail.

## Notes

- Stacked on #210 (`feat/example-store`); base retargets to `main` once that merges.
- Changeset: `@expressive/mvc` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)