### PR TITLE
Improve homepage messaging and interactive demos

### DIFF
--- a/website/app/app.css
+++ b/website/app/app.css
@@ -113,7 +113,7 @@ figure[data-rehype-pretty-code-figure] pre code,
   animation: live-counter-pulse 420ms ease-out forwards;
 }
 
-:is([class*='hero-trace-'], [class*='tip-trace-']) {
+:is([class*='hero-trace-'], [class*='tip-trace-'], [class*='context-trace-']) {
   display: inline-block;
   padding: 2px 5px;
   margin: -2px -5px;
@@ -315,6 +315,7 @@ figure[data-rehype-pretty-code-figure] pre code,
   .marquee-track,
   .aurora,
   [class*='hero-trace-'],
+  [class*='context-trace-'],
   [class*='tip-trace-'],
   .trace-pulse,
   .live-counter-pulse {

--- a/website/app/components/Compare.tsx
+++ b/website/app/components/Compare.tsx
@@ -3,7 +3,7 @@ import State, { ref } from '@expressive/react';
 import ScrollOverflowControls from './ScrollOverflowControls';
 import code from './Snippet';
 
-type Snippet = ReturnType<typeof code>;
+type Snippet = ReturnType<typeof code> | (() => React.ReactElement);
 
 interface Side {
   label: string;
@@ -123,11 +123,11 @@ export default function Compare({ left, right }: CompareProps) {
               Expressive
             </span>
           </Head>
-          <Left {...LN} />
+          <CodePanel snippet={Left} />
         </div>
         <div>
           <Head>{libTabs}</Head>
-          <Right {...LN} />
+          <CodePanel snippet={Right} />
         </div>
       </div>
 
@@ -162,9 +162,24 @@ export default function Compare({ left, right }: CompareProps) {
         </div>
 
         <div className="compare-static">
-          {face ? <Right {...LN} /> : <Left {...LN} />}
+          <CodePanel snippet={face ? Right : Left} />
         </div>
       </div>
+    </div>
+  );
+}
+
+function CodePanel({ snippet: Snippet }: { snippet: Snippet }) {
+  const tokenCount = 'tokenCount' in Snippet ? Snippet.tokenCount : undefined;
+
+  return (
+    <div className="relative">
+      <Snippet {...LN} />
+      {tokenCount !== undefined && (
+        <span className="pointer-events-none absolute right-3 bottom-3 rounded bg-fd-card/90 px-1.5 py-0.5 font-mono text-[10px] text-fd-muted-foreground shadow-sm">
+          ~{tokenCount} tokens
+        </span>
+      )}
     </div>
   );
 }

--- a/website/app/components/Snippet.tsx
+++ b/website/app/components/Snippet.tsx
@@ -6,7 +6,7 @@ type SnippetProps = Partial<Omit<DynamicCodeblockProps, 'code'>> & {
 
 export default function code(strings: TemplateStringsArray, ...values: unknown[]) {
   const code = dedent(String.raw({ raw: strings }, ...values));
-  return ({ highlight, ...props }: SnippetProps = {}) => {
+  const Snippet = ({ highlight, ...props }: SnippetProps = {}) => {
     const decorations = highlight && Object.entries(highlight.targets).flatMap(([name, pattern]) => {
       for (const [line, source] of code.split('\n').entries()) {
         pattern.lastIndex = 0;
@@ -37,6 +37,8 @@ export default function code(strings: TemplateStringsArray, ...values: unknown[]
       />
     );
   };
+
+  return Object.assign(Snippet, { tokenCount: Math.round(code.length / 4) });
 }
 
 function dedent(s: string) {

--- a/website/app/routes/home/Background.tsx
+++ b/website/app/routes/home/Background.tsx
@@ -4,6 +4,10 @@ const PARTICLE_DENSITY = 100 / (1440 * 900);
 const MOBILE_MAX_WIDTH = 640;
 const MOBILE_PARTICLE_OPACITY = 0.4;
 const MOBILE_LINE_OPACITY = 0.25;
+const LIGHT_PARTICLE_OPACITY = 0.55;
+const LIGHT_LINE_OPACITY = 0.45;
+const LIGHT_MOBILE_PARTICLE_OPACITY = 0.25;
+const LIGHT_MOBILE_LINE_OPACITY = 0.15;
 
 export function Background() {
   return (
@@ -48,13 +52,23 @@ export class AnimateBG extends Canvas2D {
     this.particleColor =
       getComputedStyle(parent).getPropertyValue('--accent') || '#bbb';
 
+    const updateOpacity = () => {
+      const mobile = this.width <= MOBILE_MAX_WIDTH;
+      const dark = document.documentElement.classList.contains('dark');
+      this.particleOpacity = dark
+        ? mobile ? MOBILE_PARTICLE_OPACITY : 1
+        : mobile ? LIGHT_MOBILE_PARTICLE_OPACITY : LIGHT_PARTICLE_OPACITY;
+      this.lineOpacity = dark
+        ? mobile ? MOBILE_LINE_OPACITY : 1
+        : mobile ? LIGHT_MOBILE_LINE_OPACITY : LIGHT_LINE_OPACITY;
+      if (this.stopped) this.paint(false);
+    };
+
     const onResize = () => {
       const rect = parent.getBoundingClientRect();
       element.width = this.width = rect.width;
       element.height = this.height = rect.height;
-      const mobile = this.width <= MOBILE_MAX_WIDTH;
-      this.particleOpacity = mobile ? MOBILE_PARTICLE_OPACITY : 1;
-      this.lineOpacity = mobile ? MOBILE_LINE_OPACITY : 1;
+      updateOpacity();
       this.particleCount = Math.min(
         100,
         Math.max(16, Math.round(this.width * this.height * PARTICLE_DENSITY)),
@@ -67,9 +81,25 @@ export class AnimateBG extends Canvas2D {
       this.active = !this.stopped && !document.hidden && document.hasFocus();
     };
 
+    const onInteraction = () => {
+      this.frames = 0;
+      this.damper = 1;
+      this.stopped = false;
+      this.active = !document.hidden && document.hasFocus();
+    };
+
+    const themeObserver = new MutationObserver(updateOpacity);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
     window.addEventListener('resize', onResize);
     window.addEventListener('blur', onVisibility);
     window.addEventListener('focus', onVisibility);
+    window.addEventListener('scroll', onInteraction, { passive: true });
+    window.addEventListener('pointerdown', onInteraction, { passive: true });
+    window.addEventListener('keydown', onInteraction);
     document.addEventListener('visibilitychange', onVisibility);
     onResize();
 
@@ -86,7 +116,11 @@ export class AnimateBG extends Canvas2D {
       window.removeEventListener('resize', onResize);
       window.removeEventListener('blur', onVisibility);
       window.removeEventListener('focus', onVisibility);
+      window.removeEventListener('scroll', onInteraction);
+      window.removeEventListener('pointerdown', onInteraction);
+      window.removeEventListener('keydown', onInteraction);
       document.removeEventListener('visibilitychange', onVisibility);
+      themeObserver.disconnect();
     };
   }
 

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -15,8 +15,8 @@ export function Comparison() {
           </h2>
           <p className="text-fd-muted-foreground text-lg">
             Say you want a reusable, component-owned <code>useFooBarBaz</code>{' '}
-            that re-renders on change. Same surface everywhere - only the cost
-            to build it differs. Higher readability <small>(and fewer tokens)</small>.
+            that re-renders on change. Examples have same state and
+            behavior. Expressive gets there with less code.
           </p>
         </div>
 

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -35,8 +35,7 @@ export function Comparison() {
 
         <p className="text-fd-muted-foreground text-lg leading-relaxed max-w-2xl mx-auto mt-10 text-center">
           With MVC, destructuring <em>is</em> your dependency list. Just read a
-          field to subscribe to it. Nothing to declare like
-          setters,  <code>useCallback</code>, or factory.
+          field to subscribe to it. No setters, dependency arrays, or memoized callbacks.
         </p>
       </div>
     </section>

--- a/website/app/routes/home/Complicated.tsx
+++ b/website/app/routes/home/Complicated.tsx
@@ -37,7 +37,7 @@ export function Complicated() {
         <Reveal className="max-w-2xl mx-auto text-center">
           <p className="text-fd-muted-foreground text-lg leading-relaxed">
             Hooks accumulate with features. Their logic stays tied to React.
-            Wiring them makes components larger, tightly coupled, and hard to trace.
+            Wiring them makes components larger, tightly coupled, and difficult to trace.
           </p>
         </Reveal>
       </div>

--- a/website/app/routes/home/Complicated.tsx
+++ b/website/app/routes/home/Complicated.tsx
@@ -37,7 +37,7 @@ export function Complicated() {
         <Reveal className="max-w-2xl mx-auto text-center">
           <p className="text-fd-muted-foreground text-lg leading-relaxed">
             Hooks accumulate with features. Their logic stays tied to React.
-            Wiring them makes components larger, tightly coupled, and harder to trace.
+            Wiring them makes components larger, tightly coupled, and hard to trace.
           </p>
         </Reveal>
       </div>

--- a/website/app/routes/home/Component.tsx
+++ b/website/app/routes/home/Component.tsx
@@ -11,14 +11,14 @@ export function ComponentSection() {
             Component is renderable State.
           </h2>
           <p className="text-fd-muted-foreground text-lg mb-4">
-            Reach for <code>Component</code> when making self-contained{" "}
+            <code>Component</code> is for self-contained{" "}
             (<a href="#molecules" className="underline-offset-2 underline">or extensible</a>) display logic.
-            Fields drive lazy getters and <code>render()</code>{' '} directly -
+            Fields drive getters and <code>render()</code>{' '} directly -
             destructure <code>this</code> as you would use hook.
           </p>
           <p className="text-fd-muted-foreground text-lg">
-            A Component is its own Provider too,
-            accessible to children with no prop drilling.
+            A Component provides itself too,
+            accessible to children without prop drilling.
           </p>
         </div>
 

--- a/website/app/routes/home/Component.tsx
+++ b/website/app/routes/home/Component.tsx
@@ -17,8 +17,8 @@ export function ComponentSection() {
             destructure <code>this</code> as you would use hook.
           </p>
           <p className="text-fd-muted-foreground text-lg">
-            A Component is its own Provider too.
-            Children can pull from it with zero prop drilling.
+            A Component is its own Provider too,
+            accessible to children with no prop drilling.
           </p>
         </div>
 

--- a/website/app/routes/home/Component.tsx
+++ b/website/app/routes/home/Component.tsx
@@ -133,7 +133,7 @@ class TipCalculator extends StateComponent {
     if (field === 'tipPercent') {
       this.demo.trace.hold('tipPercent-input', 'tipPercent-field');
     }
-    this.demo.trace.play(field);
+    this.demo.trace.play(field, field === 'tipPercent' ? 2500 : undefined);
   }
 
   settle(field: TipField) {

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -16,7 +16,7 @@ export function Context() {
           <p className="text-fd-muted-foreground text-lg">
             Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> - 
             components inside need only <code>X.get()</code>{' '}
-            to interact with the nearest instance. Fully typed, zero ceremony.
+            to interact with the nearest instance. Fully typed, zero boilerplate.
           </p>
         </div>
 

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -1,6 +1,5 @@
-import State, { Component, get, ref, use } from '@expressive/react';
+import State, { Component, get, ref, set } from '@expressive/react';
 import { Moon, Sun } from 'lucide-react';
-import { useEffect } from 'react';
 import { useTheme } from 'next-themes';
 import Playground from '@/components/Playground';
 import code from '@/components/Snippet';
@@ -11,7 +10,7 @@ export function Context() {
       <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mx-auto text-center mb-12">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
-            Classes have context.
+            Classes are their own context.
           </h2>
           <p className="text-fd-muted-foreground text-lg">
             Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> - 
@@ -56,13 +55,14 @@ class ThemeTrace extends State {
     };
   }
 
-  async play() {
+  async play(includeToggle = true) {
     const run = ++this.run.current;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
     for (const [delay, step] of themeTimeline) {
       if (delay) await wait(delay);
       if (run !== this.run.current) return;
+      if (!includeToggle && (step === 'handler' || step === 'assignment')) continue;
       if (step) this.pulse(step);
     }
   }
@@ -101,42 +101,54 @@ class ThemeDemo extends Component {
 class ThemeControl extends Component {
   demo = get(ThemeDemo);
 
-  toggle(setTheme: (mode: Mode) => void) {
+  previousTheme?: Mode;
+  toggledTheme?: Mode;
+
+  resolvedTheme = set<Mode>(undefined, theme => {
+    if (!theme) return;
+    const toggled = this.toggledTheme === theme;
+    this.toggledTheme = undefined;
+    this.demo.mode = theme;
+    if (!toggled && this.previousTheme && this.previousTheme !== theme) {
+      this.demo.trace.play(false);
+    }
+    this.previousTheme = theme;
+  });
+
+  setTheme = set<(mode: Mode) => void>();
+
+  toggle() {
     const mode = this.demo.mode === 'light' ? 'dark' : 'light';
-    setTheme(mode);
+    this.toggledTheme = mode;
     this.demo.mode = mode;
     this.demo.trace.play();
+    this.setTheme(mode);
   }
 
   render() {
-    return <ThemeButton control={this} />;
-  }
-}
+    const { setTheme, resolvedTheme } = useTheme();
+    const { demo: { mode }, toggle } = this;
 
-function ThemeButton({ control }: { control: ThemeControl }) {
-  const { resolvedTheme, setTheme } = useTheme();
-  const { demo: { mode }, toggle } = use(control);
-
-  useEffect(() => {
     if (resolvedTheme === 'light' || resolvedTheme === 'dark') {
-      control.demo.mode = resolvedTheme;
+      if (this.previousTheme !== resolvedTheme) this.resolvedTheme = resolvedTheme;
+      this.setTheme = setTheme;
     }
-  }, [control, resolvedTheme]);
 
-  const Icon = mode === 'light' ? Sun : Moon;
+    const Icon = mode === 'light' ? Sun : Moon;
 
-  return (
-    <div className="theme-demo-control flex flex-col items-center justify-center justify-self-center rounded-xl p-2">
-      <button
-        type="button"
-        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
-        onClick={() => toggle(setTheme)}
-        className="flex size-16 cursor-pointer items-center justify-center rounded-full border border-fd-border bg-fd-background shadow-sm transition-colors hover:bg-fd-muted">
-        <Icon aria-hidden className="size-7" />
-      </button>
-      <span className="mt-2 font-mono text-sm text-fd-muted-foreground">{mode} mode</span>
-    </div>
-  );
+    return (
+      <div className="theme-demo-control flex flex-col items-center justify-center justify-self-center rounded-xl p-2">
+        <button
+          type="button"
+          aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
+          onClick={toggle}
+          className="flex size-16 cursor-pointer items-center justify-center rounded-full border border-fd-border bg-fd-background shadow-sm transition-colors hover:bg-fd-muted">
+          <Icon aria-hidden className="size-7" />
+        </button>
+        <span className="mt-2 font-mono text-sm text-fd-muted-foreground">{mode} mode</span>
+      </div>
+    );
+  }
 }
 
 function ExprCode({ mode }: { mode: Mode }) {

--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -1,3 +1,7 @@
+import State, { Component, get, ref, use } from '@expressive/react';
+import { Moon, Sun } from 'lucide-react';
+import { useEffect } from 'react';
+import { useTheme } from 'next-themes';
 import Playground from '@/components/Playground';
 import code from '@/components/Snippet';
 
@@ -7,7 +11,7 @@ export function Context() {
       <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mx-auto text-center mb-12">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
-            Classes are their own context.
+            Classes have context.
           </h2>
           <p className="text-fd-muted-foreground text-lg">
             Wrap a subtree in <code>&lt;Provider for=&#123;X&#125;&gt;</code> - 
@@ -16,10 +20,7 @@ export function Context() {
           </p>
         </div>
 
-        <div className="code-nowrap max-w-3xl mx-auto">
-          <ExprCode />
-          <Playground to="/examples/composition/context" />
-        </div>
+        <ThemeDemo />
 
         <p className="text-fd-muted-foreground text-lg leading-relaxed max-w-3xl mx-auto mt-10 text-center">
           No <code>createContext&lt;T&gt;</code>, null default,
@@ -31,27 +32,149 @@ export function Context() {
   );
 }
 
-const ExprCode = code /*tsx*/`
-  import React from 'react';
-  import State, { Provider } from '@expressive/react';
+type Mode = 'light' | 'dark';
+type ThemeStep = 'handler' | 'assignment' | 'field' | 'destructure' | 'jsx';
 
-  class Theme extends State {
-    mode = 'light';
+const themeTimeline = [
+  [0, 'handler'],
+  [70, 'assignment'],
+  [14, 'field'],
+  [48, 'destructure'],
+  [48, 'jsx'],
+  [50],
+] as const;
 
-    toggle() {
-      this.mode = this.mode === 'light' ? 'dark' : 'light';
+const wait = (ms: number) => new Promise(resolve => window.setTimeout(resolve, ms));
+
+class ThemeTrace extends State {
+  root = ref<HTMLDivElement>();
+  private run = { current: 0 };
+
+  protected new() {
+    return () => {
+      this.run.current++;
+    };
+  }
+
+  async play() {
+    const run = ++this.run.current;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    for (const [delay, step] of themeTimeline) {
+      if (delay) await wait(delay);
+      if (run !== this.run.current) return;
+      if (step) this.pulse(step);
     }
   }
 
-  const Toggle = () => {
-    const { mode, toggle } = Theme.get();
+  private pulse(step: ThemeStep) {
+    for (const element of this.root.current?.querySelectorAll<HTMLElement>(`.context-trace-${step}`) ?? []) {
+      element.classList.remove('trace-pulse');
+      void element.offsetWidth;
+      element.classList.add('trace-pulse');
+      element.addEventListener('animationend', () => {
+        element.classList.remove('trace-pulse');
+      }, { once: true });
+    }
+  }
+}
 
-    return <button onClick={toggle}>{mode}</button>;
+class ThemeDemo extends Component {
+  mode: Mode = 'light';
+  trace = new ThemeTrace();
+
+  render() {
+    const { mode, trace: { root } } = this;
+
+    return (
+      <div ref={root} className="mx-auto grid w-fit max-w-full items-center gap-7 md:grid-cols-[minmax(0,max-content)_8rem] md:gap-10">
+        <div className="code-nowrap min-w-0 w-fit max-w-full">
+          <ExprCode mode={mode} />
+          <Playground to="/examples/composition/context" />
+        </div>
+        <ThemeControl />
+      </div>
+    );
+  }
+}
+
+class ThemeControl extends Component {
+  demo = get(ThemeDemo);
+
+  toggle(setTheme: (mode: Mode) => void) {
+    const mode = this.demo.mode === 'light' ? 'dark' : 'light';
+    setTheme(mode);
+    this.demo.mode = mode;
+    this.demo.trace.play();
   }
 
-  const App = () => (
-    <Provider for={Theme}>
-      <Toggle />
-    </Provider>
+  render() {
+    return <ThemeButton control={this} />;
+  }
+}
+
+function ThemeButton({ control }: { control: ThemeControl }) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const { demo: { mode }, toggle } = use(control);
+
+  useEffect(() => {
+    if (resolvedTheme === 'light' || resolvedTheme === 'dark') {
+      control.demo.mode = resolvedTheme;
+    }
+  }, [control, resolvedTheme]);
+
+  const Icon = mode === 'light' ? Sun : Moon;
+
+  return (
+    <div className="theme-demo-control flex flex-col items-center justify-center justify-self-center rounded-xl p-2">
+      <button
+        type="button"
+        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
+        onClick={() => toggle(setTheme)}
+        className="flex size-16 cursor-pointer items-center justify-center rounded-full border border-fd-border bg-fd-background shadow-sm transition-colors hover:bg-fd-muted">
+        <Icon aria-hidden className="size-7" />
+      </button>
+      <span className="mt-2 font-mono text-sm text-fd-muted-foreground">{mode} mode</span>
+    </div>
   );
-`;
+}
+
+function ExprCode({ mode }: { mode: Mode }) {
+  const Example = code /*tsx*/`
+    import React from 'react';
+    import State, { Provider } from '@expressive/react';
+
+    class Theme extends State {
+      mode = '${mode}';
+
+      toggle() {
+        this.mode = this.mode === 'light' ? 'dark' : 'light';
+      }
+    }
+
+    const Toggle = () => {
+      const { mode, toggle } = Theme.get();
+
+      return <button onClick={toggle}>{mode} mode</button>;
+    }
+
+    const App = () => (
+      <Provider for={Theme}>
+        <Toggle />
+      </Provider>
+    );
+  `;
+
+  return Example({
+    highlight: {
+      prefix: 'context-trace',
+      targets: {
+        handler: /(?<=onClick=\{)toggle/,
+        assignment: /this\.mode = this\.mode[^;]+/,
+        field: /mode = '(?:light|dark)'/,
+        destructure: /mode(?=, toggle)/,
+        jsx: /\{mode\} mode/,
+      },
+    },
+  });
+}

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -1,4 +1,4 @@
-import State, { Component, get, ref, set } from '@expressive/react';
+import State, { Component, get, ref } from '@expressive/react';
 import type { CSSProperties } from 'react';
 import { Link } from 'react-router';
 import CopyPill from '@/components/CopyPill';
@@ -22,8 +22,8 @@ export function Hero() {
           </h1>
           <p className="text-fd-muted-foreground max-w-xl lg:mr-5">
             Expressive MVC moves data, behavior, and lifecycle
-            into a focused model. Components stay small, agent code
-            readable, and apps easy to build at scale. Less code per feature, more pleasant DX.
+            to a focused model. Components stay small, agent code
+            readable, and apps easier to scale. Less code per feature, for a more pleasant DX.
           </p>
         </div>
 
@@ -166,6 +166,7 @@ class LiveCounterDemo extends Component {
   count = 0;
   compact = false;
   trace = new UpdateTrace();
+  comment = new TypedComment();
 
   responsive = ref<HTMLDivElement>(() => {
     const media = window.matchMedia('(max-width: 767px)');
@@ -177,13 +178,19 @@ class LiveCounterDemo extends Component {
   });
 
   render() {
-    const { count, compact, responsive, trace: { root } } = this;
+    const {
+      count,
+      compact,
+      responsive,
+      trace: { root },
+      comment: { value: comment },
+    } = this;
 
     return (
       <div ref={responsive}>
         <div ref={root}>
           <div className={compact ? 'hero-mobile-code code-nowrap' : 'code-nowrap'}>
-            <CounterExample compact={compact} count={count} />
+            <CounterExample compact={compact} count={count} comment={comment} />
           </div>
           <div className="mt-5 flex items-center justify-between gap-4">
             <CounterButton />
@@ -205,6 +212,7 @@ class CounterButton extends Component {
 
   increment() {
     const count = ++this.pendingCount;
+    this.demo.comment.showNormal();
     this.hue = Math.floor(Math.random() * 360);
     this.pulse++;
     this.demo.trace.play({
@@ -239,13 +247,19 @@ class CounterButton extends Component {
 type CounterExampleProps = {
   compact?: boolean;
   count: number;
+  comment: string;
 };
 
 class TypedComment extends State {
-  clicked = set(false, (yes) => yes && this.type('// Update values, update components!'));
-
+  clicked = false;
   value = '';
+  private comment = '';
   private commentTimer?: number;
+
+  showNormal() {
+    this.clicked = true;
+    this.type('// Update values, update components!');
+  }
 
   protected new() {
     if (typeof window === 'undefined') return;
@@ -264,19 +278,22 @@ class TypedComment extends State {
   }
 
   type(comment: string) {
-    if (this.value === comment) return;
+    if (this.comment === comment) return;
+    this.comment = comment;
 
     window.clearTimeout(this.commentTimer);
     this.commentTimer = undefined;
-    this.value = '';
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       this.value = comment;
       return;
     }
 
-    let length = 0;
+    const replacing = this.value.startsWith('//');
+    const width = Math.max(this.value.length, comment.length);
+    let length = replacing ? 2 : 0;
+    this.value = replacing ? '//'.padEnd(width) : '';
     const type = () => {
-      this.value = comment.slice(0, ++length);
+      this.value = comment.slice(0, ++length).padEnd(width);
       this.commentTimer = length < comment.length
         ? window.setTimeout(type, 24)
         : undefined;
@@ -286,9 +303,7 @@ class TypedComment extends State {
   }
 }
 
-function CounterExample({ compact, count }: CounterExampleProps) {
-  const { value } = TypedComment.use({ clicked: count > 0 });
-
+function CounterExample({ compact, count, comment }: CounterExampleProps) {
   const imports =
     "import React from 'react';\n    import State from '@expressive/react';\n\n    ";
   const increment = compact
@@ -302,7 +317,7 @@ function CounterExample({ compact, count }: CounterExampleProps) {
     ${imports}class Counter extends State {
       count = ${count};
 
-      ${value}
+      ${comment}
       ${increment}
     }
 

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
         <div className="min-w-0 lg:row-start-1">
           <h1 className="font-display tracking-tight mb-6">
             <span className="block whitespace-nowrap text-[clamp(1rem,4.7vw,1.4rem)] font-semibold leading-[1.05] text-fd-foreground/70">
-              Clean state management for React
+              Managed state for React
             </span>
             <span className="block mt-4 text-[clamp(1.9rem,9.5vw,3rem)] font-bold leading-[0.98] sm:text-5xl lg:leading-[1.05]">
               <span className="block whitespace-nowrap">More application,</span>
@@ -22,9 +22,8 @@ export function Hero() {
           </h1>
           <p className="text-fd-muted-foreground max-w-xl lg:mr-5">
             Expressive MVC moves data, behavior, and lifecycle
-            into a focused model. Components stay small, agent code stays
-            readable, and apps remain easy to build at scale. The goal is fewer
-            lines (and tokens) per feature, and a more pleasant DX.
+            into a focused model. Components stay small, agent code
+            readable, and apps easy to build at scale. Less code per feature, more pleasant DX.
           </p>
         </div>
 
@@ -243,19 +242,33 @@ type CounterExampleProps = {
 };
 
 class TypedComment extends State {
-  active = set(false, (yes) => yes && this.type());
+  clicked = set(false, (yes) => yes && this.type('// Update values, update components!'));
 
   value = '';
   private commentTimer?: number;
 
   protected new() {
-    return () => window.clearTimeout(this.commentTimer);
+    if (typeof window === 'undefined') return;
+
+    const onScroll = () => {
+      if (!this.clicked) this.type('// Try clicking below!');
+      window.removeEventListener('scroll', onScroll);
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      window.clearTimeout(this.commentTimer);
+      window.removeEventListener('scroll', onScroll);
+    };
   }
 
-  type() {
-    if (this.value || this.commentTimer) return;
+  type(comment: string) {
+    if (this.value === comment) return;
 
-    const comment = '// Update values, update components!';
+    window.clearTimeout(this.commentTimer);
+    this.commentTimer = undefined;
+    this.value = '';
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       this.value = comment;
       return;
@@ -274,7 +287,7 @@ class TypedComment extends State {
 }
 
 function CounterExample({ compact, count }: CounterExampleProps) {
-  const { value } = TypedComment.use({ active: count > 0 });
+  const { value } = TypedComment.use({ clicked: count > 0 });
 
   const imports =
     "import React from 'react';\n    import State from '@expressive/react';\n\n    ";

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -21,9 +21,9 @@ export function Hero() {
             </span>
           </h1>
           <p className="text-fd-muted-foreground max-w-xl lg:mr-5">
-            Expressive MVC moves data, behavior, and lifecycle
-            to a focused model. Components stay small, agent code
-            readable, and apps easier to scale. Less code per feature, for a more pleasant DX.
+            Expressive MVC moves data, behavior, and lifecycle into focused
+            models. Components stay small, application logic stays readable,
+            and every feature takes less code to build, test, and change.
           </p>
         </div>
 

--- a/website/app/routes/home/Primitives.tsx
+++ b/website/app/routes/home/Primitives.tsx
@@ -236,7 +236,7 @@ function Tab({
 
 function Instructions() {
   return (
-    <Tab title="Fields with built-in behavior.">
+    <Tab title="Fields with special behavior.">
       <>
         Instructions are property initializers with runtime behavior. You still
         read them like fields; the initializer decides what kind of field it is.
@@ -291,8 +291,7 @@ function Async() {
         <code>Component</code> can define its own{' '}
         <code>fallback</code> and even error boundary via{' '}
         <code>catch()</code> - no{' '}
-        <code>isPending</code> flags, client to provide, or
-        cache keys.
+        <code>isPending</code>, no thunks.
       </>
       <AsyncCode />
     </Tab>

--- a/website/app/routes/home/Primitives.tsx
+++ b/website/app/routes/home/Primitives.tsx
@@ -151,7 +151,7 @@ export class Primitives extends Component {
         <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
           <div className="max-w-2xl mx-auto text-center mb-4">
             <h2 className="font-display text-2xl md:text-3xl font-bold tracking-tight">
-              All the basics, built right in.
+              The basics, built right in.
             </h2>
           </div>
 
@@ -400,19 +400,18 @@ const FormsCode = code /*tsx*/`
   class MyForm extends Form {
     firstname = '';
     lastname = '';
-    email = '';
 
     submit(event: React.FormEvent) {
       event.preventDefault();
 
-      const { firstname, lastname, email } = this;
+      const { firstname, lastname } = this;
 
-      if (!firstname || !lastname || !email) {
+      if (!firstname || !lastname) {
         alert('Please fill out all fields');
         return;
       }
 
-      alert('Submitting ' + firstname + ' ' + lastname);
+      alert('Hello ' + firstname + ' ' + lastname);
     }
 
     render() {
@@ -422,7 +421,6 @@ const FormsCode = code /*tsx*/`
         <form onSubmit={submit}>
           <input ref={bind.firstname} placeholder="Firstname" />
           <input ref={bind.lastname} placeholder="Lastname" />
-          <input ref={bind.email} placeholder="Email Address" />
           <button type="submit">Submit</button>
         </form>
       );

--- a/website/app/routes/home/Product.tsx
+++ b/website/app/routes/home/Product.tsx
@@ -4,38 +4,35 @@ import Reveal from '@/components/Reveal';
 export function Product() {
   return (
     <section id="product" className="panel px-6 lg:px-[50px]">
-      <div className="mx-auto grid max-w-(--content-width) gap-12 py-16 md:py-24 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)] lg:gap-20">
-        <div className="max-w-2xl lg:self-center">
+      <div className="mx-auto grid max-w-(--content-width) gap-12 py-16 md:py-24 xl:grid-cols-[minmax(26rem,0.7fr)_minmax(0,1.3fr)] xl:gap-12">
+        <div className="max-w-2xl xl:self-center">
           <div className="mb-3 text-xs uppercase tracking-widest text-fd-primary">
             What Expressive adds
           </div>
           <h2 className="mb-5 font-display text-3xl font-bold tracking-tight md:text-4xl">
-            React renders your app.<br /> MVC keeps it organized.
+            <span className="md:whitespace-nowrap">React renders your app.</span><br />
+            <span className="md:whitespace-nowrap">MVC keeps it organized.</span>
           </h2>
           <p className="text-lg leading-relaxed text-fd-muted-foreground">
-            Expressive MVC is a model layer for React. It gives data, async and
+            Expressive MVC is a model layer for your app. It gives data, async and
             side effects a home away from display logic.
-            React keeps doing what it's good at, while the
-            logic behind it becomes easier to read, write, and test.
+            Components stay simple, behavior easy to read, write.
           </p>
         </div>
 
-        <div className="grid grid-cols-2 gap-x-5 gap-y-8 sm:gap-x-8">
-          <Point title="Smaller components" delay={0}>
-            Components focus on rendering instead of coordinating
-            features.
+        <div className="grid grid-cols-2 max-w-180 gap-x-5 gap-y-8 sm:gap-x-8">
+          <Point title="Smaller components" illustration={<SmallerComponents />} delay={0}>
+            Focus on the display logic, not coordinating features.
           </Point>
-          <Point title="Minimal boilerplate" delay={100}>
-            State classes read like normal JavaScript, even when they power
-            complex logic and UI.
-          </Point>
-          <Point title="Output you can read" delay={200}>
-            When an agent writes the feature, related logic stays together -
-            easier to extend.
-          </Point>
-          <Point title="Separation built in" delay={300}>
-            Built-in context keeps models separate without prop drilling, so
+          <Point title="Separate concerns" illustration={<BuiltInSeparation />} delay={300}>
+            Breaks up pages so
             growth isn't tech debt.
+          </Point>
+          <Point title="No Ceremony" illustration={<MinimalBoilerplate />} delay={100}>
+            Normal logic, without the factories and wrappers.
+          </Point>
+          <Point title="High Clarity" illustration={<ReadableOutput />} delay={200}>
+            Review agent output with confidence, not gymnastics.
           </Point>
         </div>
       </div>
@@ -46,18 +43,85 @@ export function Product() {
 function Point({
   title,
   children,
+  illustration,
   delay,
 }: {
   title: string;
   children: React.ReactNode;
+  illustration: React.ReactNode;
   delay: number;
 }) {
   return (
-    <Reveal delay={delay} className="border-t border-fd-border pt-4">
-      <h3 className="mb-2 font-semibold">{title}</h3>
-      <p className="text-sm leading-relaxed text-fd-muted-foreground sm:text-base">
-        {children}
-      </p>
+    <Reveal
+      delay={delay}
+      className="flex flex-wrap items-start gap-x-5 gap-y-3 pt-4 lg:flex-nowrap lg:items-center">
+      <div className="h-14 shrink-0 text-fd-muted-foreground pl-2" aria-hidden>
+        {illustration}
+      </div>
+      <div className="min-w-54 max-w-54 flex-1">
+        <h3 className="mb-2 font-semibold">{title}</h3>
+        <p className="text-sm leading-relaxed text-balance text-fd-muted-foreground sm:text-base">
+          {children}
+        </p>
+      </div>
     </Reveal>
+  );
+}
+
+const illustrationClass = 'h-14 w-20 overflow-visible';
+
+function SmallerComponents() {
+  return (
+    <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
+      <rect x="2" y="7" width="28" height="42" rx="5" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
+      <path d="M8 15h16M8 24h11M8 32h16M8 41h13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".24" />
+      <path d="M35 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
+      <rect x="49" y="4" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
+      <rect x="49" y="21" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
+      <rect x="49" y="38" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
+      <path d="M55 11h13M55 28h17M55 45h10" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function MinimalBoilerplate() {
+  return (
+    <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
+      <rect x="8" y="7" width="64" height="42" rx="6" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
+      <text
+        x="39"
+        y="35"
+        fill="currentColor"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
+        fontSize="22"
+        letterSpacing="-4"
+        textAnchor="middle"
+        opacity=".3">([{'{}'}])</text>
+    </svg>
+  );
+}
+
+function ReadableOutput() {
+  return (
+    <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
+      <path d="M3 12h16M8 21h21M2 30h14M11 39h17M5 48h18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".2" />
+      <path d="M34 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
+      <rect x="48" y="5" width="30" height="46" rx="6" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
+      <path d="M54 15h15M54 23h10M54 31h18M54 39h13" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function BuiltInSeparation() {
+  return (
+    <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
+      <rect x="2" y="7" width="29" height="42" rx="5" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
+      <path d="M8 16h17M8 24h10M8 32h16M8 40h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".22" />
+      <path d="M37 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
+      <rect x="49" y="3" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
+      <rect x="49" y="33" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
+      <path d="M55 10h16M55 17h10M55 40h11M55 47h17" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
+      <path d="M59 25v5m-2-2 2 2 2-2M68 31v-5m-2 2 2-2 2 2" stroke="var(--color-fd-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".45" />
+    </svg>
   );
 }

--- a/website/app/routes/home/Product.tsx
+++ b/website/app/routes/home/Product.tsx
@@ -16,7 +16,7 @@ export function Product() {
           <p className="text-lg leading-relaxed text-fd-muted-foreground">
             Expressive MVC is a model layer for your app. It gives data, async and
             side effects a home away from display logic.
-            Components stay simple, behavior easy to read, write.
+            Components stay simple and behavior easy to read, write and debug.
           </p>
         </div>
 
@@ -24,14 +24,14 @@ export function Product() {
           <Point title="Smaller components" illustration={<SmallerComponents />} delay={0}>
             Focus on the display logic, not coordinating features.
           </Point>
-          <Point title="Separate concerns" illustration={<BuiltInSeparation />} delay={300}>
-            Breaks up pages so
+          <Point title="Separated concerns" illustration={<BuiltInSeparation />} delay={300}>
+            Break up features so
             growth isn't tech debt.
           </Point>
-          <Point title="No Ceremony" illustration={<MinimalBoilerplate />} delay={100}>
+          <Point title="Less Ceremony" illustration={<MinimalBoilerplate />} delay={100}>
             Normal logic, without the factories and wrappers.
           </Point>
-          <Point title="High Clarity" illustration={<ReadableOutput />} delay={200}>
+          <Point title="Higher Clarity" illustration={<ReadableOutput />} delay={200}>
             Review agent output with confidence, not gymnastics.
           </Point>
         </div>
@@ -59,7 +59,7 @@ function Point({
         {illustration}
       </div>
       <div className="min-w-54 max-w-54 flex-1">
-        <h3 className="mb-2 font-semibold">{title}</h3>
+        <h3 className="mb-1 font-semibold">{title}</h3>
         <p className="text-sm leading-relaxed text-balance text-fd-muted-foreground sm:text-base">
           {children}
         </p>
@@ -73,12 +73,12 @@ const illustrationClass = 'h-14 w-20 overflow-visible';
 function SmallerComponents() {
   return (
     <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
-      <rect x="2" y="7" width="28" height="42" rx="5" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
-      <path d="M8 15h16M8 24h11M8 32h16M8 41h13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".24" />
-      <path d="M35 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
-      <rect x="49" y="4" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
-      <rect x="49" y="21" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
-      <rect x="49" y="38" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.18] dark:opacity-[.12]" />
+      <rect x="2" y="7" width="28" height="42" rx="5" fill="currentColor" className="opacity-[.17] dark:opacity-[.13]" />
+      <path d="M8 15h16M8 24h11M8 32h16M8 41h13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".3" />
+      <path d="M35 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".3" />
+      <rect x="49" y="4" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.22] dark:opacity-[.16]" />
+      <rect x="49" y="21" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.22] dark:opacity-[.16]" />
+      <rect x="49" y="38" width="29" height="14" rx="4" fill="var(--color-fd-primary)" className="opacity-[.22] dark:opacity-[.16]" />
       <path d="M55 11h13M55 28h17M55 45h10" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
@@ -87,7 +87,7 @@ function SmallerComponents() {
 function MinimalBoilerplate() {
   return (
     <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
-      <rect x="8" y="7" width="64" height="42" rx="6" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
+      <rect x="4" y="7" width="72" height="42" rx="6" fill="currentColor" className="opacity-[.17] dark:opacity-[.13]" />
       <text
         x="39"
         y="35"
@@ -96,7 +96,7 @@ function MinimalBoilerplate() {
         fontSize="22"
         letterSpacing="-4"
         textAnchor="middle"
-        opacity=".3">([{'{}'}])</text>
+        opacity=".38">([{'{}'}])</text>
     </svg>
   );
 }
@@ -104,9 +104,9 @@ function MinimalBoilerplate() {
 function ReadableOutput() {
   return (
     <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
-      <path d="M3 12h16M8 21h21M2 30h14M11 39h17M5 48h18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".2" />
-      <path d="M34 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
-      <rect x="48" y="5" width="30" height="46" rx="6" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
+      <path d="M3 12h16M8 21h8M20 21h9M2 30h14M11 39h17M5 48h4M13 48h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".26" />
+      <path d="M34 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".3" />
+      <rect x="48" y="5" width="30" height="46" rx="6" fill="var(--color-fd-primary)" className="opacity-20 dark:opacity-[.14]" />
       <path d="M54 15h15M54 23h10M54 31h18M54 39h13" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
@@ -115,11 +115,11 @@ function ReadableOutput() {
 function BuiltInSeparation() {
   return (
     <svg viewBox="0 0 80 56" className={illustrationClass} fill="none">
-      <rect x="2" y="7" width="29" height="42" rx="5" fill="currentColor" className="opacity-10 dark:opacity-[.06]" />
-      <path d="M8 16h17M8 24h10M8 32h16M8 40h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".22" />
-      <path d="M37 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".24" />
-      <rect x="49" y="3" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
-      <rect x="49" y="33" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-[.16] dark:opacity-10" />
+      <rect x="2" y="7" width="29" height="42" rx="5" fill="currentColor" className="opacity-[.17] dark:opacity-[.13]" />
+      <path d="M8 16h17M8 24h10M8 32h16M8 40h12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" opacity=".28" />
+      <path d="M37 28h8m-3-3 3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".3" />
+      <rect x="49" y="3" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-20 dark:opacity-[.14]" />
+      <rect x="49" y="33" width="29" height="20" rx="5" fill="var(--color-fd-primary)" className="opacity-20 dark:opacity-[.14]" />
       <path d="M55 10h16M55 17h10M55 40h11M55 47h17" stroke="var(--color-fd-primary)" strokeWidth="2" strokeLinecap="round" />
       <path d="M59 25v5m-2-2 2 2 2-2M68 31v-5m-2 2 2-2 2 2" stroke="var(--color-fd-primary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" opacity=".45" />
     </svg>

--- a/website/app/routes/home/Product.tsx
+++ b/website/app/routes/home/Product.tsx
@@ -5,7 +5,7 @@ export function Product() {
   return (
     <section id="product" className="panel px-6 lg:px-[50px]">
       <div className="mx-auto grid max-w-(--content-width) gap-12 py-16 md:py-24 xl:grid-cols-[minmax(26rem,0.7fr)_minmax(0,1.3fr)] xl:gap-12">
-        <div className="max-w-2xl xl:self-center">
+        <div className="mx-auto max-w-2xl text-center xl:self-center">
           <div className="mb-3 text-xs uppercase tracking-widest text-fd-primary">
             What Expressive adds
           </div>
@@ -20,7 +20,7 @@ export function Product() {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 max-w-180 gap-x-5 gap-y-8 sm:gap-x-8">
+        <div className="mx-auto grid w-full max-w-180 grid-cols-2 gap-x-5 gap-y-8 sm:gap-x-8">
           <Point title="Smaller components" illustration={<SmallerComponents />} delay={0}>
             Focus on the display logic, not coordinating features.
           </Point>

--- a/website/app/routes/home/Rails.tsx
+++ b/website/app/routes/home/Rails.tsx
@@ -21,7 +21,7 @@ export function Rails() {
           <p className="text-fd-muted-foreground text-lg md:text-xl">
             MVC covers stateful behavior you normally need a library for.
             Build forms, tables, and modals on the same foundation -
-            install a specialist where it earns its place.
+            install specialists only where you want opinions.
           </p>
         </div>
 

--- a/website/app/routes/home/Rails.tsx
+++ b/website/app/routes/home/Rails.tsx
@@ -20,8 +20,8 @@ export function Rails() {
           </h2>
           <p className="text-fd-muted-foreground text-lg md:text-xl">
             MVC covers stateful behavior you normally need a library for.
-            Build forms, tables, and modals on the same foundation -
-            install specialists only where you want opinions.
+            Build forms, tables, and modals on the same foundation. The only
+            opinions are your own.
           </p>
         </div>
 
@@ -42,12 +42,11 @@ export function Rails() {
 
         <div className="max-w-2xl mb-10">
           <h3 className="font-display text-2xl md:text-3xl font-bold tracking-tight mb-3">
-            <span className="text-fd-foreground/80">(Artificial)</span> Idiot-Proof.
+            Better architecture, better output.
           </h3>
           <p className="text-fd-muted-foreground text-lg">
             Clear conventions mean a good feature looks the same, whether
-            written by you, your team, or an agent. Fewer one-off decisions
-            keep AI focused and on-task.
+            written by you, your team, or an agent. AI-generated code stays readable and high quality.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- sharpen the homepage narrative around focused models, smaller components, and incremental adoption
- expand the product and comparison sections with clearer feature presentation and token context
- add and stabilize interactive hero and contextual theme traces
- refine supporting visuals, responsive behavior, and AI-oriented architecture messaging

## Validation

- `bun run build`
- commit hooks