### PR TITLE
Clarify nested State.use subscriptions

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -133,6 +133,16 @@ function Child() {
 
 Use `use(subject)` for externally-owned observables or State instances. It returns a tracking proxy on the initial render, re-subscribes when `subject` is replaced, activates an unready observable, and does not destroy the subject on unmount.
 
+Always prefer destructuring `State.use()` / `State.get()`. If the raw instance is needed, destructure and alias `is` (`is: counter`). Nested observable reads are proxied and tracked automatically, so nested destructuring subscribes to child State fields; do not call `use(child)` when the child was reached through the parent proxy.
+
+```tsx
+const {
+  comment: {
+    value: comment,
+  },
+} = Counter.use();
+```
+
 ### Component Class
 
 A `Component` is a `State` that renders itself. It provides context automatically and supports suspense/error boundaries.

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -75,8 +75,7 @@ class Counter extends State {
 }
 
 function App() {
-  // methods bound automatically, always prefer destructure
-  const { increment, count } = Counter.use();
+  const { count, increment } = Counter.use();
   return <button onClick={increment}>{count}</button>;
 }
 ```
@@ -85,6 +84,17 @@ function App() {
 - Component re-renders when any accessed property changes.
 - Instance is destroyed on unmount (context is popped, `set(null)` called).
 - Safe in React strict mode (handles double-mount correctly).
+- Always prefer destructuring `State.use()` / `State.get()`.
+- When the raw instance is needed, destructure `is` and alias it to the state concept (`is: counter`, `is: form`).
+- Nested observable reads are proxied and tracked automatically. Nested destructuring subscribes to child State fields; do not call `use(child)` when the child was reached through the parent proxy.
+
+```tsx
+const {
+  comment: {
+    value: comment,
+  },
+} = Counter.use();
+```
 
 ### Constructor arguments
 


### PR DESCRIPTION
## Summary

- recommend destructuring State.use and State.get results
- document the is alias for raw instance access
- clarify that nested child State reads remain subscribed without another use call

## Validation

- git diff --check