### PR TITLE
fix: prevent horizontal overflow on homepage

### DIFF
--- a/website/app/routes/home/Context.tsx
+++ b/website/app/routes/home/Context.tsx
@@ -6,7 +6,7 @@ import code from '@/components/Snippet';
 
 export function Context() {
   return (
-    <section id="context" className="panel px-6 lg:px-[50px]">
+    <section id="context" className="panel overflow-x-hidden px-6 lg:px-[50px]">
       <div className="mx-auto max-w-(--content-width) py-16 md:py-24">
         <div className="max-w-2xl mx-auto text-center mb-12">
           <h2 className="font-display text-3xl md:text-4xl font-bold tracking-tight mb-4">
@@ -87,8 +87,8 @@ class ThemeDemo extends Component {
     const { mode, trace: { root } } = this;
 
     return (
-      <div ref={root} className="mx-auto grid w-fit max-w-full items-center gap-7 md:grid-cols-[minmax(0,max-content)_8rem] md:gap-10">
-        <div className="code-nowrap min-w-0 w-fit max-w-full">
+      <div ref={root} className="mx-auto grid w-full max-w-full items-center gap-7 md:w-fit md:grid-cols-[minmax(0,max-content)_8rem] md:gap-10">
+        <div className="code-nowrap min-w-0 w-full max-w-full overflow-hidden md:w-fit">
           <ExprCode mode={mode} />
           <Playground to="/examples/composition/context" />
         </div>

--- a/website/app/routes/home/Product.tsx
+++ b/website/app/routes/home/Product.tsx
@@ -20,7 +20,7 @@ export function Product() {
           </p>
         </div>
 
-        <div className="mx-auto grid w-full max-w-180 grid-cols-2 gap-x-5 gap-y-8 sm:gap-x-8">
+        <div className="mx-auto grid w-full max-w-180 grid-cols-1 gap-x-5 gap-y-8 sm:grid-cols-2 sm:gap-x-8">
           <Point title="Smaller components" illustration={<SmallerComponents />} delay={0}>
             Focus on the display logic, not coordinating features.
           </Point>
@@ -54,13 +54,13 @@ function Point({
   return (
     <Reveal
       delay={delay}
-      className="flex flex-wrap items-start gap-x-5 gap-y-3 pt-4 lg:flex-nowrap lg:items-center">
-      <div className="h-14 shrink-0 text-fd-muted-foreground pl-2" aria-hidden>
+      className="flex items-start gap-x-5 gap-y-3 pt-4 lg:items-center">
+      <div className="h-14 shrink-0 text-fd-muted-foreground" aria-hidden>
         {illustration}
       </div>
-      <div className="min-w-54 max-w-54 flex-1">
+      <div className="min-w-0 flex-1">
         <h3 className="mb-1 font-semibold">{title}</h3>
-        <p className="text-sm leading-relaxed text-balance text-fd-muted-foreground sm:text-base">
+        <p className="max-w-46 text-sm leading-relaxed text-balance text-fd-muted-foreground sm:text-base">
           {children}
         </p>
       </div>

--- a/website/app/routes/home/index.tsx
+++ b/website/app/routes/home/index.tsx
@@ -34,7 +34,7 @@ export function meta() {
 
 export default function Home() {
   return (
-    <HomeLayout {...layoutOptions} className="[--content-width:1080px] home-sections">
+    <HomeLayout {...layoutOptions} className="[--content-width:1080px] home-sections overflow-x-clip">
       <Background />
       <Hero />
       <Complicated />


### PR DESCRIPTION
Fixes horizontal overflow on the homepage, primarily on narrow viewports:

- Clip horizontal overflow at the layout root (`overflow-x-clip` on `HomeLayout`) and on the Context panel section.
- Context demo grid: full-width on mobile with hidden code overflow, `w-fit` only from `md` up.
- Product points: single column on mobile (two from `sm`), drop the fixed `min-w-54 max-w-54` column in favor of `min-w-0 flex-1` so text wraps instead of overflowing.

Website-only change; no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)