### PR TITLE
Improve iPad example sandbox

### DIFF
--- a/examples/content/composition/subcomponents/App.tsx
+++ b/examples/content/composition/subcomponents/App.tsx
@@ -5,23 +5,27 @@ import Split from '@common/Split';
 // Picker is kept separate as a reusable, behavior-complete base.
 import { Picker } from './Picker';
 
-const COLORS: Record<string, string> = {
-  Coral: '#ff6f61',
-  Sky: '#4dabf7',
-  Mint: '#51cf66',
-};
+export default () => (
+  <div className="container">
+    <h1>Overrideable Subcomponents</h1>
+    <Split>
+      <FruitPicker />
+      <PalettePicker />
+    </Split>
+  </div>
+);
 
 // A plain vertical list. Only Item is overridden - selection behavior
 // and the default Summary are inherited untouched.
 class FruitPicker extends Picker {
   name = 'Fruit';
-  items = ['Apple', 'Banana', 'Cherry'];
+  names = ['Apple', 'Banana', 'Cherry'];
 
   Item({ index }: { index: number }) {
     return (
       <>
         {index === this.selected ? '🍎 ' : '🍏 '}
-        {this.items[index]}
+        {this.names[index]}
       </>
     );
   }
@@ -33,28 +37,25 @@ class FruitPicker extends Picker {
 class PalettePicker extends Picker {
   name = 'Color';
   className = 'palette';
-  items = Object.keys(COLORS);
+
+  colors: Record<string, string> = {
+    Coral: '#ff6f61',
+    Sky: '#4dabf7',
+    Mint: '#51cf66',
+  };
+
+  names = Object.keys(this.colors);
 
   Item({ index }: { index: number }) {
-    return <span className="swatch" style={{ background: COLORS[this.items[index]] }} />;
+    return <span className="swatch" style={{ background: this.colors[this.names[index]] }} />;
   }
 
   Summary() {
-    const name = this.items[this.selected];
+    const name = this.names[this.selected];
     return (
       <small>
-        {name} <code>{COLORS[name]}</code>
+        {name} <code>{this.colors[name]}</code>
       </small>
     );
   }
 }
-
-export default () => (
-  <div className="container">
-    <h1>Overrideable Subcomponents</h1>
-    <Split>
-      <FruitPicker />
-      <PalettePicker />
-    </Split>
-  </div>
-);

--- a/examples/content/composition/subcomponents/Picker.tsx
+++ b/examples/content/composition/subcomponents/Picker.tsx
@@ -8,7 +8,7 @@ import { Component, set } from '@expressive/react';
  */
 export class Picker extends Component {
   name = '';
-  items = [] as string[];
+  names = [] as string[];
   selected = 0;
 
   /**
@@ -26,12 +26,12 @@ export class Picker extends Component {
    * override can't touch the click-to-select wiring in render().
    */
   Item({ index }: { index: number }) {
-    return <>{this.items[index]}</>;
+    return <>{this.names[index]}</>;
   }
 
   /** Visual seam: a readout of the current choice. */
   Summary() {
-    return <small>Selected: {this.items[this.selected]}</small>;
+    return <small>Selected: {this.names[this.selected]}</small>;
   }
 
   render() {
@@ -39,7 +39,7 @@ export class Picker extends Component {
       <div className={`picker ${this.className}`}>
         {this.name && <h2>Choose {this.name}</h2>}
         <ul>
-          {this.items.map((item, i) => (
+          {this.names.map((item, i) => (
             <li
               key={item}
               className={i === this.selected ? 'active' : ''}

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -68,8 +68,31 @@ figure[data-rehype-pretty-code-figure] pre code,
   border-radius: 0.25rem;
 }
 
-.sandbox-navigation-trigger .sp-tabs-scrollable-container {
-  padding-left: 2.75rem !important;
+.sp-tabs-scrollable-container > .sp-tab-container {
+  padding-right: 0 !important;
+}
+
+.sp-tabs-scrollable-container .sp-tab-button {
+  padding-inline: 0.75rem !important;
+  background: transparent !important;
+  font-weight: 400;
+}
+
+.sp-tabs-scrollable-container
+  > .sp-tab-container[aria-selected='true']
+  .sp-tab-button {
+  color: var(--accent) !important;
+  font-weight: 600;
+}
+
+.sp-tabs-scrollable-container > .sp-tab-container:has(.sp-tab-button:focus) {
+  outline: none !important;
+}
+
+.sp-tabs-scrollable-container
+  > .sp-tab-container:has(.sp-tab-button:focus-visible) {
+  outline: 1px solid var(--color-fd-ring) !important;
+  outline-offset: -2px;
 }
 
 /* Comparison blocks opt out of wrapping - they scroll horizontally instead. */

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -68,6 +68,10 @@ figure[data-rehype-pretty-code-figure] pre code,
   border-radius: 0.25rem;
 }
 
+.sandbox-navigation-trigger .sp-tabs-scrollable-container {
+  padding-left: 2.75rem !important;
+}
+
 /* Comparison blocks opt out of wrapping - they scroll horizontally instead. */
 .code-nowrap .shiki .line,
 .code-nowrap .shiki code,

--- a/website/app/components/Compare.tsx
+++ b/website/app/components/Compare.tsx
@@ -25,7 +25,7 @@ class Control extends State {
 
   tabScroller = ref<HTMLDivElement>((el) => {
     let frame = 0;
-    const media = window.matchMedia('(max-width: 1023px)');
+    const media = window.matchMedia('(max-width: 767px)');
 
     const update = () => {
       frame = 0;
@@ -72,7 +72,7 @@ class Control extends State {
     if (!el) return;
 
     const remaining = el.scrollWidth - el.clientWidth - el.scrollLeft;
-    const mobile = window.matchMedia('(max-width: 1023px)').matches;
+    const mobile = window.matchMedia('(max-width: 767px)').matches;
     this.canScrollTabsLeft = mobile && el.scrollLeft > 1;
     this.canScrollTabsRight = mobile && remaining > 1;
   }
@@ -115,7 +115,7 @@ export default function Compare({ left, right }: CompareProps) {
 
   return (
     <div>
-      <div className="compare-static hidden lg:grid lg:grid-cols-2 lg:gap-5 lg:items-start">
+      <div className="compare-static hidden md:grid md:grid-cols-2 md:gap-5 md:items-start">
         <div>
           <Head>
             <span className="text-sm font-semibold text-fd-primary">{left.label}</span>
@@ -131,7 +131,7 @@ export default function Compare({ left, right }: CompareProps) {
         </div>
       </div>
 
-      <div className="lg:hidden">
+      <div className="md:hidden">
         <div className="mb-3 [--tab-scroll-bg:color-mix(in_oklab,var(--color-fd-muted)_50%,transparent)]">
           <div className="relative w-fit max-w-full">
             <div

--- a/website/app/components/Compare.tsx
+++ b/website/app/components/Compare.tsx
@@ -95,12 +95,12 @@ export default function Compare({ left, right }: CompareProps) {
 
   const libTabs =
     right.length > 1 ? (
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex min-w-0 max-w-full flex-nowrap items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {right.map((s, i) => (
           <button
             key={s.label}
             onClick={() => select(i + 1)}
-            className={`rounded-full font-mono text-xs py-1 px-2.5 transition-colors ${
+            className={`shrink-0 rounded-full font-mono text-xs py-1 px-2.5 transition-colors ${
               i === tab
                 ? 'bg-fd-muted text-fd-foreground'
                 : 'text-fd-muted-foreground hover:bg-fd-muted/60'
@@ -116,7 +116,7 @@ export default function Compare({ left, right }: CompareProps) {
   return (
     <div>
       <div className="compare-static hidden md:grid md:grid-cols-2 md:gap-5 md:items-start">
-        <div>
+        <div className="min-w-0">
           <Head>
             <span className="text-sm font-semibold text-fd-primary">{left.label}</span>
             <span className="text-[11px] uppercase tracking-widest text-fd-muted-foreground">
@@ -125,7 +125,7 @@ export default function Compare({ left, right }: CompareProps) {
           </Head>
           <CodePanel snippet={Left} />
         </div>
-        <div>
+        <div className="min-w-0">
           <Head>{libTabs}</Head>
           <CodePanel snippet={Right} />
         </div>
@@ -173,7 +173,7 @@ function CodePanel({ snippet: Snippet }: { snippet: Snippet }) {
   const tokenCount = 'tokenCount' in Snippet ? Snippet.tokenCount : undefined;
 
   return (
-    <div className="relative">
+    <div className="relative min-w-0">
       <Snippet {...LN} />
       {tokenCount !== undefined && (
         <span className="pointer-events-none absolute right-3 bottom-3 rounded bg-fd-card/90 px-1.5 py-0.5 font-mono text-[10px] text-fd-muted-foreground shadow-sm">
@@ -186,7 +186,7 @@ function CodePanel({ snippet: Snippet }: { snippet: Snippet }) {
 
 function Head({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-2 min-h-10 px-1 mb-2">
+    <div className="flex min-w-0 items-center justify-between gap-2 min-h-10 px-1 mb-2">
       {children}
     </div>
   );

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -6,13 +6,18 @@ import {
   useSandpack,
 } from '@codesandbox/sandpack-react';
 import State, { ref, set } from '@expressive/react';
+import { Columns2, PanelLeftOpen, Rows2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import type { MouseEvent as ReactMouseEvent } from 'react';
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react';
 import { useMemo } from 'react';
 
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
-  ratio = 50; // editor width (%) when both panels are side by side
+  stacked = false;
+  ratio = 50;
 
   // Hold Ctrl and two-finger swipe to nudge split
   layout = ref<HTMLDivElement>((el) => {
@@ -32,30 +37,64 @@ class Panes extends State {
     this.mode = is;
   }
 
-  grab(event: ReactMouseEvent) {
+  toggleSplit() {
+    this.stacked = !this.stacked;
+  }
+
+  grab(event: ReactPointerEvent<HTMLDivElement>) {
+    if (!event.isPrimary || event.button !== 0) return;
+
     event.preventDefault();
     const rect = event.currentTarget.parentElement!.getBoundingClientRect();
+    const pointerId = event.pointerId;
 
-    const move = (e: globalThis.MouseEvent) => {
-      const pct = ((e.clientX - rect.left) / rect.width) * 100;
+    const move = (e: globalThis.PointerEvent) => {
+      if (e.pointerId !== pointerId) return;
+      e.preventDefault();
+      const pct = this.stacked
+        ? ((e.clientY - rect.top) / rect.height) * 100
+        : ((e.clientX - rect.left) / rect.width) * 100;
       this.ratio = Math.min(80, Math.max(20, pct));
     };
-    const up = () => {
-      document.removeEventListener('mousemove', move);
-      document.removeEventListener('mouseup', up);
+    const up = (e: globalThis.PointerEvent) => {
+      if (e.pointerId !== pointerId) return;
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      document.removeEventListener('pointercancel', up);
     };
 
-    document.addEventListener('mousemove', move);
-    document.addEventListener('mouseup', up);
+    document.addEventListener('pointermove', move, { passive: false });
+    document.addEventListener('pointerup', up);
+    document.addEventListener('pointercancel', up);
+  }
+
+  adjust(event: ReactKeyboardEvent<HTMLDivElement>) {
+    const step = event.shiftKey ? 10 : 2;
+
+    const decrease = this.stacked ? 'ArrowUp' : 'ArrowLeft';
+    const increase = this.stacked ? 'ArrowDown' : 'ArrowRight';
+
+    if (event.key === decrease) this.ratio = Math.max(20, this.ratio - step);
+    else if (event.key === increase)
+      this.ratio = Math.min(80, this.ratio + step);
+    else if (event.key === 'Home') this.ratio = 20;
+    else if (event.key === 'End') this.ratio = 80;
+    else return;
+
+    event.preventDefault();
   }
 }
 
 export default function Sandbox({
   name,
   files,
+  navigationOpen = false,
+  onOpenNavigation,
 }: {
   name: string;
   files: Record<string, string>;
+  navigationOpen?: boolean;
+  onOpenNavigation?: () => void;
 }) {
   const { resolvedTheme } = useTheme();
   const dark = resolvedTheme === 'dark';
@@ -98,13 +137,31 @@ export default function Sandbox({
       files={themed}
       customSetup={{ dependencies }}
       style={{ height: '100%' }}>
-      <Layout />
+      <Layout
+        navigationOpen={navigationOpen}
+        onOpenNavigation={onOpenNavigation}
+      />
     </SandpackProvider>
   );
 }
 
-function Layout() {
-  const { onSelect, mode, ratio, grab, layout } = Panes.use();
+function Layout({
+  navigationOpen,
+  onOpenNavigation,
+}: {
+  navigationOpen: boolean;
+  onOpenNavigation?: () => void;
+}) {
+  const {
+    onSelect,
+    mode,
+    stacked,
+    ratio,
+    grab,
+    adjust,
+    toggleSplit,
+    layout,
+  } = Panes.use();
   const sandpack = useSandpack();
   const refreshOnSave = {
     key: 'Mod-s',
@@ -117,14 +174,23 @@ function Layout() {
 
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
-  const { matches: narrow } = MediaQuery.use({ query: '(max-width: 767px)' });
+  const { matches: narrow } = MediaQuery.use({ query: '(max-width: 639px)' });
   const showEditor = !narrow || mode === 'code';
   const showPreview = !narrow || mode === 'preview';
 
   return (
     <SandpackLayout
       ref={layout}
-      className="relative h-full [--sp-layout-height:100%]">
+      style={{ flexDirection: stacked ? 'column' : 'row' }}
+      className={`relative h-full [--sp-layout-height:100%] ${onOpenNavigation && !navigationOpen ? 'sandbox-navigation-trigger' : ''}`}>
+      {onOpenNavigation && !navigationOpen && (
+        <button
+          aria-label="Open examples navigation"
+          className="absolute top-1.5 left-1.5 z-20 flex size-7 items-center justify-center rounded-md border border-fd-border bg-fd-background text-fd-muted-foreground shadow-sm hover:bg-fd-muted hover:text-fd-foreground"
+          onClick={onOpenNavigation}>
+          <PanelLeftOpen className="size-4" />
+        </button>
+      )}
       <SandpackCodeEditor
         style={{
           display: showEditor ? 'flex' : 'none',
@@ -134,15 +200,73 @@ function Layout() {
       />
       {!narrow && (
         <div
-          className="shrink-0 w-1.5 cursor-col-resize bg-fd-border hover:bg-fd-primary"
-          onMouseDown={grab}
-        />
+          role="separator"
+          aria-label="Resize code and preview panels"
+          aria-orientation={stacked ? 'horizontal' : 'vertical'}
+          aria-valuemin={20}
+          aria-valuemax={80}
+          aria-valuenow={Math.round(ratio)}
+          tabIndex={0}
+          className={`group relative z-10 shrink-0 touch-none focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-fd-ring ${
+            stacked
+              ? '-my-4 h-11 w-full cursor-row-resize'
+              : '-mx-4 h-full w-11 cursor-col-resize'
+          }`}
+          onPointerDown={grab}
+          onKeyDown={adjust}>
+          <span
+            className={`pointer-events-none absolute bg-fd-border transition-colors group-hover:bg-fd-primary group-focus-visible:bg-fd-primary ${
+              stacked
+                ? 'inset-x-0 top-1/2 h-px -translate-y-1/2'
+                : 'inset-y-0 left-1/2 w-px -translate-x-1/2'
+            }`}
+          />
+          <span
+            className={`pointer-events-none absolute top-1/2 left-1/2 -translate-1/2 rounded-full border border-fd-border bg-fd-background shadow-sm transition-colors group-hover:border-fd-primary group-focus-visible:border-fd-primary ${
+              stacked ? 'h-1.5 w-12' : 'h-12 w-1.5'
+            }`}
+          />
+        </div>
       )}
       <SandpackPreview
         style={{ display: showPreview ? 'flex' : 'none', flex: '1 1 0%' }}
       />
+      {!narrow && (
+        <SplitSwitcher
+          stacked={stacked}
+          ratio={ratio}
+          onToggle={toggleSplit}
+        />
+      )}
       {narrow && <Switcher panel={mode} onSelect={onSelect} />}
     </SandpackLayout>
+  );
+}
+
+function SplitSwitcher({
+  stacked,
+  ratio,
+  onToggle,
+}: {
+  stacked: boolean;
+  ratio: number;
+  onToggle: () => void;
+}) {
+  const label = stacked ? 'Split panels vertically' : 'Split panels horizontally';
+
+  return (
+    <div
+      className="absolute right-2 z-20 flex rounded-md border border-fd-border bg-fd-background p-0.5 shadow-sm"
+      style={{ top: stacked ? `calc(${ratio}% + 1.25rem)` : '0.5rem' }}>
+      <button
+        type="button"
+        aria-label={label}
+        title={label}
+        className="flex size-9 cursor-pointer items-center justify-center rounded border-none bg-transparent text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
+        onClick={onToggle}>
+        {stacked ? <Columns2 className="size-4" /> : <Rows2 className="size-4" />}
+      </button>
+    </div>
   );
 }
 

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -12,7 +12,8 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
@@ -87,11 +88,13 @@ class Panes extends State {
 
 export default function Sandbox({
   name,
+  label,
   files,
   navigationOpen = false,
   onOpenNavigation,
 }: {
   name: string;
+  label: string;
   files: Record<string, string>;
   navigationOpen?: boolean;
   onOpenNavigation?: () => void;
@@ -138,6 +141,7 @@ export default function Sandbox({
       customSetup={{ dependencies }}
       style={{ height: '100%' }}>
       <Layout
+        label={label}
         navigationOpen={navigationOpen}
         onOpenNavigation={onOpenNavigation}
       />
@@ -146,9 +150,11 @@ export default function Sandbox({
 }
 
 function Layout({
+  label,
   navigationOpen,
   onOpenNavigation,
 }: {
+  label: string;
   navigationOpen: boolean;
   onOpenNavigation?: () => void;
 }) {
@@ -162,6 +168,35 @@ function Layout({
     toggleSplit,
     layout,
   } = Panes.use();
+  const [layoutElement, setLayoutElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [tabs, setTabs] = useState<HTMLElement | null>(null);
+  const connectLayout = useCallback(
+    (element: HTMLDivElement | null) => {
+      layout(element);
+      setLayoutElement(element);
+    },
+    [layout]
+  );
+  useEffect(() => {
+    if (!layoutElement) {
+      setTabs(null);
+      return;
+    }
+
+    const update = () =>
+      setTabs(
+        layoutElement.querySelector<HTMLElement>(
+          '.sp-tabs-scrollable-container'
+        )
+      );
+    const observer = new MutationObserver(update);
+
+    update();
+    observer.observe(layoutElement, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [layoutElement]);
   const sandpack = useSandpack();
   const refreshOnSave = {
     key: 'Mod-s',
@@ -180,17 +215,9 @@ function Layout({
 
   return (
     <SandpackLayout
-      ref={layout}
+      ref={connectLayout}
       style={{ flexDirection: stacked ? 'column' : 'row' }}
-      className={`relative h-full [--sp-layout-height:100%] ${onOpenNavigation && !navigationOpen ? 'sandbox-navigation-trigger' : ''}`}>
-      {onOpenNavigation && !navigationOpen && (
-        <button
-          aria-label="Open examples navigation"
-          className="absolute top-1.5 left-1.5 z-20 flex size-7 items-center justify-center rounded-md border border-fd-border bg-fd-background text-fd-muted-foreground shadow-sm hover:bg-fd-muted hover:text-fd-foreground"
-          onClick={onOpenNavigation}>
-          <PanelLeftOpen className="size-4" />
-        </button>
-      )}
+      className="relative h-full [--sp-layout-height:100%]">
       <SandpackCodeEditor
         style={{
           display: showEditor ? 'flex' : 'none',
@@ -198,6 +225,19 @@ function Layout({
         }}
         extensionsKeymap={[refreshOnSave]}
       />
+      {onOpenNavigation &&
+        !navigationOpen &&
+        tabs &&
+        createPortal(
+          <button
+            aria-label={`Open examples navigation for ${label}`}
+            className="order-first mr-1 flex max-w-40 shrink-0 items-center gap-1.5 self-stretch pr-4 pl-3 text-sm font-medium text-fd-muted-foreground hover:text-fd-foreground"
+            onClick={onOpenNavigation}>
+            <PanelLeftOpen className="size-4 shrink-0" />
+            <span className="truncate">{label}</span>
+          </button>,
+          tabs
+        )}
       {!narrow && (
         <div
           role="separator"

--- a/website/app/components/docs/Playground.tsx
+++ b/website/app/components/docs/Playground.tsx
@@ -1,5 +1,9 @@
 import { Link } from 'react-router';
-import { examples, getFiles } from '@/routes/examples/loader';
+import {
+  examples,
+  EXAMPLE_LABELS,
+  getFiles,
+} from '@/routes/examples/loader';
 import Sandbox from '@/components/Sandbox';
 
 interface PlaygroundProps {
@@ -17,7 +21,7 @@ export default function Playground({ of, height = 480 }: PlaygroundProps) {
         style={{ height }}
         className="relative overflow-hidden rounded-xl border border-fd-border">
         <div className="absolute inset-0 flex flex-col">
-          <Sandbox name={of} files={getFiles(of)} />
+          <Sandbox name={of} label={EXAMPLE_LABELS[of]} files={getFiles(of)} />
         </div>
       </div>
       <div className="mt-2 text-right">

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -1,4 +1,6 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { PanelLeftClose, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { NavLink, Outlet } from 'react-router';
 
 import { layoutOptions } from '../home';
@@ -8,41 +10,148 @@ export function meta() {
   return [{ title: 'Examples - Expressive' }];
 }
 
+export interface ExamplesOutletContext {
+  navigationOpen: boolean;
+  openNavigation: () => void;
+}
+
 export default function ExamplesLayout() {
+  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [viewport, setViewport] = useState({ height: '100dvh', offset: 0 });
+
+  useEffect(() => {
+    const media = window.matchMedia('(min-width: 1280px)');
+    const update = () => setNavigationOpen(media.matches);
+
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  useEffect(() => {
+    const visual = window.visualViewport;
+    if (!visual) return;
+
+    let frame = 0;
+    const update = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setViewport({
+          height: `${Math.round(visual.height)}px`,
+          offset: Math.round(visual.offsetTop),
+        });
+      });
+    };
+
+    update();
+    visual.addEventListener('resize', update);
+    visual.addEventListener('scroll', update);
+    return () => {
+      cancelAnimationFrame(frame);
+      visual.removeEventListener('resize', update);
+      visual.removeEventListener('scroll', update);
+    };
+  }, []);
+
+  useEffect(() => {
+    const rootOverflow = document.documentElement.style.overflow;
+    const bodyOverflow = document.body.style.overflow;
+    const bodyMinHeight = document.body.style.minHeight;
+
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
+    document.body.style.minHeight = '0';
+
+    return () => {
+      document.documentElement.style.overflow = rootOverflow;
+      document.body.style.overflow = bodyOverflow;
+      document.body.style.minHeight = bodyMinHeight;
+    };
+  }, []);
+
   return (
-    <HomeLayout {...layoutOptions}>
-      <div className="flex flex-col flex-1 p-6 gap-2 max-w-[1400px] w-full mx-auto xl:flex-row xl:items-stretch xl:gap-6">
-        <Navigation />
-        <Outlet />
+    <HomeLayout
+      {...layoutOptions}
+      className="fixed inset-x-0 top-0 min-h-0 overflow-hidden"
+      style={{
+        height: viewport.height,
+        transform: `translateY(${viewport.offset}px)`,
+      }}>
+      <div className="flex flex-1 min-h-0 p-6 gap-6 max-w-[1400px] w-full mx-auto">
+        {navigationOpen && (
+          <button
+            aria-label="Close examples navigation"
+            className="fixed inset-0 z-40 bg-black/35 xl:hidden"
+            onClick={() => setNavigationOpen(false)}
+          />
+        )}
+        <Navigation
+          open={navigationOpen}
+          onClose={() => setNavigationOpen(false)}
+        />
+        <Outlet
+          context={{
+            navigationOpen,
+            openNavigation: () => setNavigationOpen(true),
+          } satisfies ExamplesOutletContext}
+        />
       </div>
     </HomeLayout>
   );
 }
 
-function Navigation() {
+function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
-    <nav className="flex items-center gap-2 overflow-x-auto ml-3 pb-3 xl:flex-col xl:items-stretch xl:self-start xl:overflow-x-visible xl:overflow-y-auto xl:min-h-0 xl:max-h-[calc(100vh-7rem)] xl:sticky xl:top-6 xl:w-36 xl:shrink-0 xl:ml-0 xl:pb-0 xl:gap-5">
-      {GROUPS.map((group) => (
-        <div
-          className="flex items-center mr-[1.2em] gap-2 xl:flex-col xl:items-stretch xl:mr-0 xl:gap-1"
-          key={group.slug}>
-          <GroupLabel label={group.label} />
-          <div className="contents xl:flex xl:flex-col xl:gap-0.5 xl:ml-2.5 xl:border-l xl:border-fd-border">
-            {(group.children ?? []).map((e) => (
-              <ExampleLink key={e.slug} path={e.path} label={e.label} />
-            ))}
+    <aside
+      className={`${open ? 'flex' : 'hidden'} fixed inset-y-0 left-0 z-50 w-64 flex-col bg-fd-background p-5 shadow-2xl xl:static xl:z-auto xl:w-40 xl:shrink-0 xl:self-stretch xl:bg-transparent xl:p-0 xl:shadow-none`}>
+      <div className="mb-5 flex items-center justify-between xl:mb-4">
+        <span className="text-sm font-semibold">Examples</span>
+        <button
+          aria-label="Collapse examples navigation"
+          className="flex size-8 items-center justify-center rounded-md text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
+          onClick={onClose}>
+          <PanelLeftClose className="hidden size-4 xl:block" />
+          <X className="size-4 xl:hidden" />
+        </button>
+      </div>
+      <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">
+        {GROUPS.map((group) => (
+          <div className="flex flex-col gap-1" key={group.slug}>
+            <GroupLabel label={group.label} />
+            <div className="ml-2.5 flex flex-col gap-0.5 border-l border-fd-border">
+              {(group.children ?? []).map((e) => (
+                <ExampleLink
+                  key={e.slug}
+                  path={e.path}
+                  label={e.label}
+                  onNavigate={() => {
+                    if (window.matchMedia('(max-width: 1279px)').matches)
+                      onClose();
+                  }}
+                />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
-    </nav>
+        ))}
+      </nav>
+    </aside>
   );
 }
 
-function ExampleLink({ path, label }: { path: string; label: string }) {
+function ExampleLink({
+  path,
+  label,
+  onNavigate,
+}: {
+  path: string;
+  label: string;
+  onNavigate: () => void;
+}) {
   return (
     <NavLink
       to={`/examples/${path}`}
-      className="py-1.5 px-3 rounded-md border border-fd-border text-sm no-underline text-fd-muted-foreground select-none whitespace-nowrap hover:text-fd-foreground hover:border-fd-muted-foreground aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] aria-[current=page]:border-[color-mix(in_srgb,var(--accent)_45%,transparent)] aria-[current=page]:text-(--accent) xl:border-0 xl:border-l-2 xl:border-l-transparent xl:rounded-l-none xl:rounded-r-sm xl:-ml-px xl:hover:bg-fd-muted xl:hover:border-l-fd-muted-foreground xl:aria-[current=page]:border-l-(--accent)">
+      onClick={onNavigate}
+      className="-ml-px rounded-r-sm border-l-2 border-l-transparent py-1.5 px-3 text-sm no-underline text-fd-muted-foreground select-none whitespace-nowrap hover:border-l-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground aria-[current=page]:border-l-(--accent) aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] aria-[current=page]:text-(--accent)">
       {label}
     </NavLink>
   );
@@ -50,10 +159,8 @@ function ExampleLink({ path, label }: { path: string; label: string }) {
 
 function GroupLabel({ label }: { label: string }) {
   return (
-    <span className="flex items-center self-stretch text-xs font-semibold uppercase tracking-widest text-fd-foreground whitespace-nowrap bg-fd-background sticky left-0 z-[1] xl:static xl:mb-1.5 xl:pl-2 xl:text-xs xl:text-fd-muted-foreground">
+    <span className="mb-1.5 pl-2 text-xs font-semibold uppercase tracking-widest text-fd-muted-foreground whitespace-nowrap">
       {label}
-      <span className="w-0.5 inline-block h-[2.2em] rounded-xs ml-3 mr-1 bg-fd-border xl:hidden" />
-      <span className="absolute left-full top-0 bottom-0 w-2 pointer-events-none bg-[linear-gradient(to_right,var(--color-fd-background),transparent)] xl:hidden" />
     </span>
   );
 }

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -1,5 +1,5 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { PanelLeftClose, X } from 'lucide-react';
+import { PanelLeftClose } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet } from 'react-router';
 
@@ -27,6 +27,21 @@ export default function ExamplesLayout() {
     media.addEventListener('change', update);
     return () => media.removeEventListener('change', update);
   }, []);
+
+  useEffect(() => {
+    if (!navigationOpen) return;
+
+    const close = (event: KeyboardEvent) => {
+      if (
+        event.key === 'Escape' &&
+        window.matchMedia('(max-width: 1279px)').matches
+      )
+        setNavigationOpen(false);
+    };
+
+    window.addEventListener('keydown', close);
+    return () => window.removeEventListener('keydown', close);
+  }, [navigationOpen]);
 
   useEffect(() => {
     const visual = window.visualViewport;
@@ -77,14 +92,13 @@ export default function ExamplesLayout() {
         height: viewport.height,
         transform: `translateY(${viewport.offset}px)`,
       }}>
-      <div className="flex flex-1 min-h-0 p-6 gap-6 max-w-[1400px] w-full mx-auto">
-        {navigationOpen && (
-          <button
-            aria-label="Close examples navigation"
-            className="fixed inset-0 z-40 bg-black/35 xl:hidden"
-            onClick={() => setNavigationOpen(false)}
-          />
-        )}
+      <div className="relative flex min-h-0 w-full max-w-[1400px] flex-1 gap-6 p-6 mx-auto">
+        <button
+          aria-label="Close examples navigation"
+          className={`${navigationOpen ? 'pointer-events-auto bg-black/45' : 'pointer-events-none bg-black/0'} absolute inset-6 z-40 transition-colors duration-150 ease-out motion-reduce:transition-none xl:hidden`}
+          onClick={() => setNavigationOpen(false)}
+          tabIndex={navigationOpen ? 0 : -1}
+        />
         <Navigation
           open={navigationOpen}
           onClose={() => setNavigationOpen(false)}
@@ -103,15 +117,16 @@ export default function ExamplesLayout() {
 function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
   return (
     <aside
-      className={`${open ? 'flex' : 'hidden'} fixed inset-y-0 left-0 z-50 w-64 flex-col bg-fd-background p-5 shadow-2xl xl:static xl:z-auto xl:w-40 xl:shrink-0 xl:self-stretch xl:bg-transparent xl:p-0 xl:shadow-none`}>
-      <div className="mb-5 flex items-center justify-between xl:mb-4">
+      aria-hidden={!open}
+      inert={!open}
+      className={`${open ? 'translate-x-0 xl:flex' : 'pointer-events-none -translate-x-[calc(100%+1.5rem)] xl:hidden'} absolute inset-y-4 left-6 z-50 flex w-64 flex-col overflow-hidden rounded-lg border border-fd-border bg-fd-background/75 p-5 shadow-2xl backdrop-blur-2xl backdrop-saturate-150 transition-transform duration-[220ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform supports-[backdrop-filter:blur(0)]:bg-fd-background/45 motion-reduce:transition-none xl:static xl:z-auto xl:w-40 xl:shrink-0 xl:translate-x-0 xl:self-stretch xl:overflow-visible xl:rounded-none xl:border-0 xl:bg-transparent xl:p-0 xl:shadow-none xl:backdrop-blur-none xl:backdrop-saturate-100 xl:transition-none`}>
+      <div className="mb-4 hidden items-center justify-between xl:flex">
         <span className="text-sm font-semibold">Examples</span>
         <button
           aria-label="Collapse examples navigation"
           className="flex size-8 items-center justify-center rounded-md text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
           onClick={onClose}>
-          <PanelLeftClose className="hidden size-4 xl:block" />
-          <X className="size-4 xl:hidden" />
+          <PanelLeftClose className="size-4" />
         </button>
       </div>
       <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">

--- a/website/app/routes/examples/loader.ts
+++ b/website/app/routes/examples/loader.ts
@@ -13,6 +13,9 @@ Object.entries(
 });
 
 export const GROUPS = structure(MANIFESTS);
+export const EXAMPLE_LABELS = Object.fromEntries(
+  leaves(GROUPS).map(({ path, label }) => [path, label])
+);
 
 // `*/**/*` requires at least one folder under examples/ - skips top-level
 // SPA scaffolding (package.json, vite.config.ts, main.tsx, etc.).

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { Navigate, useOutletContext, useParams } from 'react-router';
 import type { ExamplesOutletContext } from './layout';
-import { examples, getFiles, REDIRECT } from './loader';
+import { examples, EXAMPLE_LABELS, getFiles, REDIRECT } from './loader';
 
 const Sandbox = lazy(() => import('@/components/Sandbox'));
 
@@ -22,6 +22,7 @@ export default function CodeSample() {
           }>
           <Sandbox
             name={name}
+            label={EXAMPLE_LABELS[name]}
             files={getFiles(name)}
             navigationOpen={navigationOpen}
             onOpenNavigation={openNavigation}

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -1,11 +1,14 @@
 import { lazy, Suspense } from 'react';
-import { Navigate, useParams } from 'react-router';
+import { Navigate, useOutletContext, useParams } from 'react-router';
+import type { ExamplesOutletContext } from './layout';
 import { examples, getFiles, REDIRECT } from './loader';
 
 const Sandbox = lazy(() => import('@/components/Sandbox'));
 
 export default function CodeSample() {
   const name = useParams()['*'];
+  const { navigationOpen, openNavigation } =
+    useOutletContext<ExamplesOutletContext>();
 
   if (!name || !examples[name])
     return <Navigate to={`/examples/${REDIRECT}`} replace />;
@@ -17,7 +20,12 @@ export default function CodeSample() {
           fallback={
             <div className="text-fd-muted-foreground">Loading sandbox...</div>
           }>
-          <Sandbox name={name} files={getFiles(name)} />
+          <Sandbox
+            name={name}
+            files={getFiles(name)}
+            navigationOpen={navigationOpen}
+            onOpenNavigation={openNavigation}
+          />
         </Suspense>
       </div>
     </div>

--- a/website/app/routes/home/Comparison.tsx
+++ b/website/app/routes/home/Comparison.tsx
@@ -25,6 +25,7 @@ export function Comparison() {
           right={[
             { label: 'Hooks', code: HookCode },
             { label: 'Zustand', code: ZustandCode },
+            { label: 'XState', code: XStateCode },
             { label: 'Jotai', code: JotaiCode },
             { label: 'Redux', code: ReduxCode },
             { label: 'MobX', code: MobxCode },
@@ -103,6 +104,39 @@ const ZustandCode = code /*tsx*/`
   function useFooBarBaz() {
     const [store] = useState(makeStore);
     return useStore(store);
+  }
+
+  function Widget() {
+    const { foo, bar, baz, bump } = useFooBarBaz();
+
+    return (
+      <button onClick={bump}>
+        {foo} · {bar} · {String(baz)}
+      </button>
+    );
+  }
+`;
+
+const XStateCode = code /*tsx*/`
+  import { createStoreHook } from '@xstate/store-react';
+  import React from 'react';
+
+  const useFooBarBazStore = createStoreHook({
+    context: { foo: 0, bar: 'hello', baz: true },
+    on: {
+      bump: context => ({
+        ...context,
+        foo: context.foo + 1,
+      }),
+    },
+  });
+
+  function useFooBarBaz() {
+    const [{ foo, bar, baz }, store] =
+      useFooBarBazStore(state => state.context);
+    const bump = () => store.trigger.bump();
+
+    return { foo, bar, baz, bump };
   }
 
   function Widget() {

--- a/website/app/routes/home/Hero.tsx
+++ b/website/app/routes/home/Hero.tsx
@@ -13,7 +13,7 @@ export function Hero() {
         <div className="min-w-0 lg:row-start-1">
           <h1 className="font-display tracking-tight mb-6">
             <span className="block whitespace-nowrap text-[clamp(1rem,4.7vw,1.4rem)] font-semibold leading-[1.05] text-fd-foreground/70">
-              Managed state for React
+              Class-based state for React
             </span>
             <span className="block mt-4 text-[clamp(1.9rem,9.5vw,3rem)] font-bold leading-[0.98] sm:text-5xl lg:leading-[1.05]">
               <span className="block whitespace-nowrap">More application,</span>


### PR DESCRIPTION
## Summary

- make the examples workspace fill the iPad visual viewport and stay above the software keyboard without introducing page-level overflow
- add side-by-side and stacked sandbox layouts with a floating split-direction control over the preview
- replace mouse-only resizing with pointer and keyboard controls, including a 44px touch target
- keep split view available on iPad-sized viewports while retaining Code/Preview tabs on narrow phones
- replace the tablet examples strip with collapsible navigation and show comparison columns from the tablet breakpoint

## Why

The examples workspace previously used layout-viewport sizing, a mouse-only divider, and phone-style single-panel behavior on some iPads. The software keyboard could cover or overflow the sandbox, the divider was difficult to manipulate by touch, and users could not choose a top/bottom split.

## Impact

iPad users can keep editing while the software keyboard is open, choose the split direction that fits the current orientation, and resize panels with touch or keyboard input. Desktop behavior remains split by default, while narrow phones continue to use the single-panel selector.

## Validation

- `cd website && bun run types:check`
- `git diff --check`

Real-device iPad Safari verification is still recommended for software-keyboard geometry.