### PR TITLE
test: cover transparent writes through tracking proxies

### DIFF
--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -907,6 +907,62 @@ describe('get method', () => {
       expect(effect).toBeCalledTimes(2);
     });
 
+    it('will update when assigned through proxy', async () => {
+      class Test extends State {
+        value = 'foo';
+      }
+
+      const test = Test.new();
+      let proxy!: Test;
+
+      const effect = mock((state: Test) => {
+        proxy = state;
+        void state.value;
+      });
+
+      test.get(effect);
+
+      expect(proxy).not.toBe(test);
+      expect(Object.getPrototypeOf(proxy)).toBe(test);
+
+      proxy.value = 'bar';
+
+      await expect(test).toHaveUpdated('value');
+
+      expect(test.value).toBe('bar');
+      expect(effect).toBeCalledTimes(2);
+    });
+
+    it('will update when assigned through nested proxy', async () => {
+      class Child extends State {
+        value = 'foo';
+      }
+
+      class Test extends State {
+        child = new Child();
+      }
+
+      const test = Test.new();
+      let child!: Child;
+
+      const effect = mock((state: Test) => {
+        child = state.child;
+        void child.value;
+      });
+
+      test.get(effect);
+
+      expect(child).not.toBe(test.child);
+      expect(Object.getPrototypeOf(child)).toBe(test.child);
+
+      child.value = 'bar';
+
+      await expect(test.child).toHaveUpdated('value');
+
+      expect(test.child.value).toBe('bar');
+      expect(effect).toBeCalledTimes(2);
+    });
+
     it('will subscribe deeply', async () => {
       class Parent extends State {
         value = 'foo';

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -776,6 +776,50 @@ describe('State.get', () => {
       expect(didRender).toBeCalledTimes(3);
     });
 
+    it('will update when assigned through proxy', async () => {
+      class Test extends State {
+        value = 'foo';
+      }
+
+      const test = Test.new();
+      const didRender = mock();
+
+      const Inner = () => {
+        const state = Test.get();
+
+        didRender();
+
+        return (
+          <button
+            onClick={() => {
+              state.value = 'bar';
+            }}>
+            {state.value}
+          </button>
+        );
+      };
+
+      const element = render(
+        <Provider for={test}>
+          <Inner />
+        </Provider>
+      );
+
+      const button = element.getByRole('button');
+
+      expect(button.textContent).toBe('foo');
+      expect(didRender).toBeCalledTimes(1);
+
+      await act(async () => {
+        button.click();
+        await expect(test).toHaveUpdated('value');
+      });
+
+      expect(test.value).toBe('bar');
+      expect(didRender).toBeCalledTimes(2);
+      expect(button.textContent).toBe('bar');
+    });
+
     it('will use factory with replaced instance', async () => {
       const test1 = Test.new();
       const test2 = Test.new();

--- a/packages/react/src/state.use.test.tsx
+++ b/packages/react/src/state.use.test.tsx
@@ -35,6 +35,50 @@ describe('State.use', () => {
       expect(result.current.value).toBe('bar');
     });
 
+    it('will update when assigned through nested proxy', async () => {
+      class Child extends State {
+        value = 'foo';
+      }
+
+      class Parent extends State {
+        child = new Child();
+      }
+
+      let parent!: Parent;
+      const didRender = mock();
+
+      const Inner = () => {
+        const { is, child } = Parent.use();
+
+        parent = is;
+        didRender();
+
+        return (
+          <button
+            onClick={() => {
+              child.value = 'bar';
+            }}>
+            {child.value}
+          </button>
+        );
+      };
+
+      const element = render(<Inner />);
+      const button = element.getByRole('button');
+
+      expect(button.textContent).toBe('foo');
+      expect(didRender).toBeCalledTimes(1);
+
+      await act(async () => {
+        button.click();
+        await expect(parent.child).toHaveUpdated('value');
+      });
+
+      expect(parent.child.value).toBe('bar');
+      expect(didRender).toBeCalledTimes(2);
+      expect(button.textContent).toBe('bar');
+    });
+
     it('will assign `is` as a circular reference', async () => {
       const { result } = renderHook(() => Test.use());
 


### PR DESCRIPTION
## Why

Writes made through subscription proxies are transparent: a tracking proxy is `Object.create(subject)`, so assigning to a reactive field through it invokes the inherited accessor, lands the write on the real State instance, and dispatches updates to subscribers. Real usage relies on this (e.g. destructuring a nested State from a hook and assigning through it in an event handler), and the behavior is about to be advertised in `skills/` documentation - so it needs to be locked in by tests.

## What

Test-only. Adds explicit coverage in both the core and the React adapter:

**packages/mvc/src/state.test.ts** (`get method > effect`)
- `will update when assigned through proxy` - captures the effect's tracking proxy, asserts it is a distinct object prototyped on the instance, assigns through it, and verifies the underlying value changes, the update dispatches (`toHaveUpdated`), and the effect re-runs.
- `will update when assigned through nested proxy` - same, through a nested State reached via the parent proxy (wrapped by `touch()`), verifying the child's value updates and its subscribers are notified.

**packages/react/src/state.get.test.tsx** (`reactive context`)
- `will update when assigned through proxy` - a component renders `Test.get()` and an event handler assigns through the returned proxy; the write reaches the instance and the component re-renders with the new value.

**packages/react/src/state.use.test.tsx** (`hook`)
- `will update when assigned through nested proxy` - a component destructures a nested State from `Parent.use()`, an event handler assigns through the destructured child proxy, and the component re-renders with the new value.

## Note: pre-existing `State.get()` nested-refresh gap

While writing these, I found the nested-destructure case cannot be tested against `State.get()`: a component reading `Parent.get().child.value` does not re-render when only the child's field changes - even for a plain write to the raw instance. The write itself is fully transparent (the child updates and `toHaveUpdated` resolves), but the `State.get()` hook only calls its refresh when the watched (parent) subject reports changed keys (`if (changed.length) update()` in `packages/react/src/state.get.ts`), and a child-only update surfaces no parent events. `State.use()` refreshes unconditionally, so the nested React test lives there. This gap is out of scope here and may deserve its own issue, since `skills/SKILL.md` describes nested destructuring as subscribing to child fields.

No changeset - test-only change per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)