### PR TITLE
Disable social preview metadata

### DIFF
--- a/website/app/routes/home/index.tsx
+++ b/website/app/routes/home/index.tsx
@@ -29,15 +29,6 @@ export function meta() {
       content:
         'Cleaner React state with smaller components and fewer lines per feature',
     },
-    { property: 'og:title', content: 'Expressive MVC' },
-    {
-      property: 'og:description',
-      content:
-        'Cleaner React state with smaller components and fewer lines per feature',
-    },
-    { property: 'og:image', content: '/brand/logo.png' },
-    { name: 'twitter:card', content: 'summary' },
-    { name: 'twitter:image', content: '/brand/logo.png' },
   ];
 }
 


### PR DESCRIPTION
## Summary
- remove Open Graph metadata from the homepage
- remove Twitter card metadata so shared links no longer advertise the logo image
- preserve the standard page title and description

## Validation
- 