### PR TITLE
feat(mvc): reactive get() snapshot seam for hot objects

### DIFF
--- a/.changeset/hot-shape-reactivity.md
+++ b/.changeset/hot-shape-reactivity.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": minor
+---
+
+hot() object enumeration is now shape-reactive. `Object.keys`/`values`/`entries`, spread, and `for...in` on a hot object inside a watch context now see the collection's real keys (previously they saw none) and subscribe to shape: adding or deleting a key re-runs the consumer, while writes to existing keys remain tracked per key. Getters aggregating over a keyed collection (e.g. `Object.values(this.items).reduce(...)`) now stay reactive. Enumerating a hot array subscribes to `length`.

--- a/.changeset/hot-shape-reactivity.md
+++ b/.changeset/hot-shape-reactivity.md
@@ -2,4 +2,4 @@
 "@expressive/mvc": minor
 ---
 
-hot() object enumeration is now shape-reactive. `Object.keys`/`values`/`entries`, spread, and `for...in` on a hot object inside a watch context now see the collection's real keys (previously they saw none) and subscribe to shape: adding or deleting a key re-runs the consumer, while writes to existing keys remain tracked per key. Getters aggregating over a keyed collection (e.g. `Object.values(this.items).reduce(...)`) now stay reactive. Enumerating a hot array subscribes to `length`.
+hot() objects gain a reactive snapshot seam. Reading `get()` on a hot object inside a watch context subscribes to every change of the collection - key add, key delete, and value writes - so getters aggregating over a keyed collection (e.g. `Object.values(this.items.get()).reduce(...)`) stay reactive. Plain enumeration of the proxy remains untracked. The object overload now types the snapshot: `hot<T>(value: T): T & { get(): Readonly<T> }`.

--- a/packages/mvc/src/field/hot.test.ts
+++ b/packages/mvc/src/field/hot.test.ts
@@ -334,6 +334,22 @@ describe('array', () => {
     expect(cb).toHaveBeenCalledWith(3, 1);
   });
 
+  it('enumeration of keys subscribes to length', async () => {
+    const arr = hot([1, 2]);
+    const cb = mock();
+    watch(arr, ($) => {
+      expect(Object.keys($)).toEqual(
+        Array.from({ length: $.length }, (_, i) => String(i))
+      );
+      cb();
+    });
+    cb.mockClear();
+
+    arr.push(3);
+    await flush();
+    expect(cb).toHaveBeenCalled();
+  });
+
   it('length truncation fires length event', async () => {
     const arr = hot([1, 2, 3]);
     const onIndex = mock();
@@ -464,6 +480,58 @@ describe('object', () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
+  it('enumeration sees keys and values through watch proxy', () => {
+    const obj = hot({ a: 1, b: 2 });
+
+    watch(obj, ($) => {
+      expect(Object.keys($)).toEqual(['a', 'b']);
+      expect(Object.values($)).toEqual([1, 2]);
+      expect({ ...$ }).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  it('enumeration fires when a key is added', async () => {
+    const obj = hot({ a: 1 } as Record<string, number>);
+    const cb = mock();
+    watch(obj, ($) => {
+      void Object.keys($);
+      cb();
+    });
+    cb.mockClear();
+
+    obj.b = 2;
+    await flush();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('enumeration fires when a key is deleted', async () => {
+    const obj = hot({ a: 1, b: 2 } as Record<string, number>);
+    const cb = mock();
+    watch(obj, ($) => {
+      void Object.keys($);
+      cb();
+    });
+    cb.mockClear();
+
+    delete obj.b;
+    await flush();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('enumeration does not fire on existing-key write', async () => {
+    const obj = hot({ a: 1, b: 2 });
+    const cb = mock();
+    watch(obj, ($) => {
+      void Object.keys($);
+      cb();
+    });
+    cb.mockClear();
+
+    obj.a = 99;
+    await flush();
+    expect(cb).not.toHaveBeenCalled();
+  });
+
   it('does not recurse into nested objects', () => {
     const obj = hot({ inner: { x: 1 } });
     expect(observer(obj.inner)).toBeUndefined();
@@ -571,5 +639,33 @@ describe('as State field', () => {
     await flush();
 
     expect(cb).toHaveBeenCalledWith('X');
+  });
+
+  it('getter aggregating over keyed collection stays reactive', async () => {
+    class Cart extends State {
+      items: Record<string, number> = hot({});
+
+      get count() {
+        return Object.values(this.items).reduce((sum, qty) => sum + qty, 0);
+      }
+    }
+
+    const cart = Cart.new();
+    const cb = mock();
+
+    cart.get(($) => cb($.count));
+    expect(cb).toHaveBeenCalledWith(0);
+
+    cart.items.pizza = 2;
+    await flush();
+    expect(cb).toHaveBeenCalledWith(2);
+
+    cart.items.pizza = 5;
+    await flush();
+    expect(cb).toHaveBeenCalledWith(5);
+
+    delete cart.items.pizza;
+    await flush();
+    expect(cb).toHaveBeenLastCalledWith(0);
   });
 });

--- a/packages/mvc/src/field/hot.test.ts
+++ b/packages/mvc/src/field/hot.test.ts
@@ -334,22 +334,6 @@ describe('array', () => {
     expect(cb).toHaveBeenCalledWith(3, 1);
   });
 
-  it('enumeration of keys subscribes to length', async () => {
-    const arr = hot([1, 2]);
-    const cb = mock();
-    watch(arr, ($) => {
-      expect(Object.keys($)).toEqual(
-        Array.from({ length: $.length }, (_, i) => String(i))
-      );
-      cb();
-    });
-    cb.mockClear();
-
-    arr.push(3);
-    await flush();
-    expect(cb).toHaveBeenCalled();
-  });
-
   it('length truncation fires length event', async () => {
     const arr = hot([1, 2, 3]);
     const onIndex = mock();
@@ -480,21 +464,21 @@ describe('object', () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('enumeration sees keys and values through watch proxy', () => {
+  it('snapshot returns keys and values', () => {
     const obj = hot({ a: 1, b: 2 });
 
     watch(obj, ($) => {
-      expect(Object.keys($)).toEqual(['a', 'b']);
-      expect(Object.values($)).toEqual([1, 2]);
-      expect({ ...$ }).toEqual({ a: 1, b: 2 });
+      const snapshot = $.get();
+      expect(Object.keys(snapshot)).toEqual(['a', 'b']);
+      expect(Object.values(snapshot)).toEqual([1, 2]);
     });
   });
 
-  it('enumeration fires when a key is added', async () => {
+  it('snapshot fires when a key is added', async () => {
     const obj = hot({ a: 1 } as Record<string, number>);
     const cb = mock();
     watch(obj, ($) => {
-      void Object.keys($);
+      void $.get();
       cb();
     });
     cb.mockClear();
@@ -504,11 +488,11 @@ describe('object', () => {
     expect(cb).toHaveBeenCalled();
   });
 
-  it('enumeration fires when a key is deleted', async () => {
+  it('snapshot fires when a key is deleted', async () => {
     const obj = hot({ a: 1, b: 2 } as Record<string, number>);
     const cb = mock();
     watch(obj, ($) => {
-      void Object.keys($);
+      void $.get();
       cb();
     });
     cb.mockClear();
@@ -518,16 +502,44 @@ describe('object', () => {
     expect(cb).toHaveBeenCalled();
   });
 
-  it('enumeration does not fire on existing-key write', async () => {
+  it('snapshot fires on existing-key write', async () => {
     const obj = hot({ a: 1, b: 2 });
     const cb = mock();
     watch(obj, ($) => {
-      void Object.keys($);
+      void $.get();
       cb();
     });
     cb.mockClear();
 
     obj.a = 99;
+    await flush();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('snapshot does not fire on same-value write', async () => {
+    const obj = hot({ a: 1 });
+    const cb = mock();
+    watch(obj, ($) => {
+      void $.get();
+      cb();
+    });
+    cb.mockClear();
+
+    obj.a = 1;
+    await flush();
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('per-key effect does not fire on unrelated shape change', async () => {
+    const obj = hot({ a: 1 } as Record<string, number>);
+    const cb = mock();
+    watch(obj, ($) => {
+      void $.a;
+      cb();
+    });
+    cb.mockClear();
+
+    obj.b = 2;
     await flush();
     expect(cb).not.toHaveBeenCalled();
   });
@@ -641,12 +653,12 @@ describe('as State field', () => {
     expect(cb).toHaveBeenCalledWith('X');
   });
 
-  it('getter aggregating over keyed collection stays reactive', async () => {
+  it('getter aggregating over snapshot stays reactive', async () => {
     class Cart extends State {
-      items: Record<string, number> = hot({});
+      items = hot({} as Record<string, number>);
 
       get count() {
-        return Object.values(this.items).reduce((sum, qty) => sum + qty, 0);
+        return Object.values(this.items.get()).reduce((sum, qty) => sum + qty, 0);
       }
     }
 

--- a/packages/mvc/src/field/hot.ts
+++ b/packages/mvc/src/field/hot.ts
@@ -1,9 +1,11 @@
-import { event, touch } from '../observable';
+import { event, KEYS, touch } from '../observable';
 
 /**
  * Wrap an array or object as a reactive Proxy.
  *
  * Reads register subscriptions in active watch contexts; writes fire keyed events.
+ * Key enumeration is shape-reactive: add/delete of object keys re-fires consumers
+ * which enumerated, while existing-key writes stay tracked per key.
  * Single-level only - nested objects are not wrapped recursively. Use a child State
  * (or a separate `hot()` call) for nested reactivity.
  *
@@ -103,10 +105,20 @@ function object<T extends object>(value: T) {
       return touch(receiver, key, result);
     },
     set(target, key, value) {
-      return assign(proxy, target, key, value);
+      const added = !(key in target);
+      const ok = assign(proxy, target, key, value);
+
+      if (ok && added && typeof key !== 'symbol') event(proxy, KEYS);
+
+      return ok;
     },
     deleteProperty(target, key) {
-      return remove(proxy, target, key);
+      const had = key in target;
+      const ok = remove(proxy, target, key);
+
+      if (ok && had && typeof key !== 'symbol') event(proxy, KEYS);
+
+      return ok;
     }
   });
 

--- a/packages/mvc/src/field/hot.ts
+++ b/packages/mvc/src/field/hot.ts
@@ -91,6 +91,7 @@ function array<T>(value: T[]) {
 
 function object<T extends object>(value: T) {
   const get = () => Object.freeze({ ...value });
+  const notify = (key: unknown) => typeof key !== 'symbol' && event(proxy, KEYS);
 
   const proxy: any = new Proxy(value, {
     has,
@@ -105,10 +106,10 @@ function object<T extends object>(value: T) {
       return touch(receiver, key, result);
     },
     set(target, key, value) {
-      const added = !(key in target);
+      const had = key in target;
       const ok = assign(proxy, target, key, value);
 
-      if (ok && added && typeof key !== 'symbol') event(proxy, KEYS);
+      if (ok && !had) notify(key);
 
       return ok;
     },
@@ -116,7 +117,7 @@ function object<T extends object>(value: T) {
       const had = key in target;
       const ok = remove(proxy, target, key);
 
-      if (ok && had && typeof key !== 'symbol') event(proxy, KEYS);
+      if (ok && had) notify(key);
 
       return ok;
     }

--- a/packages/mvc/src/field/hot.ts
+++ b/packages/mvc/src/field/hot.ts
@@ -1,19 +1,24 @@
-import { event, KEYS, touch } from '../observable';
+import { event, touch } from '../observable';
 
 /**
  * Wrap an array or object as a reactive Proxy.
  *
  * Reads register subscriptions in active watch contexts; writes fire keyed events.
- * Key enumeration is shape-reactive: add/delete of object keys re-fires consumers
- * which enumerated, while existing-key writes stay tracked per key.
+ * Plain key enumeration is not tracked; for aggregates, read the object `get()`
+ * snapshot, which subscribes to every change of the collection.
  * Single-level only - nested objects are not wrapped recursively. Use a child State
  * (or a separate `hot()` call) for nested reactivity.
  *
  * Storage is shared with the input value: external mutation of the original
  * collection bypasses dispatch. Pass a fresh value when this matters.
  */
+type Snapshot<T> = { get(): Readonly<T> };
+type HotObject<T> = 'get' extends keyof T
+  ? string extends keyof T ? T & Snapshot<T> : T
+  : T & Snapshot<T>;
+
 function hot<T>(value: T[]): T[];
-function hot<T extends object>(value: T): T;
+function hot<T extends object>(value: T): HotObject<T>;
 function hot(value: any) {
   if (typeof value !== 'object' || !value)
     throw new Error('hot() requires an array or object');
@@ -89,14 +94,17 @@ function array<T>(value: T[]) {
   return proxy;
 }
 
+const SNAPSHOT = Symbol('snapshot');
+
 function object<T extends object>(value: T) {
   const get = () => Object.freeze({ ...value });
-  const notify = (key: unknown) => typeof key !== 'symbol' && event(proxy, KEYS);
+  const notify = (key: unknown) => typeof key !== 'symbol' && event(proxy, SNAPSHOT);
 
   const proxy: any = new Proxy(value, {
     has,
     get(target, key, receiver) {
-      if (key === 'get' && !(key in target)) return get;
+      if (key === 'get' && !(key in target))
+        return touch(receiver, SNAPSHOT, get);
 
       const result = Reflect.get(target, key, receiver);
 
@@ -106,10 +114,10 @@ function object<T extends object>(value: T) {
       return touch(receiver, key, result);
     },
     set(target, key, value) {
-      const had = key in target;
+      const changed = !(key in target) || (target as any)[key] !== value;
       const ok = assign(proxy, target, key, value);
 
-      if (ok && !had) notify(key);
+      if (ok && changed) notify(key);
 
       return ok;
     },

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -43,7 +43,6 @@ interface Observing {
 
 const Observer: unique symbol = Symbol('Observer');
 const Observing: unique symbol = Symbol('Observing');
-const KEYS: unique symbol = Symbol('keys');
 
 /** Central event dispatch. Bunches all updates to occur at same time. */
 const DISPATCH = new Set<() => void>();
@@ -97,18 +96,10 @@ function observe<T extends object>(
       if (update !== true) release();
     });
 
-  const observing: Observing = { callback, watching, required };
+  const proxy = Object.create(object) as T;
 
-  return new Proxy(object, {
-    get(target, key, receiver) {
-      return key === Observing
-        ? observing
-        : Reflect.get(target, key, receiver);
-    },
-    ownKeys(target) {
-      watching.add(Array.isArray(target) ? 'length' : KEYS);
-      return Reflect.ownKeys(target);
-    }
+  return Object.defineProperty(proxy, Observing, {
+    value: { callback, watching, required } as Observing
   });
 }
 
@@ -359,7 +350,6 @@ function capture(scope: (release: (update?: boolean | null) => void) => void) {
 export {
   listener,
   event,
-  KEYS,
   Observer,
   touch,
   pending,

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -43,6 +43,7 @@ interface Observing {
 
 const Observer: unique symbol = Symbol('Observer');
 const Observing: unique symbol = Symbol('Observing');
+const KEYS: unique symbol = Symbol('keys');
 
 /** Central event dispatch. Bunches all updates to occur at same time. */
 const DISPATCH = new Set<() => void>();
@@ -96,10 +97,18 @@ function observe<T extends object>(
       if (update !== true) release();
     });
 
-  const proxy = Object.create(object) as T;
+  const observing: Observing = { callback, watching, required };
 
-  return Object.defineProperty(proxy, Observing, {
-    value: { callback, watching, required } as Observing
+  return new Proxy(object, {
+    get(target, key, receiver) {
+      return key === Observing
+        ? observing
+        : Reflect.get(target, key, receiver);
+    },
+    ownKeys(target) {
+      watching.add(Array.isArray(target) ? 'length' : KEYS);
+      return Reflect.ownKeys(target);
+    }
   });
 }
 
@@ -350,6 +359,7 @@ function capture(scope: (release: (update?: boolean | null) => void) => void) {
 export {
   listener,
   event,
+  KEYS,
   Observer,
   touch,
   pending,

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -35,7 +35,7 @@ export class Router extends Component {
    * }
    * ```
    */
-  query = hot({} as Record<string, string | undefined>);
+  query: Record<string, string | undefined> = hot({} as Record<string, string | undefined>);
 
   /** In-memory history: visited urls (path + query) and the cursor into them. */
   entries: string[] = [];

--- a/skills/field/hot.md
+++ b/skills/field/hot.md
@@ -168,6 +168,6 @@ function hot<T extends object>(value: T): T;
 - Array `push`, `unshift`, `pop`, `shift`, `splice`, `sort`, and `reverse` work through native methods and notify the affected keys.
 - Array holes are not allowed; use placeholders or `splice()`.
 - Object property reads and writes are tracked by property key.
-- Object key enumeration is not shape-reactive; effects should read the keys they depend on.
+- Object key enumeration (`Object.keys`/`values`/`entries`, spread, `for...in`) is shape-reactive: key add and delete re-run the effect, while writes to existing keys stay tracked per key.
 - Symbol keys and function values are passed through without keyed tracking.
 - Nested arrays and objects are not wrapped recursively.

--- a/skills/field/hot.md
+++ b/skills/field/hot.md
@@ -66,6 +66,32 @@ form.values.name = 'Ada'; // does not rerun an effect that only read email
 
 Object reads track individual property keys. Adding or deleting a property notifies effects that already read that key.
 
+### Aggregates
+
+Key enumeration (`Object.keys`/`values`/`entries`, spread, `for...in`) is not tracked. To derive from the whole collection, read the `get()` snapshot - it subscribes to every change: key add, key delete, and value writes.
+
+```ts
+class Cart extends State {
+  items = hot({} as Record<string, number>);
+
+  get count() {
+    return Object.values(this.items.get()).reduce((sum, qty) => sum + qty, 0);
+  }
+}
+
+const cart = Cart.new();
+
+cart.get(($) => {
+  console.log($.count);
+});
+
+cart.items.pizza = 2; // logs 2
+cart.items.pizza = 5; // logs 5
+delete cart.items.pizza; // logs 0
+```
+
+If the wrapped object has its own `get` property, it wins and the snapshot method is unavailable.
+
 ## Dense Array Contract
 
 `hot()` arrays must be dense. Sparse arrays are rejected on creation, and operations that would create holes throw.
@@ -157,8 +183,10 @@ list[0] = 100; // changes storage and dispatches
 
 ```ts
 function hot<T>(value: T[]): T[];
-function hot<T extends object>(value: T): T;
+function hot<T extends object>(value: T): T & { get(): Readonly<T> };
 ```
+
+The object overload types the `get()` snapshot method, except when `T` declares its own `get` property. To keep a field's declared type plain (e.g. so subclasses can narrow it), annotate the field explicitly: `query: Record<string, string | undefined> = hot({} as Record<string, string | undefined>)`.
 
 ## Behavior
 
@@ -168,6 +196,7 @@ function hot<T extends object>(value: T): T;
 - Array `push`, `unshift`, `pop`, `shift`, `splice`, `sort`, and `reverse` work through native methods and notify the affected keys.
 - Array holes are not allowed; use placeholders or `splice()`.
 - Object property reads and writes are tracked by property key.
-- Object key enumeration (`Object.keys`/`values`/`entries`, spread, `for...in`) is shape-reactive: key add and delete re-run the effect, while writes to existing keys stay tracked per key.
+- Object key enumeration (`Object.keys`/`values`/`entries`, spread, `for...in`) is not tracked; read the `get()` snapshot to depend on the whole collection.
+- Reading `get` on a hot object subscribes to every change of the collection: key add, key delete, and value writes.
 - Symbol keys and function values are passed through without keyed tracking.
 - Nested arrays and objects are not wrapped recursively.


### PR DESCRIPTION
## Problem

Aggregating getters over a hot object (e.g. \`Object.values(this.items).reduce(...)\`) were silently non-reactive: enumeration of the watch wrapper sees no own keys and subscribes to nothing (#218).

## Approach

Rather than making \`observe()\` a full Proxy with an \`ownKeys\` trap (rejected: it puts a Proxy get trap on every tracked read library-wide), shape reactivity is confined to an explicit seam on the hot object variant:

- Reading \`get()\` on a hot object inside a watch context subscribes to a private snapshot channel.
- The object proxy notifies that channel on any effective change: key add, key delete, and value writes (snapshot consumers get no per-key tracking, so value writes must notify).
- Plain enumeration of the proxy remains untracked, and the docs now say so explicitly.
- The object overload types the seam: \`hot<T>(value: T): T & { get(): Readonly<T> }\` (suppressed when \`T\` has its own \`get\`). Fields that want a plain declared type (e.g. router \`query\`, narrowable via \`declare\`) annotate explicitly.

Aggregates are written as \`Object.values(this.items.get()).reduce(...)\` - explicit about subscribing to the whole collection.

## Notes

- \`observable.ts\` is untouched relative to main.
- Follow-up (discussed, next up): convert \`hot()\` from free-standing factory to a field instruction so whole-collection replacement (\`this.items = {}\`) re-wraps instead of silently dropping reactivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)