### PR TITLE
polish(website): homepage follow-up polish

### DIFF
--- a/website/app/app.css
+++ b/website/app/app.css
@@ -69,6 +69,13 @@ figure[data-rehype-pretty-code-figure] pre code,
   overflow-x: auto !important;
 }
 
+.hero-mobile-code pre,
+.hero-mobile-code code,
+.hero-mobile-code .line {
+  font-size: 0.8125rem !important;
+  line-height: 1.45 !important;
+}
+
 :root {
   --purple: #7864f7;
   --accent: var(--purple);

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -76,6 +76,27 @@ figure[data-rehype-pretty-code-figure] pre code,
   line-height: 1.45 !important;
 }
 
+.live-counter-button {
+  box-shadow:
+    0 1px 2px hsl(var(--click-hue) 70% 45% / 0.08),
+    inset 0 0 0 1px hsl(var(--click-hue) 75% 60% / 0.18);
+}
+
+.live-counter-pulse {
+  position: absolute;
+  inset: -0.2rem;
+  border: 2px solid hsl(var(--click-hue) 82% 58% / 0.7);
+  border-radius: 9999px;
+  animation: live-counter-pulse 420ms ease-out forwards;
+}
+
+@keyframes live-counter-pulse {
+  to {
+    opacity: 0;
+    transform: scale(1.18, 1.35);
+  }
+}
+
 :root {
   --purple: #7864f7;
   --accent: var(--purple);
@@ -138,7 +159,8 @@ figure[data-rehype-pretty-code-figure] pre code,
 
 @media (prefers-reduced-motion: reduce) {
   .marquee-track,
-  .aurora {
+  .aurora,
+  .live-counter-pulse {
     animation: none !important;
   }
 }

--- a/website/app/components/Compare.tsx
+++ b/website/app/components/Compare.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
-import State from '@expressive/react';
+import State, { ref } from '@expressive/react';
+import ScrollOverflowControls from './ScrollOverflowControls';
 import code from './Snippet';
 
 type Snippet = ReturnType<typeof code>;
@@ -19,6 +20,36 @@ const LN = { codeblock: { 'data-line-numbers': true } } as const;
 class Control extends State {
   tab = 0;
   face = 0;
+  canScrollTabsLeft = false;
+  canScrollTabsRight = false;
+
+  tabScroller = ref<HTMLDivElement>((el) => {
+    let frame = 0;
+    const media = window.matchMedia('(max-width: 1023px)');
+
+    const update = () => {
+      frame = 0;
+      const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
+      this.canScrollTabsLeft = media.matches && el.scrollLeft > 1;
+      this.canScrollTabsRight = media.matches && remaining > 1;
+    };
+
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    el.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    media.addEventListener('change', schedule);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      media.removeEventListener('change', schedule);
+    };
+  });
 
   select(i: number) {
     if (i === 0) {
@@ -28,10 +59,35 @@ class Control extends State {
       this.face = 1;
     }
   }
+
+  scrollTabs(direction: -1 | 1) {
+    this.tabScroller.current?.scrollBy({
+      left: direction * 160,
+      behavior: 'smooth',
+    });
+  }
+
+  updateTabScrollState() {
+    const el = this.tabScroller.current;
+    if (!el) return;
+
+    const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
+    const mobile = window.matchMedia('(max-width: 1023px)').matches;
+    this.canScrollTabsLeft = mobile && el.scrollLeft > 1;
+    this.canScrollTabsRight = mobile && remaining > 1;
+  }
 }
 
 export default function Compare({ left, right }: CompareProps) {
-  const { tab, face, select } = Control.use();
+  const {
+    tab,
+    face,
+    select,
+    tabScroller,
+    canScrollTabsLeft,
+    canScrollTabsRight,
+    scrollTabs,
+  } = Control.use();
 
   const active = right[Math.min(tab, right.length - 1)];
   const Left = left.code;
@@ -76,18 +132,33 @@ export default function Compare({ left, right }: CompareProps) {
       </div>
 
       <div className="lg:hidden">
-        <div className="flex flex-wrap gap-1 p-1 mb-3 w-fit rounded-2xl bg-fd-muted/50">
-          <Segment active={face === 0} onClick={() => select(0)}>
-            Expressive
-          </Segment>
-          {right.map((s, i) => (
-            <Segment
-              key={s.label}
-              active={face === 1 && tab === i}
-              onClick={() => select(i + 1)}>
-              {s.label}
-            </Segment>
-          ))}
+        <div className="mb-3 [--tab-scroll-bg:color-mix(in_oklab,var(--color-fd-muted)_50%,transparent)]">
+          <div className="relative w-fit max-w-full">
+            <div
+              ref={tabScroller}
+              className="flex w-fit max-w-full gap-[0.25em] overflow-x-auto rounded-[999px] bg-(--tab-scroll-bg) p-[0.25em] text-base [scrollbar-width:none] sm:text-sm [&::-webkit-scrollbar]:hidden">
+              <Segment active={face === 0} onClick={() => select(0)}>
+                Expressive
+              </Segment>
+              {right.map((s, i) => (
+                <Segment
+                  key={s.label}
+                  active={face === 1 && tab === i}
+                  onClick={() => select(i + 1)}>
+                  {s.label}
+                </Segment>
+              ))}
+            </div>
+
+            <ScrollOverflowControls
+              canScrollLeft={canScrollTabsLeft}
+              canScrollRight={canScrollTabsRight}
+              leftLabel="Scroll comparison tabs left"
+              rightLabel="Scroll comparison tabs right"
+              onScrollLeft={() => scrollTabs(-1)}
+              onScrollRight={() => scrollTabs(1)}
+            />
+          </div>
         </div>
 
         <div className="compare-static relative">
@@ -131,7 +202,7 @@ function Segment({
   return (
     <button
       onClick={onClick}
-      className={`rounded-full text-sm font-medium py-1 px-3 transition-colors ${
+      className={`shrink-0 whitespace-nowrap rounded-[999px] px-[1em] py-[0.625em] text-[inherit] leading-[1.5] font-medium transition-colors ${
         active ? 'bg-fd-background text-fd-foreground shadow-sm' : 'text-fd-muted-foreground'
       }`}>
       {children}

--- a/website/app/components/Playground.tsx
+++ b/website/app/components/Playground.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router';
 
-export default function Playground({ className = 'text-right', to }: { className?: string; to: string }) {
+export default function Playground({ className = 'mt-4 mr-2 text-right', to }: { className?: string; to: string }) {
   return (
-    <div className={`mt-4 mr-2 ${className}`}>
+    <div className={className}>
       <Link
         className="text-sm text-fd-primary/50 font-medium no-underline hover:text-fd-primary"
         to={to}>

--- a/website/app/components/Playground.tsx
+++ b/website/app/components/Playground.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router';
 
-export default function Playground({ to }: { to: string }) {
+export default function Playground({ className = 'text-right', to }: { className?: string; to: string }) {
   return (
-    <div className="mt-4 mr-2 text-right">
+    <div className={`mt-4 mr-2 ${className}`}>
       <Link
         className="text-sm text-fd-primary/50 font-medium no-underline hover:text-fd-primary"
         to={to}>

--- a/website/app/components/ScrollOverflowControls.tsx
+++ b/website/app/components/ScrollOverflowControls.tsx
@@ -1,0 +1,57 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface ScrollOverflowControlsProps {
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+  leftLabel: string;
+  rightLabel: string;
+  onScrollLeft: () => void;
+  onScrollRight: () => void;
+  hideAt?: string;
+}
+
+export default function ScrollOverflowControls({
+  canScrollLeft,
+  canScrollRight,
+  leftLabel,
+  rightLabel,
+  onScrollLeft,
+  onScrollRight,
+  hideAt = '',
+}: ScrollOverflowControlsProps) {
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute inset-y-0 left-0 w-[6em] rounded-l-[999px] bg-[linear-gradient(to_right,var(--tab-scroll-bg)_0%,color-mix(in_oklab,var(--tab-scroll-bg)_96%,transparent)_24%,color-mix(in_oklab,var(--tab-scroll-bg)_64%,transparent)_58%,transparent)] transition-opacity duration-200 ${hideAt} ${
+          canScrollLeft ? 'opacity-100' : 'opacity-0'
+        }`}>
+      </div>
+      <button
+        type="button"
+        aria-label={leftLabel}
+        tabIndex={canScrollLeft ? 0 : -1}
+        onClick={onScrollLeft}
+        className={`absolute left-[0.25em] top-1/2 flex size-[1.75em] -translate-y-1/2 items-center justify-center rounded-full bg-(--tab-scroll-bg) text-fd-foreground transition-[opacity,background-color,box-shadow] duration-200 hover:bg-fd-background/80 hover:shadow-sm focus-visible:bg-fd-background/80 focus-visible:shadow-sm ${hideAt} ${
+          canScrollLeft ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}>
+        <ChevronLeft className="size-[1em]" />
+      </button>
+
+      <div
+        className={`pointer-events-none absolute inset-y-0 right-0 w-[6em] rounded-r-[999px] bg-[linear-gradient(to_left,var(--tab-scroll-bg)_0%,color-mix(in_oklab,var(--tab-scroll-bg)_96%,transparent)_24%,color-mix(in_oklab,var(--tab-scroll-bg)_64%,transparent)_58%,transparent)] transition-opacity duration-200 ${hideAt} ${
+          canScrollRight ? 'opacity-100' : 'opacity-0'
+        }`}>
+      </div>
+      <button
+        type="button"
+        aria-label={rightLabel}
+        tabIndex={canScrollRight ? 0 : -1}
+        onClick={onScrollRight}
+        className={`absolute right-[0.25em] top-1/2 flex size-[1.75em] -translate-y-1/2 items-center justify-center rounded-full bg-(--tab-scroll-bg) text-fd-foreground transition-[opacity,background-color,box-shadow] duration-200 hover:bg-fd-background/80 hover:shadow-sm focus-visible:bg-fd-background/80 focus-visible:shadow-sm ${hideAt} ${
+          canScrollRight ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}>
+        <ChevronRight className="size-[1em]" />
+      </button>
+    </>
+  );
+}

--- a/website/app/routes/home/Background.tsx
+++ b/website/app/routes/home/Background.tsx
@@ -8,7 +8,7 @@ const MOBILE_LINE_OPACITY = 0.25;
 export function Background() {
   return (
     <div className="fixed h-screen w-screen -z-1">
-      <AnimateBG className="absolute top-0 left-0 sm:blur-xs" />
+      <AnimateBG className="absolute top-0 left-0 blur-xs" />
     </div>
   );
 }
@@ -27,8 +27,8 @@ export class AnimateBG extends Canvas2D {
   maxLineLength = 150;
   minLineLength = 140;
 
-  // Wind down after ~45s so an idle tab stops burning frames.
-  decayAfter = 45 * 60;
+  // Wind down after ~5m so an idle tab stops burning frames.
+  decayAfter = 5 * 60 * 60;
   frames = 0;
   damper = 1;
   stopped = false;

--- a/website/app/routes/home/Benefits.tsx
+++ b/website/app/routes/home/Benefits.tsx
@@ -3,8 +3,8 @@ import Reveal from '@/components/Reveal';
 
 export function Benefits() {
   return (
-    <section id="benefits" className="panel">
-      <div className="mx-auto max-w-(--content-width) py-16 md:py-24 px-6">
+    <section id="benefits" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mb-16">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
             The rest comes along for free.

--- a/website/app/routes/home/Benefits.tsx
+++ b/website/app/routes/home/Benefits.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import Reveal from '@/components/Reveal';
 
 export function Benefits() {
   return (
@@ -14,20 +15,20 @@ export function Benefits() {
           </p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <Benefit title="Coexists with hooks">
+          <Benefit title="Coexists with hooks" delay={0}>
             No big-bang rewrite. Adopt it one feature at a time and leave simple
             useState calls alone. A tool for complexity, not a replacement.
           </Benefit>
-          <Benefit title="Async is built in">
+          <Benefit title="Async is built in" delay={100}>
             Async factories integrate with Suspense - required data suspends
             until it resolves. No query library, no middleware, no thunks.
           </Benefit>
-          <Benefit title="Headless by design">
+          <Benefit title="Headless by design" delay={200}>
             State classes are plain objects - create with .new(), call methods,
             assert on properties. Whole app unit-testable with just expect.
             No @testing-library, no act(), no DOM.
           </Benefit>
-          <Benefit title="Self-documenting">
+          <Benefit title="Self-documenting" delay={300}>
             Fields, types, and JSDoc live on the class, so editors surface intent
             inline. Reusable state your team - and its tools - can reason about
             without digging.
@@ -41,13 +42,16 @@ export function Benefits() {
 interface BenefitProps {
   title: string;
   children: React.ReactNode;
+  delay: number;
 }
 
-function Benefit({ title, children }: BenefitProps) {
+function Benefit({ title, children, delay }: BenefitProps) {
   return (
-    <div className="before:content-[''] before:block before:h-[3px] before:w-full before:rounded-full before:bg-fd-muted-foreground/10 before:mb-4">
+    <Reveal
+      delay={delay}
+      className="before:content-[''] before:block before:h-[3px] before:w-full before:rounded-full before:bg-fd-muted-foreground/10 before:mb-4">
       <h3 className="text-lg font-semibold mb-2">{title}</h3>
       <p className="text-fd-muted-foreground leading-relaxed">{children}</p>
-    </div>
+    </Reveal>
   );
 }

--- a/website/app/routes/home/CTA.tsx
+++ b/website/app/routes/home/CTA.tsx
@@ -6,8 +6,8 @@ export function CTA() {
     'inline-flex items-center justify-center rounded-full font-medium py-3 px-6 no-underline transition-[opacity,background-color] duration-200';
 
   return (
-    <section id="cta" className="panel">
-      <div className="mx-auto max-w-2xl py-16 md:py-24 px-6 text-center">
+    <section id="cta" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-2xl py-16 md:py-24 text-center">
         <h2 className="font-display text-2xl md:text-4xl font-bold tracking-tight mb-4">
           Move just one feature out of hooks.
         </h2>

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -34,10 +34,9 @@ export function Comparison() {
         <Playground to="/examples/essentials/counter" />
 
         <p className="text-fd-muted-foreground text-lg leading-relaxed max-w-2xl mx-auto mt-10 text-center">
-          With MVC, destructuring <em>is</em> the dependency list. Read a
-          field, subscribe to it. 
-          Nothing to declare, nothing to forget - no setters, no 
-          <code>useCallback</code>, no factory.
+          With MVC, destructuring <em>is</em> your dependency list. Just read a
+          field to subscribe to it. Nothing to declare like
+          setters,  <code>useCallback</code>, or factory.
         </p>
       </div>
     </section>

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -16,7 +16,7 @@ export function Comparison() {
           <p className="text-fd-muted-foreground text-lg">
             Say you want a reusable, component-owned <code>useFooBarBaz</code>{' '}
             that re-renders on change. Same surface everywhere - only the cost
-            of building it differs. Higher readability <small>(and fewer tokens)</small>.
+            to build it differs. Higher readability <small>(and fewer tokens)</small>.
           </p>
         </div>
 

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -4,8 +4,8 @@ import code from '@/components/Snippet';
 
 export function Comparison() {
   return (
-    <section id="comparison" className="panel">
-      <div className="mx-auto max-w-(--content-width) px-6 py-16 md:py-24">
+    <section id="comparison" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-3xl mb-12">
           <div className="text-xs uppercase tracking-widest text-fd-muted-foreground mb-3">
             For local state

--- a/website/app/routes/home/Complicated.tsx
+++ b/website/app/routes/home/Complicated.tsx
@@ -34,7 +34,7 @@ export function Complicated() {
       </div>
 
       <div className="mx-auto max-w-4xl px-6 pb-12 md:pb-20">
-        <Reveal from="right" delay={120}>
+        <Reveal from="right" delay={220}>
           <h2 className="font-display text-3xl md:text-5xl font-bold tracking-tight leading-none text-right">
             ...gotten complicated<span className="text-fd-primary">.</span>
           </h2>
@@ -42,10 +42,10 @@ export function Complicated() {
 
         <Reveal className="mt-10 md:mt-14 max-w-2xl mx-auto text-center">
           <p className="text-fd-muted-foreground text-lg leading-relaxed">
-            Every feature has a hook. They need to remember,
-            derive, refresh, and persist. Each concern becomes another hook,
-            another dependency array, another way to drift out of sync.
-            Logic that belongs together winds up scattered and hard to follow.
+            Every feature has a hook. They need to persist, derive, remember,
+            and refresh. Each concern is another hook, another dependency array,
+            another thing to drift. Logic that belongs together winds
+            up scattered and hard to follow.
           </p>
         </Reveal>
       </div>

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -7,12 +7,12 @@ export function Context() {
       <div className="mx-auto max-w-(--content-width) px-6 py-16 md:py-24">
         <div className="max-w-2xl mx-auto text-center mb-12">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
-            Your classes themselves have context.
+            Classes are their own context.
           </h2>
           <p className="text-fd-muted-foreground text-lg">
-            Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> and
-            anything below just uses <code>X.get()</code>{' '}
-            to find the nearest instance. Fully typed, zero boilerplate.
+            Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> - 
+            components inside need only <code>X.get()</code>{' '}
+            to interact with nearest instance. Fully typed, zero boilerplate.
           </p>
         </div>
 
@@ -23,11 +23,7 @@ export function Context() {
 
         <p className="text-fd-muted-foreground text-lg leading-relaxed max-w-3xl mx-auto mt-10 text-center">
           No <code>createContext&lt;T&gt;</code>, null default,
-          missing-provider guard to write and maintain.
-        </p>
-        <p className="text-fd-muted-foreground max-w-3xl mx-auto mt-4 text-center">
-          Every library needs this eventually - Zustand has you wrap a
-          store in React context yourself, Jotai's Provider scopes a whole atom
+          missing-provider guard to write and maintain. Every app needs this eventually. Jotai's Provider will wrap a whole atom
           store, MobX leaves it to you entirely.
         </p>
       </div>

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -3,8 +3,8 @@ import code from '@/components/Snippet';
 
 export function Context() {
   return (
-    <section id="context" className="panel">
-      <div className="mx-auto max-w-(--content-width) px-6 py-16 md:py-24">
+    <section id="context" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mx-auto text-center mb-12">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
             Classes are their own context.
@@ -55,4 +55,3 @@ const ExprCode = code /*tsx*/`
     </Provider>
   );
 `;
-

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -12,7 +12,7 @@ export function Context() {
           <p className="text-fd-muted-foreground text-lg">
             Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> - 
             components inside need only <code>X.get()</code>{' '}
-            to interact with nearest instance. Fully typed, zero boilerplate.
+            to interact with the nearest instance. Fully typed, zero boilerplate.
           </p>
         </div>
 
@@ -24,7 +24,7 @@ export function Context() {
         <p className="text-fd-muted-foreground text-lg leading-relaxed max-w-3xl mx-auto mt-10 text-center">
           No <code>createContext&lt;T&gt;</code>, null default,
           missing-provider guard to write and maintain. Every app needs this eventually. Jotai's Provider will wrap a whole atom
-          store, MobX leaves it to you entirely.
+          store, MobX leaves it to you.
         </p>
       </div>
     </section>

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -6,25 +6,39 @@ import code from '@/components/Snippet';
 
 export function Hero() {
   return (
-    <section id="hero" className="relative flex items-center min-h-[calc(100vh-56px)]">
+    <section id="hero" className="relative lg:flex lg:items-center lg:min-h-[calc(100vh-56px)]">
       <Aurora />
-      <div className="relative w-full mx-auto max-w-(--content-width) px-6 py-24 grid gap-12 lg:grid-cols-2 lg:items-center">
-        <div>
-          <h1 className="font-display tracking-tight mb-6">
-            <span className="block text-xl md:text-[1.4rem] font-semibold text-fd-foreground/70">
+      <div className="relative w-full mx-auto max-w-(--content-width) px-6 pt-14 pb-16 grid gap-6 sm:pt-18 sm:pb-20 lg:py-24 lg:gap-12 lg:grid-cols-2 lg:items-center">
+        <div className="min-w-0 lg:row-start-1">
+          <h1 className="font-display tracking-tight mb-10">
+            <span className="block whitespace-nowrap text-[clamp(1rem,4.7vw,1.4rem)] font-semibold leading-[1.05] text-fd-foreground/70">
               Your state shouldn't live in components
             </span>
-            <span className="block text-3xl md:text-5xl font-bold leading-[1.05] mt-4">
-              It belongs to a class of its own
+            <span className="block mt-4 text-[clamp(2.2rem,10.5vw,3rem)] font-bold leading-[0.98] sm:text-5xl lg:leading-[1.05]">
+              <span className="block">It belongs to a</span>
+              <span className="block">class of its own</span>
             </span>
           </h1>
-          <p className="text-fd-muted-foreground max-w-xl mb-8 mr-5">
+          <p className="text-fd-muted-foreground max-w-xl lg:mr-5">
             With MVC, <code>.use()</code>{' '}
-            a State instead - data, behavior, lifecycle, and updates in one
+            your State instead - data, behavior, lifecycle, and updates in one
             place. Components read what they need; class itself does the rest.
           </p>
+        </div>
 
-          <div className="flex flex-wrap gap-3 mb-8">
+        <div className="min-w-0 lg:row-span-2 lg:col-start-2">
+          <div className="hero-mobile-code code-nowrap md:hidden">
+            <MobileCounterExample />
+          </div>
+          <div className="code-nowrap hidden md:block">
+            <CounterExample />
+          </div>
+          <LiveCounter />
+          <Playground to="/examples/essentials/counter" />
+        </div>
+
+        <div className="lg:row-start-2 lg:col-start-1">
+          <div className="flex flex-wrap justify-center gap-3 mt-16 mb-8 lg:justify-start lg:mt-0">
             <Link
               className={`${btn} bg-fd-primary text-fd-primary-foreground hover:opacity-90`}
               to="/docs/getting-started">
@@ -36,23 +50,14 @@ export function Hero() {
               View Docs
             </Link>
           </div>
-
           <div className="flex flex-col gap-2 max-w-md">
             <CopyPill label="Add to your app" command="npm install @expressive/react" />
             <CopyPill label="Ask your agent" command="npx skills add gabeklein/expressive-mvc" />
           </div>
           <p className="text-sm text-fd-muted-foreground mt-4">
-            Drops into React app you already have - not a framework, no
+            Drops into React you already have - not a framework, no
             rewrite.
           </p>
-        </div>
-
-        <div className="min-w-0">
-          <div className="code-nowrap">
-            <CounterExample />
-          </div>
-          <LiveCounter />
-          <Playground to="/examples/essentials/counter" />
         </div>
       </div>
     </section>
@@ -141,6 +146,23 @@ const CounterExample = code /*tsx*/`
     increment() {
       this.count++;
     }
+  }
+
+  function App() {
+    const { count, increment } = Counter.use();
+
+    return (
+      <button onClick={increment}>
+        Clicked {count} times
+      </button>
+    );
+  }
+`;
+
+const MobileCounterExample = code /*tsx*/`
+  class Counter extends State {
+    count = 0;
+    increment() { this.count++; }
   }
 
   function App() {

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -57,7 +57,7 @@ export function Hero() {
             <CopyPill label="Add to your app" command="npm install @expressive/react" />
             <CopyPill label="Ask your agent" command="npx skills add gabeklein/expressive-mvc" />
           </div>
-          <p className="mx-auto mt-4 max-w-md text-center text-sm text-fd-muted-foreground lg:mx-0 lg:text-left">
+          <p className="mx-auto mt-4 max-w-md text-center text-sm text-fd-muted-foreground lg:mx-0">
             Drops into React you already have - not a framework, no
             rewrite.
           </p>

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -7,9 +7,9 @@ import code from '@/components/Snippet';
 
 export function Hero() {
   return (
-    <section id="hero" className="relative lg:flex lg:items-center lg:min-h-[calc(100vh-56px)]">
+    <section id="hero" className="relative px-6 lg:flex lg:items-center lg:min-h-[calc(100vh-56px)] lg:px-[50px]">
       <Aurora />
-      <div className="relative w-full mx-auto max-w-(--content-width) px-6 pt-14 pb-16 grid gap-6 sm:pt-18 sm:pb-20 lg:py-24 lg:gap-12 lg:grid-cols-2 lg:items-center">
+      <div className="relative w-full mx-auto max-w-3xl pt-14 pb-16 grid gap-6 sm:pt-18 sm:pb-20 lg:max-w-[1020px] lg:py-24 lg:gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.92fr)] lg:items-center">
         <div className="min-w-0 lg:row-start-1">
           <h1 className="font-display tracking-tight mb-6">
             <span className="block whitespace-nowrap text-[clamp(1rem,4.7vw,1.4rem)] font-semibold leading-[1.05] text-fd-foreground/70">
@@ -53,11 +53,11 @@ export function Hero() {
               View Docs
             </Link>
           </div>
-          <div className="flex flex-col gap-2 max-w-md">
+          <div className="mx-auto flex max-w-md flex-col gap-2 lg:mx-0">
             <CopyPill label="Add to your app" command="npm install @expressive/react" />
             <CopyPill label="Ask your agent" command="npx skills add gabeklein/expressive-mvc" />
           </div>
-          <p className="text-sm text-fd-muted-foreground mt-4">
+          <p className="mx-auto mt-4 max-w-md text-center text-sm text-fd-muted-foreground lg:mx-0 lg:text-left">
             Drops into React you already have - not a framework, no
             rewrite.
           </p>

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -1,4 +1,5 @@
 import State, { ref } from '@expressive/react';
+import type { CSSProperties } from 'react';
 import { Link } from 'react-router';
 import CopyPill from '@/components/CopyPill';
 import Playground from '@/components/Playground';
@@ -10,7 +11,7 @@ export function Hero() {
       <Aurora />
       <div className="relative w-full mx-auto max-w-(--content-width) px-6 pt-14 pb-16 grid gap-6 sm:pt-18 sm:pb-20 lg:py-24 lg:gap-12 lg:grid-cols-2 lg:items-center">
         <div className="min-w-0 lg:row-start-1">
-          <h1 className="font-display tracking-tight mb-10">
+          <h1 className="font-display tracking-tight mb-6">
             <span className="block whitespace-nowrap text-[clamp(1rem,4.7vw,1.4rem)] font-semibold leading-[1.05] text-fd-foreground/70">
               Your state shouldn't live in components
             </span>
@@ -33,8 +34,10 @@ export function Hero() {
           <div className="code-nowrap hidden md:block">
             <CounterExample />
           </div>
-          <LiveCounter />
-          <Playground to="/examples/essentials/counter" />
+          <div className="mt-5 flex items-center justify-between gap-4">
+            <LiveCounter />
+            <Playground className="mt-0 mr-2 text-right" to="/examples/essentials/counter" />
+          </div>
         </div>
 
         <div className="lg:row-start-2 lg:col-start-1">
@@ -111,27 +114,29 @@ function Aurora() {
 
 class Counter extends State {
   count = 0;
+  hue = 260;
+  pulse = 0;
 
   increment() {
     this.count++;
+    this.hue = Math.floor(Math.random() * 360);
+    this.pulse++;
   }
 }
 
 function LiveCounter() {
-  const { count, increment } = Counter.use();
+  const { count, hue, increment, pulse } = Counter.use();
+  const style = { '--click-hue': hue } as CSSProperties;
 
   return (
-    <div className="mt-4 rounded-lg border border-fd-border py-3 px-4">
-      <div className="text-xs tracking-widest text-fd-muted-foreground mb-3">
-        LIVE - the class above, running.
-      </div>
-      <div className="flex justify-center sm:justify-start">
-        <button
-          onClick={increment}
-          className="rounded-full border border-fd-border font-mono text-sm py-1.5 px-4 hover:bg-fd-muted transition-colors">
-          Clicked {count} times
-        </button>
-      </div>
+    <div className="shrink-0">
+      <button
+        onClick={increment}
+        style={style}
+        className="live-counter-button relative rounded-full border border-fd-border bg-fd-background/70 font-mono text-sm py-2 px-5 hover:bg-fd-muted transition-colors">
+        {pulse > 0 && <span key={pulse} aria-hidden className="live-counter-pulse" />}
+        <span className="relative">Clicked {count} times</span>
+      </button>
     </div>
   );
 }

--- a/website/app/routes/home/More.tsx
+++ b/website/app/routes/home/More.tsx
@@ -2,17 +2,21 @@ import { Children, type ReactNode } from 'react';
 import { Component, get, ref } from '@expressive/react';
 import { Hash } from '@/components/Hash';
 import Playground from '@/components/Playground';
+import ScrollOverflowControls from '@/components/ScrollOverflowControls';
 import code from '@/components/Snippet';
 
 export class More extends Component {
   hash = get(Hash);
 
   tab = 0;
+  tabsStuck = false;
+  canScrollTabsLeft = false;
+  canScrollTabsRight = false;
   tabs = {
     Async,
     Computed,
-    Forms,
     Molecules,
+    Forms,
     Singletons,
     Testing,
     Instructions,
@@ -35,6 +39,101 @@ export class More extends Component {
     return hash.set('active', apply);
   });
 
+  tabBar = ref<HTMLDivElement>((el) => {
+    let frame = 0;
+
+    const update = () => {
+      frame = 0;
+      this.tabsStuck = el.getBoundingClientRect().top <= 56;
+    };
+
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+    };
+  });
+
+  tabScroller = ref<HTMLDivElement>((el) => {
+    let frame = 0;
+    const media = window.matchMedia('(max-width: 767px)');
+
+    const update = () => {
+      frame = 0;
+      const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
+      this.canScrollTabsLeft = media.matches && el.scrollLeft > 1;
+      this.canScrollTabsRight = media.matches && remaining > 1;
+    };
+
+    const schedule = () => {
+      if (!frame) frame = requestAnimationFrame(update);
+    };
+
+    update();
+    el.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule);
+    media.addEventListener('change', schedule);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      el.removeEventListener('scroll', schedule);
+      window.removeEventListener('resize', schedule);
+      media.removeEventListener('change', schedule);
+    };
+  });
+
+  content = ref<HTMLDivElement>();
+
+  select(i: number) {
+    this.tab = i;
+
+    queueMicrotask(() => {
+      const content = this.content.current;
+      const tabBar = this.tabBar.current;
+      if (!content || !tabBar) return;
+
+      const top =
+        window.scrollY +
+        content.getBoundingClientRect().top -
+        tabBar.offsetHeight -
+        96;
+
+      if (top < window.scrollY) {
+        window.scrollTo({
+          top,
+          behavior: 'smooth',
+        });
+      }
+
+      requestAnimationFrame(() => this.updateTabScrollState());
+    });
+  }
+
+  scrollTabs(direction: -1 | 1) {
+    this.tabScroller.current?.scrollBy({
+      left: direction * 160,
+      behavior: 'smooth',
+    });
+  }
+
+  updateTabScrollState() {
+    const el = this.tabScroller.current;
+    if (!el) return;
+
+    const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
+    const mobile = window.matchMedia('(max-width: 767px)').matches;
+    this.canScrollTabsLeft = mobile && el.scrollLeft > 1;
+    this.canScrollTabsRight = mobile && remaining > 1;
+  }
+
   get active() {
     return Object.values(this.tabs)[this.tab];
   }
@@ -51,26 +150,50 @@ export class More extends Component {
         <div className="mx-auto max-w-(--content-width) px-6 py-16 md:py-24">
           <div className="max-w-2xl mx-auto text-center mb-4">
             <h2 className="font-display text-2xl md:text-3xl font-bold tracking-tight">
-              That and more, built in.
+              That and more, built right in.
             </h2>
           </div>
 
-          <div className="flex flex-wrap justify-center gap-1 p-1 mb-10 w-fit mx-auto rounded-2xl bg-fd-muted/50">
-            {Object.keys(this.tabs).map((label, i) => (
-              <button
-                key={label}
-                onClick={() => (this.tab = i)}
-                className={`rounded-full text-sm font-medium py-1 px-3 transition-colors ${
-                  i === this.tab
-                    ? 'bg-fd-background text-fd-foreground shadow-sm'
-                    : 'text-fd-muted-foreground'
-                }`}>
-                {label}
-              </button>
-            ))}
+          <div
+            ref={this.tabBar}
+            className={`sticky top-14 z-20 -mx-6 mb-10 overflow-hidden px-6 py-3 transition-colors [--more-panel-bg:color-mix(in_oklab,var(--color-fd-foreground)_2%,var(--color-fd-background))] [--tab-scroll-bg:color-mix(in_oklab,var(--color-fd-muted)_50%,transparent)] md:overflow-visible ${
+              this.tabsStuck
+                ? 'bg-(--more-panel-bg)'
+                : 'bg-transparent'
+            }`}>
+            <div className="relative mx-auto w-fit max-w-full">
+              <div
+                ref={this.tabScroller}
+                className="flex w-fit max-w-full gap-[0.25em] overflow-x-auto rounded-[999px] bg-(--tab-scroll-bg) p-[0.25em] text-base [scrollbar-width:none] md:flex-wrap md:justify-center md:overflow-visible md:text-sm [&::-webkit-scrollbar]:hidden">
+                {Object.keys(this.tabs).map((label, i) => (
+                  <button
+                    key={label}
+                    onClick={() => this.select(i)}
+                    className={`shrink-0 whitespace-nowrap rounded-[999px] px-[1em] py-[0.625em] text-[inherit] leading-[1.5] font-medium transition-colors ${
+                      i === this.tab
+                        ? 'bg-fd-background text-fd-foreground shadow-sm'
+                        : 'text-fd-muted-foreground'
+                    }`}>
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              <ScrollOverflowControls
+                canScrollLeft={this.canScrollTabsLeft}
+                canScrollRight={this.canScrollTabsRight}
+                leftLabel="Scroll tabs left"
+                rightLabel="Scroll tabs right"
+                onScrollLeft={() => this.scrollTabs(-1)}
+                onScrollRight={() => this.scrollTabs(1)}
+                hideAt="md:hidden"
+              />
+            </div>
           </div>
 
-          <Active />
+          <div ref={this.content}>
+            <Active />
+          </div>
         </div>
       </section>
     );
@@ -149,9 +272,9 @@ function Async() {
   return (
     <Tab title="Async without ceremony." to="/examples/essentials/async">
       <>
-        An async <code>set()</code> suspends render until it
-        resolves. A <code>Component</code> brings its own{' '}
-        <code>fallback</code> and its own error boundary via{' '}
+        Accessing <code>set(async)</code> will thorw suspense until it
+        resolves. A <code>Component</code> can define its own{' '}
+        <code>fallback</code> and even error boundary via{' '}
         <code>catch()</code> - no{' '}
         <code>isPending</code> flags, client to provide, or
         cache keys.
@@ -162,7 +285,6 @@ function Async() {
 }
 
 const AsyncCode = code /*tsx*/`
-  import React from 'react';
   import { Component, set } from '@expressive/react';
 
   class Profile extends Component {
@@ -172,9 +294,11 @@ const AsyncCode = code /*tsx*/`
       const res = await fetch('/api/user/1');
 
       if (!res.ok)
-        throw new Error('Something broke');
+        throw new Error('Could not find the user.');
 
-      return res.json();
+      const { first, last } = await res.json();
+
+      return first + " " + last;
     });
 
     async catch(error: Error) {
@@ -182,7 +306,7 @@ const AsyncCode = code /*tsx*/`
     }
 
     render() {
-      return <h1>Hello {this.user.name}</h1>;
+      return <h1>Hello {this.user.name}!</h1>;
     }
   }
 
@@ -254,12 +378,10 @@ function Forms() {
 }
 
 const FormsCode = code /*tsx*/`
-  import React from 'react';
-  import { Form } from "@components/form"
+  import { Form } from "@/components/form"
 
-  // Form can be a ~30 line base class _you_ write once, not a
-  // dependency - built on the ref() instruction to bind inputs.
-  // Full example in the Playground.
+  // Form can be a ~30 line base class _you_ write once.
+  // Here, \`bind\` is defined with a ref instruction.
   class MyForm extends Form {
     firstname = '';
     lastname = '';
@@ -296,12 +418,12 @@ const FormsCode = code /*tsx*/`
 function Molecules() {
   return (
     <Tab
-      title="Components compose by subclass."
+      title="Components customize by subclass."
       to="/examples/composition/subcomponents">
       <>
         A base owns structure and behavior; PascalCase subcomponents are seams a
         subclass overrides for appearance. Your own behavior-complete widgets -
-        Table, Toast, Picker - without the config soup or shadcn.
+        Table, Toast, Picker - all without config soup or shadcn.
       </>
       <MoleculesCode />
     </Tab>
@@ -309,7 +431,6 @@ function Molecules() {
 }
 
 const MoleculesCode = code /*tsx*/`
-  import React from 'react';
   import { Component } from '@expressive/react';
 
   // A behavior-complete base: owns data and selection,
@@ -354,7 +475,7 @@ const MoleculesCode = code /*tsx*/`
 function Singletons() {
   return (
     <Tab
-      title="Global state, no ceremony."
+      title="Global state with no setup."
       to="/examples/composition/singletons">
       <>
         Create a State once with <code>.new()</code> and it
@@ -368,10 +489,8 @@ function Singletons() {
 }
 
 const SingletonsCode = code /*tsx*/`
-  import React from 'react';
   import State from '@expressive/react';
 
-  // One instance for the whole app.
   class Session extends State {
     user: string | null = null;
 
@@ -383,7 +502,7 @@ const SingletonsCode = code /*tsx*/`
   // Creating outside components activates and parks in global context.
   Session.new();
 
-  // Any component reaches it with .get() - no props, no Provider.
+  // Component still reach for it with .get() - no Provider needed.
   function Status() {
     const { user, login } = Session.get();
 
@@ -395,13 +514,11 @@ const SingletonsCode = code /*tsx*/`
 
 function Testing() {
   return (
-    <Tab title="Test the class, not the DOM.">
+    <Tab title="Test the workflow, not the DOM.">
       <>
-        State classes are plain objects - create with{' '}
-        <code>.new()</code>, call methods, assert on
-        properties. Whole features tested with just{' '}
-        <code>expect</code> - no{' '}
-        <code>act()</code>, no @testing-library.
+        Both state and components are plain instances - 
+        create with{' '} <code>.new()</code>, call methods, assert on properties.
+        Test whole workflows with only <code>expect</code> - no <code>act()</code> no React.
       </>
       <TestingCode />
     </Tab>
@@ -409,18 +526,25 @@ function Testing() {
 }
 
 const TestingCode = code /*tsx*/`
-  import { Counter } from './Counter';
+  import { LoginForm } from './LoginForm';
 
-  it('will update on increment', async () => {
-    const counter = Counter.new();
+  it('will show admin state after login', async () => {
+    const form = LoginForm.new();
 
-    counter.increment();
-    counter.increment();
+    form.username = 'admin@example.com';
+    form.password = 'correct-horse';
 
-    expect(counter.count).toBe(2);
-    expect(await counter.set()).toEqual(['count']);
+    const login = form.submit();
+
+    expect(form.loading).toBe(true);
+    expect(form.canSubmit).toBe(false);
+
+    await login;
+
+    expect(form.loading).toBe(false);
+    expect(form.error).toBeUndefined();
+    expect(form.user?.email).toBe('admin@example.com');
+    expect(form.isAdmin).toBe(true);
+    expect(form.avatarIcon.loaded).toBe(true);
   });
-
-  // the Counter class from the top of this page,
-  // tested as-is. No render, no DOM.
 `;

--- a/website/app/routes/home/More.tsx
+++ b/website/app/routes/home/More.tsx
@@ -514,11 +514,12 @@ const SingletonsCode = code /*tsx*/`
 
 function Testing() {
   return (
-    <Tab title="Test the workflow, not the DOM.">
+    <Tab title="Test the app, not the DOM.">
       <>
-        Both state and components are plain instances - 
+        Technically, state and components are plain instances - 
         create with{' '} <code>.new()</code>, call methods, assert on properties.
-        Test whole workflows with only <code>expect</code> - no <code>act()</code> no React.
+        Test whole workflows with only <code>expect</code> -{" "}
+        no <code>act()</code>, not even React.
       </>
       <TestingCode />
     </Tab>

--- a/website/app/routes/home/More.tsx
+++ b/website/app/routes/home/More.tsx
@@ -146,8 +146,8 @@ export class More extends Component {
     const { Active } = this;
 
     return (
-      <section ref={this.section} id="more" className="panel">
-        <div className="mx-auto max-w-(--content-width) px-6 py-16 md:py-24">
+      <section ref={this.section} id="more" className="panel px-6 lg:px-[50px]">
+        <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
           <div className="max-w-2xl mx-auto text-center mb-4">
             <h2 className="font-display text-2xl md:text-3xl font-bold tracking-tight">
               That and more, built right in.
@@ -156,7 +156,7 @@ export class More extends Component {
 
           <div
             ref={this.tabBar}
-            className={`sticky top-14 z-20 -mx-6 mb-10 overflow-hidden px-6 py-3 transition-colors [--more-panel-bg:color-mix(in_oklab,var(--color-fd-foreground)_2%,var(--color-fd-background))] [--tab-scroll-bg:color-mix(in_oklab,var(--color-fd-muted)_50%,transparent)] md:overflow-visible ${
+            className={`sticky top-14 z-20 -mx-6 mb-10 overflow-hidden px-6 py-3 transition-colors [--more-panel-bg:color-mix(in_oklab,var(--color-fd-foreground)_2%,var(--color-fd-background))] [--tab-scroll-bg:color-mix(in_oklab,var(--color-fd-muted)_50%,transparent)] md:overflow-visible lg:-mx-[50px] lg:px-[50px] ${
               this.tabsStuck
                 ? 'bg-(--more-panel-bg)'
                 : 'bg-transparent'

--- a/website/app/routes/home/Turn.tsx
+++ b/website/app/routes/home/Turn.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import Reveal from '@/components/Reveal';
 
 const SHED = [
   'swr', 'react-error-boundary', 'immer', 'use-context-selector',
@@ -18,9 +19,8 @@ export function Turn() {
             Rails for your React app.
           </h2>
           <p className="text-fd-muted-foreground text-lg md:text-xl">
-            Fields are state, methods change it, classes are context keys. A few
-            conventions replace a pile of decisions - a good feature looks the same
-            whether it came from you, a teammate, or an agent.
+            Strong conventions replace a pile of decisions - a good feature
+            looks the same whether it came from you, a teammate, or an agent.
           </p>
         </div>
 
@@ -41,30 +41,31 @@ export function Turn() {
 
         <div className="max-w-2xl mb-10">
           <h3 className="font-display text-2xl md:text-3xl font-bold tracking-tight mb-3">
-            <span className="text-fd-foreground/70">(Artificial)</span> Idiot-Proof.
+            <span className="text-fd-foreground/80">(Artificial)</span> Idiot-Proof.
           </h3>
           <p className="text-fd-muted-foreground text-lg">
             The same structure keeps the models working in your codebase on
-            task - a feature is one class an agent can load whole.
+            task - individual features and pages are classes an agent can
+            skim and load as-needed.
           </p>
         </div>
 
         <div className="grid gap-x-10 gap-y-8 md:grid-cols-2">
-          <Point title="Dense business logic">
+          <Point title="Dense business logic" delay={0}>
             State, derived value, async methods, and lifecycle live together.
             Composition helps separate concerns into readable chunks.
           </Point>
-          <Point title="Fewer imports, less lock-in">
+          <Point title="Fewer imports, less surface area." delay={100}>
             Reach for the class before another hook, provider, or client
-            library. Less surface area for people and your agents to know about.
+            library. Removes bloat for people and your agents to know about.
           </Point>
-          <Point title="Less to trace when things break">
+          <Point title="Less to trace when things break" delay={200}>
             No dependency arrays, stale closures, or complicated interactions.
             A fix starts at the class, not a hunt through wiring.
           </Point>
-          <Point title="Class instances are just objects">
+          <Point title="Class instances are just objects" delay={300}>
             The instance is the source of truth. Log it, assert on it, or bind
-            it to <code>window</code> and inspect it directly.
+            it to <code>window</code> to inspect directly.
           </Point>
         </div>
       </div>
@@ -72,11 +73,21 @@ export function Turn() {
   );
 }
 
-function Point({ title, children }: { title: string; children: React.ReactNode }) {
+function Point({
+  title,
+  children,
+  delay,
+}: {
+  title: string;
+  children: React.ReactNode;
+  delay: number;
+}) {
   return (
-    <div className="before:content-[''] before:block before:h-[3px] before:w-full before:rounded-full before:bg-fd-primary/10 before:mb-4">
+    <Reveal
+      delay={delay}
+      className="before:content-[''] before:block before:h-[3px] before:w-full before:rounded-full before:bg-fd-primary/10 before:mb-4">
       <h3 className="font-semibold mb-2">{title}</h3>
       <p className="text-fd-muted-foreground leading-relaxed">{children}</p>
-    </div>
+    </Reveal>
   );
 }

--- a/website/app/routes/home/Turn.tsx
+++ b/website/app/routes/home/Turn.tsx
@@ -19,8 +19,8 @@ export function Turn() {
             Rails for your React app.
           </h2>
           <p className="text-fd-muted-foreground text-lg md:text-xl">
-            Strong conventions replace a pile of decisions - a good feature
-            looks the same whether it came from you, a teammate, or an agent.
+            Strong conventions replace a pile of opinions - a good feature
+            looks the same whether it came from you, your team, or an agent.
           </p>
         </div>
 

--- a/website/app/routes/home/Turn.tsx
+++ b/website/app/routes/home/Turn.tsx
@@ -9,8 +9,8 @@ const SHED = [
 
 export function Turn() {
   return (
-    <section id="rails" className="panel">
-      <div className="mx-auto max-w-(--content-width) py-16 md:py-24 px-6">
+    <section id="rails" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mb-12">
           <div className="text-xs uppercase tracking-widest text-fd-primary mb-3">
             Batteries (and charger) included.
@@ -45,7 +45,7 @@ export function Turn() {
           </h3>
           <p className="text-fd-muted-foreground text-lg">
             The same structure keeps the models working in your codebase on
-            task - individual features and pages are classes an agent can
+            task - individual features and pages modularize for an agent to
             skim and load as-needed.
           </p>
         </div>

--- a/website/app/routes/home/View.tsx
+++ b/website/app/routes/home/View.tsx
@@ -4,8 +4,8 @@ import code from '@/components/Snippet';
 
 export function View() {
   return (
-    <section id="component" className="panel">
-      <div className="mx-auto max-w-(--content-width) py-16 md:py-24 px-6 grid gap-12 lg:grid-cols-[2fr_3fr] lg:items-center">
+    <section id="component" className="panel px-6 lg:px-[50px]">
+      <div className="mx-auto max-w-(--content-width) py-16 md:py-24 grid gap-12 lg:grid-cols-[2fr_3fr] lg:items-center">
         <div>
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
             Component is renderable State.

--- a/website/app/routes/home/View.tsx
+++ b/website/app/routes/home/View.tsx
@@ -8,17 +8,17 @@ export function View() {
       <div className="mx-auto max-w-(--content-width) py-16 md:py-24 px-6 grid gap-12 lg:grid-cols-[2fr_3fr] lg:items-center">
         <div>
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
-            Component is state that renders itself.
+            Component is renderable State.
           </h2>
           <p className="text-fd-muted-foreground text-lg mb-4">
             Reach for <code>Component</code> when making self-contained{" "}
             (<a href="#molecules" className="underline-offset-2 underline">or extensible</a>) display logic.
             Fields drive lazy getters and <code>render()</code>{' '} directly -
-            destructure <code>this</code>, assign for events.
+            destructure <code>this</code> as you would use hook.
           </p>
           <p className="text-fd-muted-foreground text-lg">
             A Component is also its own Provider.
-            Children access from context with zero prop drilling.
+            Children can pull from it with zero prop drilling.
           </p>
         </div>
 
@@ -52,14 +52,16 @@ class TipCalculator extends Component {
     return (
       <div className="mt-4 rounded-lg border border-fd-border py-3 px-4">
         <div className="text-xs tracking-widest text-fd-muted-foreground mb-3">
-          LIVE - Code above is whole component, ready to use.
+          LIVE - Code above is whole component
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <label className="flex items-center gap-2 font-mono text-sm">
             $
             <input
               type="number"
-              className="w-16 rounded border border-fd-border bg-transparent py-1 px-2"
+              inputMode="decimal"
+              min={0}
+              className="w-16 rounded border border-fd-border bg-transparent py-1 px-2 text-base sm:text-sm"
               value={bill}
               onChange={(e) => (this.bill = +e.target.value)}
             />

--- a/website/app/routes/home/View.tsx
+++ b/website/app/routes/home/View.tsx
@@ -51,9 +51,6 @@ class TipCalculator extends Component {
 
     return (
       <div className="mt-4 rounded-lg border border-fd-border py-3 px-4">
-        <div className="text-xs tracking-widest text-fd-muted-foreground mb-3">
-          LIVE - Code above is whole component
-        </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
           <label className="flex items-center gap-2 font-mono text-sm">
             $
@@ -63,6 +60,7 @@ class TipCalculator extends Component {
               min={0}
               className="w-16 rounded border border-fd-border bg-transparent py-1 px-2 text-base sm:text-sm"
               value={bill}
+              onFocus={(e) => e.currentTarget.select()}
               onChange={(e) => (this.bill = +e.target.value)}
             />
           </label>
@@ -112,9 +110,12 @@ const TipExample = code /*tsx*/`
       return (
         <div>
           <input type="number" value={bill}
-            onChange={(e) => (this.bill = +e.target.value)} />
+            onFocus={(e) => e.currentTarget.select()}
+            onChange={(e) => (this.bill = +e.target.value)}
+          />
           <input type="range" min={0} max={30} value={tipPercent}
-            onChange={(e) => (this.tipPercent = +e.target.value)} />
+            onChange={(e) => (this.tipPercent = +e.target.value)}
+          />
           <p>
             Tip {tip.toFixed(2)} · Total {total.toFixed(2)}
           </p>

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -8,6 +8,9 @@ import { resolve, join } from 'path';
 import { cp, readFile } from 'fs/promises';
 
 export default defineConfig({
+  server: {
+    allowedHosts: ['trainer-fairy-highest-appropriate.trycloudflare.com'],
+  },
   resolve: {
     alias: {
       '@examples': resolve(__dirname, '../examples')

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,7 +9,7 @@ import { cp, readFile } from 'fs/promises';
 
 export default defineConfig({
   server: {
-    allowedHosts: ['trainer-fairy-highest-appropriate.trycloudflare.com'],
+    allowedHosts: ['.trycloudflare.com'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Follow-up polish pass on the redesigned homepage (#223):

- Reveal animations for homepage cards and improved tab navigation in the More section
- Hero layout polish: live counter refinement, copy tightening, panel gutter alignment
- Tip example input focus behavior improved
- Dev-only: allow a cloudflare tunnel host in the website vite config

No package code changes; website only, so no changeset.