### PR TITLE
chore: add worktree-setup script

### DIFF
--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Make a freshly-created worktree runnable: install deps (node_modules is not
+# shared across worktrees) and carry local, gitignored config over from the
+# main checkout. Safe to re-run; only acts when something is missing.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+main="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+cd "$root"
+
+if [ ! -d node_modules ]; then
+  echo "→ installing deps…"
+  bun install
+fi
+
+if [ "$root" != "$main" ]; then
+  for f in .claude/launch.json .claude/settings.local.json; do
+    if [ -f "$main/$f" ] && [ ! -f "$root/$f" ]; then
+      mkdir -p "$(dirname "$root/$f")"
+      cp "$main/$f" "$root/$f"
+      echo "→ copied $f from main checkout"
+    fi
+  done
+fi
+
+echo "✓ worktree ready: $root"


### PR DESCRIPTION
## What

Adds `scripts/worktree-setup.sh` - a one-shot bootstrap for freshly-created git worktrees.

A new worktree starts with **no `node_modules`** (deps are not shared across worktrees), so it can't run until you install. This script:

- runs `bun install` if `node_modules` is missing
- copies local, gitignored config (`.claude/launch.json`, `.claude/settings.local.json`) from the main checkout into the worktree, since gitignored files don't propagate to new worktrees

Idempotent - only acts when something is missing, safe to re-run.

## Usage

Not auto-invoked. Run once after creating a worktree:

```bash
bash scripts/worktree-setup.sh
```

(Can be wired to a global `SessionStart` hook later for zero-touch; deliberately left manual here.)

## Notes

- No changeset: internal dev tooling, no user-facing/package behavior change.