### PR TITLE
Remove homepage social metadata

### DIFF
--- a/website/app/routes/home/index.tsx
+++ b/website/app/routes/home/index.tsx
@@ -29,15 +29,6 @@ export function meta() {
       content:
         'Cleaner React state with smaller components and fewer lines per feature',
     },
-    { property: 'og:title', content: 'Expressive MVC' },
-    {
-      property: 'og:description',
-      content:
-        'Cleaner React state with smaller components and fewer lines per feature',
-    },
-    { property: 'og:image', content: '/brand/logo.png' },
-    { name: 'twitter:card', content: 'summary' },
-    { name: 'twitter:image', content: '/brand/logo.png' },
   ];
 }
 


### PR DESCRIPTION
## Summary
- remove homepage-specific Open Graph metadata
- remove homepage-specific Twitter card metadata
- retain the page title and description metadata

## Validation
- `bun run --filter website types:check`
- `git diff --check`