### PR TITLE
fix(mvc): rerun same-tick re-enqueued dispatch handlers

### DIFF
--- a/.changeset/tidy-dispatch-rerun.md
+++ b/.changeset/tidy-dispatch-rerun.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix a dropped refresh when an observer is re-notified within the same dispatch tick. The batched event queue coalesced handlers by identity and drained with `Set.forEach`, so a handler re-enqueued after it had already run in the current tick was silently skipped. This stranded a `.get()` subscription that observed both a field and a computed derived from that field (the field's change and the computed's recompute land in one tick): the component refreshed once, then froze. The queue now removes each handler before invoking it, so a same-tick re-enqueue runs again.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ await expect(state).not.toHaveUpdated();
 ## Change flow
 
 - When starting actual work, switch from any agent-scratch branch (`claude/*`) to a conventional named branch (`feat/...`, `fix/...`, `chore/...`) before the first real commit.
+- Always open PRs against `main` unless explicitly told otherwise. Never assume a PR should target another branch, even when the current work branch is stacked on one. If asked to break a fix out of a larger branch, the intent is to land it independently off `main` - carve out only the change in question and base its branch on `main`.
 - For new features and non-trivial refactors, capture agreed scope, key decisions, and approach in the PR description before implementation - it is the canonical shared plan and review context. (Working notes may live in untracked local scratch; only the PR description is shared.)
 - Write a changeset (`bun run changeset`) when a change is user-facing: new feature, behavior change, API addition, breaking change.
 - No changeset for internal refactors, test-only changes, or fixes with no observable effect. A zero-changeset PR is legitimate.

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -218,14 +218,14 @@ function emit(o: Observer, key: Observer.Signal): void {
 function enqueue(eventHandler: () => void) {
   if (!DISPATCH.size)
     queueMicrotask(() => {
-      DISPATCH.forEach((event) => {
+      for (const event of DISPATCH) {
+        DISPATCH.delete(event);
         try {
           event();
         } catch (err) {
           console.error(err);
         }
-      });
-      DISPATCH.clear();
+      }
     });
 
   DISPATCH.add(eventHandler);

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -1066,3 +1066,38 @@ describe('State.get', () => {
     });
   });
 });
+
+describe('State.get - computed dependency', () => {
+  // A component that observes BOTH a field and a computed getter derived from
+  // that field used to refresh once, then freeze on its first-update value:
+  // the field's change and the computed's recompute land in one dispatch tick,
+  // and the batched queue dropped the second, same-tick refresh request.
+  it('will refresh when observing a field and a computed derived from it', async () => {
+    class Test extends State {
+      n = 1;
+      get double() {
+        return this.n * 2;
+      }
+    }
+
+    const test = Test.new();
+    const hook = renderWith(test, () => {
+      const state = Test.get();
+      return `${state.n}/${state.double}`;
+    });
+
+    expect(hook.result.current).toBe('1/2');
+
+    await act(async () => {
+      test.n = 2;
+    });
+
+    expect(hook.result.current).toBe('2/4');
+
+    await act(async () => {
+      test.n = 3;
+    });
+
+    expect(hook.result.current).toBe('3/6');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a dropped refresh when an observer is re-notified within the same batched dispatch tick. Landed independently of the store-example branch (#210) it was discovered on.

`enqueue()` in `packages/mvc/src/observable.ts` coalesced handlers by identity in a `Set` and drained with `Set.forEach` + `.clear()`. A single field change emits **two** sequential events in one tick — the field's own event, and the recompute event of any computed getter deriving from it. The observer's stable handler runs on the first event, so its `Set` slot has already been visited; the second event re-adds the same handler, but `Set.add` is a no-op for a member `forEach` has already passed, so the second refresh is silently dropped.

This stranded a React `.get()` subscription observing **both** a field and a computed derived from it (the no-factory form stores the proxy and reads during render): the component refreshed exactly once, then froze on its first-update value. `state.get(effect)` masked the bug because an effect re-reads inside its callback and doesn't depend on the dropped re-run.

## Fix

Drain the queue by removing each handler *before* invoking it, so a same-tick re-enqueue runs again in the same tick.

## Regression coverage

New test in `packages/react/src/state.get.test.tsx` (`State.get - computed dependency`) observing a field plus a computed derived from it across two updates. Confirmed it **fails** on `main` (freezes at `2/4`) and passes with the fix.

## Verification

- `packages/mvc`: 501 pass, 0 fail, 100% coverage on `observable.ts`.
- `packages/react`: `state.get.test.tsx` 44 pass, 0 fail.

## Also

- `AGENTS.md`: note to always target `main` for PRs unless told otherwise, and that breaking a fix out means landing it independently off `main`.

## Notes

- Changeset: `@expressive/mvc` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)