### PR TITLE
Chore/env tunnel config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-mvc",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci:version": "changeset version && bun install",
     "ci:publish": "bun run --filter='./packages/*' build && changeset publish",
     "pr": "bash .github/scripts/pr.sh",
-    "tunnel": "cloudflared tunnel --url http://localhost:5173",
+    "tunnel": "cloudflared tunnel --no-autoupdate ${TUNNEL_NAME:+run} --url http://localhost:5173 ${TUNNEL_NAME:-}",
     "watch": "bun test --watch --only-failures",
     "nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"
   },

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,7 +9,7 @@ import { cp, readFile } from 'fs/promises';
 
 export default defineConfig({
   server: {
-    allowedHosts: ['.trycloudflare.com'],
+    allowedHosts: ['.trycloudflare.com', ...(process.env.STAGING_HOST ? [process.env.STAGING_HOST] : [])],
   },
   resolve: {
     alias: {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,9 +9,14 @@ import { cp, readFile } from 'fs/promises';
 
 export default defineConfig({
   server: {
+    port: 8080,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
     allowedHosts: ['.trycloudflare.com', ...(process.env.STAGING_HOST ? [process.env.STAGING_HOST] : [])],
   },
   resolve: {
+    dedupe: ['react', 'react-dom'],
     alias: {
       '@examples': resolve(__dirname, '../examples')
     }

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -8,6 +8,17 @@ import { resolve, join } from 'path';
 import { cp, readFile } from 'fs/promises';
 
 export default defineConfig({
+  optimizeDeps: {
+    include: [
+      '@codesandbox/sandpack-react',
+      'lucide-react',
+      'next-themes',
+      'react',
+      'react-dom',
+      'react/jsx-dev-runtime',
+      'react/jsx-runtime',
+    ],
+  },
   server: {
     port: 8080,
     headers: {


### PR DESCRIPTION
## Summary

- make the Cloudflare tunnel command configurable for quick or named tunnels through `TUNNEL_NAME`
- pin the website dev server to port 8080, disable response caching, and allow an optional `STAGING_HOST`
- prebundle the website's shared runtime dependencies and deduplicate React and React DOM for more reliable tunneled development
- record Bun's lockfile configuration version

## Configuration

Run the existing quick-tunnel workflow without additional configuration:

```sh
bun run tunnel
```

Set `TUNNEL_NAME` to run a named Cloudflare tunnel, and set `STAGING_HOST` when the Vite server should accept a staging hostname:

```sh
TUNNEL_NAME=<name> bun run tunnel
STAGING_HOST=<hostname> bun --cwd website run dev
```

## Validation

- `cd website && bun run types:check`
