### PR TITLE
chore(website): add build:site script for Cloudflare Pages deploy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-state",
@@ -131,7 +130,6 @@
         "typescript": "^5.9.3",
         "vite": "^7.3.1",
         "vite-tsconfig-paths": "^6.1.1",
-        "wrangler": "^4.93.0",
       },
     },
   },
@@ -1514,7 +1512,7 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
-    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -1956,8 +1954,6 @@
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
-    "fumadocs-core/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
-
     "fumadocs-mdx/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "hast-util-to-estree/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -2031,6 +2027,8 @@
     "vite-node/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "wrangler/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "wrangler/path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "bun run --filter='./packages/*' test",
     "build": "bun run --filter='./packages/*' build",
+    "build:site": "bun run build && bun run --filter website build",
     "changeset": "changeset",
     "wrap": "changeset",
     "ci:version": "changeset version && bun install",

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,6 @@
     "dev": "react-router dev",
     "start": "serve ./build/client --config ../../serve.json",
     "types:check": "react-router typegen && fumadocs-mdx && tsc --noEmit",
-    "publish": "wrangler pages deploy --branch main",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
@@ -41,8 +40,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vite": "^7.3.1",
-    "vite-tsconfig-paths": "^6.1.1",
-    "wrangler": "^4.93.0"
+    "vite-tsconfig-paths": "^6.1.1"
   },
   "version": "0.77.0"
 }

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -1,4 +1,0 @@
-{
-  "name": "expressive-mvc",
-  "pages_build_output_dir": "build/client"
-}


### PR DESCRIPTION
## What

1. Adds a root script `build:site` that builds the workspace packages then the website:
   ```jsonc
   "build:site": "bun run build && bun run --filter website build"
   ```
2. Removes the manual `wrangler` CLI deploy path, superseded by the Cloudflare Pages **Git connector**:
   - `website/wrangler.jsonc` (only read by `wrangler pages deploy` / Functions; we have neither)
   - `"publish": "wrangler pages deploy --branch main"` script
   - `wrangler` devDependency

## Why

Deploying the website via the Cloudflare Pages **Git connector** (CF builds in its own CI on push). The connector needs one entry-point command. `react-router build` alone doesn't build the `@expressive/*` packages the site imports via `workspace:*` (they resolve to `dist`), so packages must build first. `build:site` encodes that ordering in-repo.

bun has no dependency-aware filter (no pnpm-style `website...`), so the two phases are explicit: `bun run build` (packages only, existing `--filter='./packages/*'` script) then the website build.

With the connector owning deploys, the wrangler bits are dead weight (one source of truth). Restoring the CLI fallback later is trivial.

## Deploy strategy (dashboard-side)

- **Connector settings**: root directory `/`, build command `bun run build:site`, output `website/build/client`, `BUN_VERSION` pinned to `1.3.1`.
- **Build watch paths** (minimize builds for a rarely-changing site):
  ```
  website/*
  examples/*                # sandbox globs raw source from examples/ at build time
  bun.lock
  packages/*/CHANGELOG.md    # fires only on a changesets release → site rebuilds with new package source
  ```
- No deploy hook / no `release.yml` change: the `CHANGELOG.md` watch path is a path-based proxy for "a release happened."

## Notes

- No changeset: chore, no user-facing package change.
- Verified: `bun run build:site` builds all packages and prerenders `/` cleanly; `wrangler` no longer installed/linked after removal.