### PR TITLE
fix(router): run consumer onClick before Link navigation

### DIFF
--- a/packages/router/src/link.test.tsx
+++ b/packages/router/src/link.test.tsx
@@ -72,6 +72,36 @@ describe('Link', () => {
     expect(router.current.path).toBe('/');
   });
 
+  it('will call consumer onClick before navigating', async () => {
+    let clicked = false;
+    const view = render(
+      <Route to="/">
+        <Link to="/about" onClick={() => (clicked = true)}>
+          about
+        </Link>
+      </Route>
+    );
+    await act(async () => {
+      fireEvent.click(view.container.querySelector('a')!, { button: 0 });
+    });
+    expect(clicked).toBe(true);
+    expect(router.current.path).toBe('/about');
+  });
+
+  it('will not navigate if consumer onClick prevents default', async () => {
+    const view = render(
+      <Route to="/">
+        <Link to="/about" onClick={(e) => e.preventDefault()}>
+          about
+        </Link>
+      </Route>
+    );
+    await act(async () => {
+      fireEvent.click(view.container.querySelector('a')!, { button: 0 });
+    });
+    expect(router.current.path).toBe('/');
+  });
+
   it('replace=true uses replaceState', async () => {
     const view = render(
       <Route to="/">

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -55,6 +55,10 @@ export class Link extends Component {
   }
 
   protected go = (e: ClickEvent) => {
+    const { onClick } = this.props as { onClick?: (e: ClickEvent) => void };
+
+    onClick && onClick(e);
+
     if (e.defaultPrevented || e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -57,10 +57,10 @@ export class Link extends Component {
   protected go = (e: ClickEvent) => {
     const { onClick } = this.props as { onClick?: (e: ClickEvent) => void };
 
-    onClick && onClick(e);
-
+    if (onClick) onClick(e);
     if (e.defaultPrevented || e.button !== 0) return;
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
     e.preventDefault();
     this.route.goto(this.to, this.replace);
   };


### PR DESCRIPTION
## Problem

`Link.render` spreads consumer props onto the anchor, then sets its own handler after: `<a {...rest} href={this.href} onClick={this.go}>`. Any `onClick` passed to `<Link>` is silently discarded.

Surfaced by the store example, where `<Link to="/" onClick={() => cart.reset()}>` (Continue shopping) never fired the reset - broken since the example's first pass, invisible because nothing re-visited the cart afterward.

## Fix

`go()` now calls `props.onClick` first. The existing `defaultPrevented` guard then doubles as the cancellation contract: a consumer handler calling `e.preventDefault()` stops navigation. Chaining inside `go()` (rather than in render) means subclasses that author their own render and wire `onClick={this.go}` inherit the behavior.

## Tests

- will call consumer onClick before navigating
- will not navigate if consumer onClick prevents default

Full router suite: 212 pass / 0 fail.

No changeset: `@expressive/router` is unpublished (0.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)