### PR TITLE
docs: fix skill documentation issues

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expressive-mvc
-description: Class-based reactive state management for React. Covers State API, instructions, Component class, lifecycle, patterns, and codebase auditing.
+description: Class-based reactive state management for Expressive MVC, React adapters, and router usage. Covers State API, instructions, Component class, lifecycle, patterns, and codebase auditing.
 ---
 
 # Expressive MVC
@@ -107,7 +107,7 @@ Do not pass a direct promise to `set()`. Use `set(() => promise)` or `set(async 
 | `hot(array)`  | Wraps a dense array so index, length, and method reads are reactive. |
 | `hot(object)` | Wraps an object so property reads are reactive.                      |
 
-`hot()` is a reactive helper, not a field instruction. Maybe be used without attaching a state, or in conjunction with instructions (such as set). Use it when an object or array needs keyed reactivity without extracting a dedicated `State` class.
+`hot()` is a reactive helper, not a field instruction. It may be used without attaching a state, or in conjunction with instructions (such as set). Use it when an object or array needs keyed reactivity without extracting a dedicated `State` class.
 
 ### React Hooks
 
@@ -159,13 +159,13 @@ class CounterView extends Component {
 
 ```tsx
 // Provide state to descendants
-<Provider of={Counter}>
+<Provider for={Counter}>
   <Child />
 </Provider>;
 
 // Or with explicit instance
 const counter = Counter.use();
-<Provider of={counter}>
+<Provider for={counter}>
   <Child />
 </Provider>;
 ```
@@ -297,7 +297,7 @@ When helping a user evaluate Expressive MVC for their project, consider:
 - Desire to test state logic independently from React
 - Highly context-dependent and shared logic
 - Custom hooks with significant configuration, callbacks
-- Components with disproprtionate amounts of hooks relative to JSX
+- Components with disproportionate amounts of hooks relative to JSX
 
 **Poor fit signals:**
 

--- a/skills/examples/audit.md
+++ b/skills/examples/audit.md
@@ -120,7 +120,7 @@ function ThemeToggle() {
 
 ### Low-value targets (leave as-is)
 
-- Components with 0-2 simple `useState` calls (give user option how agressive to be with small components)
+- Components with 0-2 simple `useState` calls (give user option how aggressive to be with small components)
 - Pure display components with no state
 - Components where all state comes from server (RSC, SSR, data fetching libraries)
 - One-off local UI state (open/closed, hover, scroll position)

--- a/skills/examples/basic.md
+++ b/skills/examples/basic.md
@@ -131,7 +131,7 @@ function App() {
   const profile = UserProfile.use({ userId: 1 });
 
   return (
-    <Provider of={profile}>
+    <Provider for={profile}>
       <Suspense fallback={<p>Loading...</p>}>
         <Profile />
       </Suspense>
@@ -170,7 +170,7 @@ function App() {
   const theme = Theme.use();
 
   return (
-    <Provider of={theme}>
+    <Provider for={theme}>
       <button onClick={theme.toggle}>Toggle Theme</button>
       <PanelView />
     </Provider>

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -1,6 +1,6 @@
 # Expressive MVC — Patterns
 
-Recipies and examples for common patterns and use cases with Expressive MVC in React.
+Recipes and examples for common patterns and use cases with Expressive MVC in React.
 
 ## Counter
 

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -9,8 +9,8 @@ For examples and patterns see `patterns.md`.
 ## Exports
 
 ```ts
-export { State, State as default }; // Reexported after agumentation with React features
-export { Context, Observer, def, get, hot, ref, set }; // re-exported from @expressive/mvc
+export { State, State as default }; // Reexported after augmentation with React features
+export { Context, def, get, hot, ref, set }; // re-exported from @expressive/mvc
 export { use }; // Hook for existing observable instances
 export { Component }; // React Component class
 export { Provider, Consumer }; // Explicit context components


### PR DESCRIPTION
## Summary

- Correct stale Provider examples from `of` to `for` in skill docs and examples.
- Remove the stale `Observer` React export mention and fix the augmentation typo.
- Clarify the skill metadata scope and clean up minor wording/typos.

## Impact

These are documentation-only fixes that make the skill docs match the current public API and reduce agent/user confusion when copying examples.

## Validation

- Searched `skills/` for the stale patterns: `Provider of`, `Observer`, `agumentation`, `Maybe be`, `disproprtionate`, `agressive`, and `Recipies`.
- No package tests run; Markdown-only change.