### PR TITLE
docs: restructure skills around golden-path refactor algorithm

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -282,12 +282,12 @@ PascalCase methods become reactive subcomponents - but they are **extension poin
 
 ## Rules & Counter-Rules
 
-Every broad rule here has a locality constraint. Apply both halves.
+Every broad rule here has a locality constraint. Apply both halves. When auditing a result, weigh findings by the severity labels defined in [react/refactor.md](react/refactor.md) - invariant, default, heuristic, style - and never fail a heuristic on its numerical signal alone.
 
 | Rule                                                        | Counter-rule                                                                                                                        |
 | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Reactive fields are assigned directly                       | Keep a method when the write validates, normalizes, coordinates fields, or triggers behavior. Delete methods whose body is only `this.x = value`. |
-| Derived values become getters                               | Only when shared by multiple consumers, semantic to the domain, or part of the state's API. Single-consumer display derivations live in the consuming component. |
+| Derived values become getters                               | Only when shared by multiple consumers, semantic to the domain, expensive, or a deliberate part of the state's API/introspection surface. Single-consumer display derivations live in the consuming component - but judge meaning, not reference counts. |
 | Contextual components read via `.get()`                     | Pure presentation components may still take plain props. Context replaces drilled *state*, not every value.                          |
 | PascalCase subcomponents compose renders                    | Only for genuine extension points a subclass would replace or wrap. Implementation scopes are freestanding FCs using `.get()`.        |
 | Extract long conditional JSX (~10+ lines or ~5+ levels)     | Keep branches together when they share dependencies, read locally, and contain no nested logic.                                      |

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expressive-mvc
-description: Class-based reactive state management for Expressive MVC, React adapters, and router usage. Covers State API, instructions, Component class, lifecycle, patterns, and codebase auditing.
+description: Class-based reactive state management for React (Expressive MVC). Use when writing or refactoring React state - converting useState/useEffect/useMemo hooks, fixing prop drilling, choosing state ownership (State vs Component), dependency snapshots, presence boundaries with get(true), Provider/context, async suspense, router - and when auditing a codebase for fit.
 ---
 
 # Expressive MVC
@@ -12,9 +12,45 @@ Class-based reactive state for React and Preact. State classes define reactive p
 | Package              | Status    | Description                                                       |
 | -------------------- | --------- | ----------------------------------------------------------------- |
 | `@expressive/react`  | Published | React adapter. Primary import for State, Component, instructions. |
-| `@expressive/mvc`  | Published | Framework-agnostic core. Rarely imported directly.                |
+| `@expressive/mvc`    | Published | Framework-agnostic core. Rarely imported directly.                |
 | `@expressive/preact` | Private   | Thin wrapper over React adapter via preact/hooks. Prerelease.     |
 | `@expressive/router` | Private   | Host-agnostic, class-based router built on MVC. Prerelease.       |
+
+## Start With Ownership, Not APIs
+
+The most common failure when adopting this library is translating hooks one-for-one before deciding who owns each behavior. Resolve ownership first; APIs come second.
+
+For every stateful concern, pick exactly one owner:
+
+- **`Component`** - state intrinsic to one display subtree: controls, shells, panels, editors, review/confirm surfaces. Usually defines `render()`. Fields, handlers, and rendering live on one class.
+- **`State`** - headless model or workflow: network operations, domain rules, cross-view coordination. Views subscribe via `State.get()` / `State.use()`.
+- **Plain function component** - simple presentation, or trivial local UI state. Not everything needs a class.
+
+Counter-rules:
+
+- Do not create `FooState` plus `FooView` just because hooks were present. If the behavior and rendering are one unit, `class Foo extends Component` is the refactor.
+- Avoid `Component` where a provided `State` suffices - Components carry React instance surface (`props`, `state`, `setState`, `forceUpdate`) that makes `.get()` IntelliSense noisier.
+- A render-less `Component` (children pass through while providing context and boundary placement) is only for cases where React tree placement is the feature: route controllers, progressive boundaries.
+- A provided State implicitly provides its child States - prefer `theme = new Theme()` on an existing owner over stacking Providers for every small controller.
+
+## Golden-Path Refactor Algorithm
+
+**Before refactoring existing React code, read [react/refactor.md](react/refactor.md)** - it expands every step with before/after examples and ends with the review checklist. The short form:
+
+1. Identify lifecycle and ownership boundaries before translating any hooks.
+2. Separate headless workflow state from display-intrinsic state.
+3. Choose `State`, `Component`, or a plain function component for each owner.
+4. Provide state classes directly (`<Provider for={AppState}>`); never create an instance only to provide it.
+5. Move source fields and behavioral methods first; do not mechanically translate setters.
+6. Keep shared, semantic derivations as getters; leave single-consumer display derivations in their consuming component.
+7. Let contextual children call `.get()` themselves instead of receiving drilled props.
+8. At every `.get()` / `.use()`, destructure an exact nested dependency snapshot.
+9. Assign directly through subscribed proxies; use `is` only to retain the root object alongside sibling destructuring.
+10. Gate optional children at the call site; inside, assert requirements with `.get(true)`.
+11. Extract long conditional JSX into named scopes, then consolidate scopes that share dependencies and hold no nested logic.
+12. Audit the result against the checklist in [react/refactor.md](react/refactor.md).
+
+Write output in the conventions of [react/style.md](react/style.md). They are opinion, not semantics - but they exist to keep reactive dependencies auditable, and the golden path applies them by default.
 
 ## Core API
 
@@ -52,62 +88,40 @@ counter.count; // 1
 
 Properties assigned in the class body are reactive - updates notify subscribers. Methods are auto-bound.
 
-### Instructions & Helpers
+### Instructions & Reactive Helpers
 
-Field initializers and helper values that configure reactive behavior. Each has multiple overloads - see linked docs for full details.
+Field initializers that configure reactive behavior. Each has multiple overloads - fetch the reference when a task needs them.
 
-#### `def()` - Custom Property
+| Helper  | Use for                                                                                                | Reference                  |
+| ------- | ------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `set()` | Defaults, placeholders (suspend until assigned), lazy/async factories (suspense), setter callbacks and validation | [field/set.md](field/set.md) |
+| `get()` | Context lookup between States - required or optional upstream, downstream collection                   | [field/get.md](field/get.md) |
+| `ref()` | Mutable refs (`.current`), ref callbacks with cleanup, ref proxies                                      | [field/ref.md](field/ref.md) |
+| `hot()` | Keyed reactivity for a plain array or object without extracting a State class                           | [field/hot.md](field/hot.md) |
+| `def()` | Low-level custom property behavior                                                                      | [field/def.md](field/def.md) |
 
-| Form           | Behavior                                                                                                    |
-| -------------- | ----------------------------------------------------------------------------------------------------------- |
-| `def(factory)` | Primitive instruction. Factory receives `(key, subject, state)`. Return config object, cleanup fn, or void. |
+For **computed values**, declare a normal class getter - getters on a State subclass are auto-promoted to memoized, dependency-tracked properties. See [state/computed.md](state/computed.md) for tracking rules and when a derivation should *not* be a getter.
 
-#### `set()` - Values, Factories & Validation
+Do not pass a bare promise to `set()`. Use `set(() => promise)` or `set(async () => value)` so work starts during activation/access instead of construction.
 
-| Form                  | Behavior                                                       |
-| --------------------- | -------------------------------------------------------------- |
-| `set<T>()`            | Placeholder. Suspends on access until assigned.                |
-| `set(value)`          | Default value. Non-enumerable, writable.                       |
-| `set(() => v)`        | Lazy factory. Read-only. If async, suspends.                   |
-| `set(() => v, false)` | Lazy factory. Returns `undefined` while pending (no suspense). |
-| `set(() => v, true)`  | Eager factory. Runs immediately on init.                       |
-| `set(value, cb)`      | Default with setter callback. `throw false` to reject.         |
-| `set(() => v, cb)`    | Factory with setter callback. Makes writable.                  |
+```tsx
+class UserProfile extends State {
+  userId = set<string>();
 
-For **reactive computed values**, declare a normal class getter (e.g. `get total() { ... }`). Getters on a State subclass are auto-promoted to memoized, dependency-tracked properties.
+  user = set(async () => {
+    const res = await fetch(`/api/users/${this.userId}`);
+    return res.json();
+  });
 
-Do not pass a direct promise to `set()`. Use `set(() => promise)` or `set(async () => value)` so work starts during activation/access instead of construction, which avoids leaked work from abandoned instances.
+  email = set('', (value) => {
+    if (!value.includes('@')) throw false;
+  });
 
-#### `get()` - Context Lookup
-
-| Form                     | Behavior                                         |
-| ------------------------ | ------------------------------------------------ |
-| `get(Type)`              | Required upstream lookup. Throws if missing.     |
-| `get(Type, false)`       | Optional upstream. Returns `T \| undefined`.     |
-| `get(Type, cb)`          | Upstream with callback. Return cleanup function. |
-| `get(Type, true)`        | Downstream collection. Returns `readonly T[]`.   |
-| `get(Type, true, cb)`    | Downstream collection with per-child callback.   |
-| `get(Type, true, true)`  | Single downstream child. Required.               |
-| `get(Type, true, false)` | Single downstream child. Optional.               |
-
-#### `ref()` - Mutable References
-
-| Form                | Behavior                                                |
-| ------------------- | ------------------------------------------------------- |
-| `ref<T>()`          | Mutable ref with `.current`. Like `useRef`.             |
-| `ref<T>(cb)`        | Ref with callback on set. Return cleanup.               |
-| `ref<T>(cb, false)` | Ref callback also fires for `null`.                     |
-| `ref(this)`         | Ref proxy - creates refs for all enumerable properties. |
-| `ref(this, mapFn)`  | Custom ref proxy with transform per key.                |
-
-#### `hot()` - Reactive Arrays & Objects
-
-| Form          | Behavior                                                             |
-| ------------- | -------------------------------------------------------------------- |
-| `hot(array)`  | Wraps a dense array so index, length, and method reads are reactive. |
-| `hot(object)` | Wraps an object so property reads are reactive.                      |
-
-`hot()` is a reactive helper, not a field instruction. It may be used without attaching a state, or in conjunction with instructions (such as set). Use it when an object or array needs keyed reactivity without extracting a dedicated `State` class.
+  get displayName() {
+    return `${this.user.firstName} ${this.user.lastName}`;
+  }
+}
+```
 
 ### React Hooks
 
@@ -118,7 +132,7 @@ function Existing({ counter }: { counter: Counter }) {
   return <button onClick={increment}>{count}</button>;
 }
 
-// Local state - creates instance, subscribes to accessed fields
+// Local state - creates instance, owns lifecycle, subscribes to accessed fields
 function MyComponent() {
   const { count, increment } = Counter.use();
   return <button onClick={increment}>{count}</button>;
@@ -131,19 +145,119 @@ function Child() {
 }
 ```
 
-Use `use(subject)` for externally-owned observables or State instances. It returns a tracking proxy on the initial render, re-subscribes when `subject` is replaced, activates an unready observable, and does not destroy the subject on unmount.
+Use `use(subject)` for externally-owned observables. Use `State.use()` when the component should create and own the instance. Use `State.get()` when the instance comes from context. See [react/react.md](react/react.md) for overloads (optional lookup, required values, computed selector).
 
-Always prefer destructuring `State.use()` / `State.get()`. If the raw instance is needed, destructure and alias `is` (`is: counter`). Nested observable reads are proxied and tracked automatically, so nested destructuring subscribes to child State fields; do not call `use(child)` when the child was reached through the parent proxy.
+## The Dependency Snapshot
+
+Open every subscribing component by destructuring the exact reactive values it renders - nested ones included. Nested observable reads are proxied and tracked automatically, so nested destructuring subscribes to child fields; never call `use(child)` on an object reached through a parent proxy.
 
 ```tsx
-const {
-  comment: {
-    value: comment,
-  },
-} = Counter.use();
+function OrderSummary() {
+  const {
+    status,
+    customer: {
+      name,
+      address: {
+        city,
+      } = {},
+    },
+  } = Order.get();
+
+  return <p>{name} ({city ?? 'no address'}) - {status}</p>;
+}
 ```
 
-### Component Class
+This is the norm, not a preference:
+
+1. The component's complete dependency surface is visible at the top - reviewable at a glance.
+2. Each trapped getter is traversed once, instead of re-walking `order.customer.address.city` in every expression.
+3. Reads create subscriptions. A deep read buried in a conditional branch subscribes only on renders where that branch runs - a **conditional subscription**. Hoisting reads into the snapshot makes the dependency surface deterministic.
+
+Optional nested objects take in-place defaults (`= {}`) rather than a separate unwrap step. The same rule applies to `this` inside `Component.render()` and subcomponents.
+
+## Transparent Writes
+
+Subscription proxies pass assignments through to the real instance - no unwrapping needed:
+
+```tsx
+const form = LoginForm.get();          // whole object is the only need - take it directly
+
+<input
+  value={form.username}
+  onChange={(e) => (form.username = e.target.value)}
+/>
+```
+
+Nested objects reached through a snapshot are equally writable:
+
+```tsx
+const { transfer, confirmed } = ReviewStep.get();
+
+<button onClick={() => (transfer.step = 'generate')} disabled={!confirmed} />
+```
+
+Use `is` **only** when retaining the root object alongside sibling values from the same snapshot:
+
+```tsx
+const { is: review, confirmed, hasBlocking } = ReviewStep.get();
+```
+
+Do not unwrap every writable object through `is` - that is the most common misuse.
+
+## Presence Boundaries & `get(true)`
+
+When a child's content requires values that may not exist yet, the parent owns the gate and the child asserts the invariant with `get(true)`:
+
+```tsx
+function SettingsContent() {
+  const { draft } = SettingsState.get();
+
+  return (
+    <div className="settings-layout">
+      <LocationList />
+      {draft && <SettingsEditor />}
+    </div>
+  );
+}
+
+function SettingsEditor() {
+  const {
+    saveSettings,
+    saving,
+    draft: {
+      bankAccount,
+      categoryAccounts,
+    },
+  } = SettingsState.get(true); // Required<T> - throws if an accessed value is undefined
+
+  return <section className="settings-editor">...</section>;
+}
+```
+
+This gives the child a strong contract - no fallback values threaded through its body. Declare gateable fields **optional** (`draft?: SettingsLocation`), not `| null`: the runtime check rejects only `undefined`, and `Required<T>` does not strip `null` from a union (see [react/react.md](react/react.md)).
+
+## Provider & Context
+
+Pass the State class directly. If no preconfiguration or external ownership is needed, do not create an instance only to provide it:
+
+```tsx
+<Provider for={TransferState}>
+  <TransferPage />
+</Provider>
+```
+
+Provide an instance only when it is genuinely owned elsewhere:
+
+```tsx
+const counter = Counter.use();
+<Provider for={counter}>
+  <Child />
+</Provider>
+```
+
+Multiple states: `<Provider for={{ app: AppState, user: UserState }}>`. See [react/react.md](react/react.md) for `is` callbacks, fallback, and field props.
+
+## Component Class
 
 A `Component` is a `State` that renders itself. It provides context automatically and supports suspense/error boundaries.
 
@@ -161,112 +275,39 @@ class CounterView extends Component {
   }
 }
 
-// Use directly in JSX
 <CounterView />;
 ```
 
-### Provider & Context
+PascalCase methods become reactive subcomponents - but they are **extension points**, not a general decomposition tool. The test: would a subclass reasonably replace or wrap this renderer? If not, use a freestanding function component that calls `MyComponent.get()`. See [react/component.md](react/component.md).
 
-```tsx
-// Provide state to descendants
-<Provider for={Counter}>
-  <Child />
-</Provider>;
+## Rules & Counter-Rules
 
-// Or with explicit instance
-const counter = Counter.use();
-<Provider for={counter}>
-  <Child />
-</Provider>;
-```
+Every broad rule here has a locality constraint. Apply both halves.
 
-### Common Patterns
-
-```tsx
-// Async data with Suspense
-class UserProfile extends State {
-  userId = set<string>();
-  user = set(async () => {
-    const res = await fetch(`/api/users/${this.userId}`);
-    return res.json();
-  });
-}
-
-// Computed values (reactive - auto-tracks dependencies)
-class Cart extends State {
-  items = set<Item[]>([]);
-  get total() {
-    return this.items.reduce((sum, i) => sum + i.price, 0);
-  }
-}
-
-// Setter callback (validation)
-class Form extends State {
-  email = set('', (value) => {
-    if (!value.includes('@')) throw false; // reject update
-  });
-}
-```
-
-### Choosing State vs Component
-
-Before extracting state, decide who owns the behavior:
-
-- Use `Component` when state is intrinsic to display logic: controls, shells, panels, editors, canvases, toasts. Usually that means defining `render()`.
-- A `Component` without `render()` passes children through while still providing itself to context and acting as Suspense/ErrorBoundary placement. Use that only when React tree placement matters: route controllers, progressive `Boundary` wrappers, or repeated contextual owners.
-- Use `State` for headless models/controllers, even if they are only useful in context. A provided State or Component implicitly provides its child States, so prefer `public theme = new Theme()` over stacking Providers for every small controller.
-- Avoid `Component` when a provided `State` would suffice; Components carry React instance surface (`props`, `state`, `context`, `setState`, `forceUpdate`) that can make `.get()` IntelliSense noisier.
-- Keep plain function components for simple presentation or trivial local UI state.
-
-Do not create a separate `FooState` plus `FooView` just because hooks were present. If the behavior and rendering are one unit, `class Foo extends Component` is the better refactor.
-
-### Refactoring React Hooks
-
-Do not translate hooks one-for-one. First identify the owner, then model it as either a `Component` or a display-agnostic `State`:
-
-- Values directly written by user input, browser events, timers, or network callbacks become mutable class fields.
-- Values derived from those fields become class getters, not extra fields kept in sync by effects.
-- `useEffect` setup/teardown becomes `protected new()` with a returned cleanup function.
-- `useCallback` handlers become auto-bound class methods.
-- If the state is only meaningful for that component's own UI, put those fields and methods directly on a `Component` subclass.
-- If the state is a headless model, keep it in a `State` subclass and have React components call `State.use()` / `State.get()` or attach it to component's controller.
-- If tree placement, rendering, boundaries, or subcomponents are the point, make it a `Component`.
-
-```tsx
-class Viewport extends State {
-  width = window.innerWidth;
-
-  get compact() {
-    return this.width < 720;
-  }
-
-  protected new() {
-    const update = () => {
-      this.width = window.innerWidth;
-    };
-
-    window.addEventListener('resize', update);
-    return () => window.removeEventListener('resize', update);
-  }
-}
-
-function LayoutBadge() {
-  const { width, compact } = Viewport.use();
-
-  return <span>{compact ? 'Compact' : `Wide (${width}px)`}</span>;
-}
-```
+| Rule                                                        | Counter-rule                                                                                                                        |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Reactive fields are assigned directly                       | Keep a method when the write validates, normalizes, coordinates fields, or triggers behavior. Delete methods whose body is only `this.x = value`. |
+| Derived values become getters                               | Only when shared by multiple consumers, semantic to the domain, or part of the state's API. Single-consumer display derivations live in the consuming component. |
+| Contextual components read via `.get()`                     | Pure presentation components may still take plain props. Context replaces drilled *state*, not every value.                          |
+| PascalCase subcomponents compose renders                    | Only for genuine extension points a subclass would replace or wrap. Implementation scopes are freestanding FCs using `.get()`.        |
+| Extract long conditional JSX (~10+ lines or ~5+ levels)     | Keep branches together when they share dependencies, read locally, and contain no nested logic.                                      |
+| `is` retains the raw instance                               | Only alongside sibling destructuring from the same snapshot. Writes through proxies are transparent; nested objects need no unwrapping. |
 
 ## File Reference
 
-Fetch these for detailed API documentation when the task requires deeper knowledge.
+Fetch these for detailed documentation when the task requires deeper knowledge. **Read `react/refactor.md` in full before any hook-migration or refactor task.**
+
+### Golden path
+
+- [react/refactor.md](react/refactor.md) - the refactor algorithm expanded: ownership triage, mechanical-setter and prop-drilling anti-patterns, single-consumer getters, dependency snapshots and conditional subscriptions, presence boundaries, restrained `is`, subcomponent overuse, extract-then-consolidate, review checklist
+- [react/style.md](react/style.md) - style profile: snapshot formatting, affirmative conditions, render fallthrough vs operational guards
 
 ### State (core)
 
 - [state/state.md](state/state.md) - State class, instantiation, properties, methods, events, context
 - [state/get.md](state/get.md) - Instance `.get()` method: read values, run effects, context lookup
 - [state/set.md](state/set.md) - Instance `.set()` method: write values, listen to updates, events, destroy
-- [state/computed.md](state/computed.md) - Reactive class getters: tracking, caching, inheritance, suspense
+- [state/computed.md](state/computed.md) - Reactive class getters: tracking, caching, inheritance, suspense, when a derivation should stay local
 - [state/lifecycle.md](state/lifecycle.md) - Construction, activation, operation, destruction phases
 - [state/context.md](state/context.md) - Context system, global root, home context, ownership rules
 - [state/types.md](state/types.md) - TypeScript type aliases and utility types
@@ -281,9 +322,9 @@ Fetch these for detailed API documentation when the task requires deeper knowled
 
 ### React
 
-- [react/react.md](react/react.md) - use(), State.use(), State.get(), Provider, Consumer, ForceRefresh
-- [react/component.md](react/component.md) - Component class, props, children, render composition (subclass renders wrap base as `props.children`, or a base defers to let a subclass replace it), subcomponents, error boundaries
-- [react/patterns.md](react/patterns.md) - Recipes: forms, async, nested state, debounce, effects
+- [react/react.md](react/react.md) - use(), State.use(), State.get() (optional lookup, required values `get(true)`, computed selector), Provider, Consumer, transparent writes, ForceRefresh
+- [react/component.md](react/component.md) - Component class, props, children, render composition, subcomponent extension points, error boundaries
+- [react/patterns.md](react/patterns.md) - Recipes: forms, async, nested state, presence boundary, contextual children, debounce, effects
 
 ### Router
 
@@ -296,32 +337,22 @@ Fetch these for detailed API documentation when the task requires deeper knowled
 
 ## Auditing & Evaluation
 
-When helping a user evaluate Expressive MVC for their project, consider:
+When helping a user evaluate Expressive MVC for their project - see [examples/audit.md](examples/audit.md) for the full guide.
 
 **Good fit signals:**
 
 - Stateful logic scattered across many `useState`/`useEffect`/`useCallback`/`useMemo` calls
 - Complex forms, wizards, or multi-step flows
 - State shared via context that causes excessive re-renders
-- Business logic tangled into component bodies
+- Business logic tangled into component bodies; prop drilling through intermediaries
 - Desire to test state logic independently from React
-- Highly context-dependent and shared logic
-- Custom hooks with significant configuration, callbacks
-- Components with disproportionate amounts of hooks relative to JSX
+- Custom hooks with significant configuration and callbacks
 
 **Poor fit signals:**
 
 - App is mostly server-rendered with minimal client state
 - State is simple enough that `useState` covers it cleanly
 - Team strongly prefers functional-only patterns
-- Existing state solution (Redux, Zustand, etc.) is working well and not causing pain
+- Existing state solution is working well and not causing pain
 
-**Migration approach:**
-
-- Expressive MVC coexists with hooks - no big-bang rewrite needed
-- Start by deciding whether the behavior belongs to one view (`Component`) or to reusable/display-agnostic state (`State`)
-- Treat `State.use()` as the React subscription point for `State` classes, not as a one-for-one hook rewrite
-- Separate mutable source fields from derived getters instead of syncing duplicate state in effects
-- Context sharing via Provider replaces manual `createContext` + `useContext` boilerplate
-
-When auditing existing code, look for components where extracting behavior into a class would reduce hooks count by 3+ and consolidate related logic into methods. Prefer `Component` for display-intrinsic state; prefer `State` for headless controllers.
+**Migration approach:** Expressive MVC coexists with hooks - no big-bang rewrite needed. Start with one complex component, decide its owner (`Component` vs `State`), and follow [react/refactor.md](react/refactor.md). When auditing existing code, look for components where extracting behavior into a class would reduce hook count by 3+ and consolidate related logic into methods.

--- a/skills/examples/audit.md
+++ b/skills/examples/audit.md
@@ -134,6 +134,8 @@ function ThemeToggle() {
 
 ## Refactor Heuristic
 
+For the full conversion procedure - ownership triage, anti-patterns, and the review checklist - follow [../react/refactor.md](../react/refactor.md). The summary:
+
 For a one-shot hook migration, do not mirror React hooks mechanically. First identify the stateful concept the component is managing, then decide its owner:
 
 - Use `Component` when the concept is display-intrinsic or needs React tree placement.

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -40,6 +40,16 @@ class Counter extends Component {
 
 Properties accessed via `this` in `render()` are reactive - changes trigger re-renders automatically.
 
+When a render reads more than a value or two, destructure everything it reads from `this` at the top - the same dependency-snapshot rule as `.get()` / `.use()` (see [react.md](react.md)). Rendering shares its subscription plumbing with the hooks, so scattered deep reads carry the same conditional-subscription risk:
+
+```tsx
+render() {
+  const { count, step, increment } = this;
+
+  return <button onClick={increment}>{count} (+{step})</button>;
+}
+```
+
 ## Inheritance and Custom Primitives
 
 The primary power of Component: build reusable base classes, extend to specialize.
@@ -334,7 +344,23 @@ class Dashboard extends Component {
 - Accessible from context: `Dashboard.get()` then `<dashboard.Sidebar />`.
 - **Overridable by subclasses** for plug-and-play composition.
 
-They also double as a decomposition tool: pulling a section (a list `.map`, a chunk of chrome) out of `render()` into its own method keeps `render()` a flat composition of named sections. Optional - a judgement call for readability, not a default - but worth reaching for when `render()` is getting busy.
+Subcomponents are **extension points**, not a general decomposition tool. The decision test: **would a subclass reasonably replace or wrap this renderer?** If yes - a `Toggle.Active`, a grid's `Row`, chrome a theme variant swaps out - a subcomponent carries that intent. If no, the section is an implementation scope: keep it a freestanding function component that calls `Dashboard.get()`. Contextual FCs keep dependencies local without inheriting the override machinery, and decomposing a busy `render()` into them costs nothing:
+
+```tsx
+function SidebarItems() {
+  const { items } = Dashboard.get();
+
+  return (
+    <ul>
+      {items.map((i) => (
+        <li key={i}>{i}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Inside a subcomponent body, destructure what it reads from `this` at the top, same as `render()`.
 
 ## Lifecycle
 

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -46,22 +46,24 @@ class LoginForm extends Component {
   }
 
   render() {
+    const { email, password, valid, submit } = this;
+
     return (
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          this.submit();
+          submit();
         }}>
         <input
-          value={this.email}
+          value={email}
           onChange={(e) => (this.email = e.target.value)}
         />
         <input
           type="password"
-          value={this.password}
+          value={password}
           onChange={(e) => (this.password = e.target.value)}
         />
-        <button disabled={!this.valid}>Log In</button>
+        <button disabled={!valid}>Log In</button>
       </form>
     );
   }
@@ -162,6 +164,79 @@ function App() {
       <ThemedWidget />
     </Provider>
   );
+}
+```
+
+## Contextual Children (No Prop Drilling)
+
+Children of a provided state declare their own dependencies with `.get()`. Do not thread state values and callbacks through props:
+
+```tsx
+// Before: parent unpacks state and drills it down
+function Wizard() {
+  const { step, busy, canContinue, advance, retreat } = TransferState.get();
+  return <WizardActions step={step} busy={busy} canContinue={canContinue}
+    onNext={advance} onBack={retreat} />;
+}
+
+// After: the child is contextual - dependencies are local
+function Wizard() {
+  return <WizardActions />;
+}
+
+function WizardActions() {
+  const {
+    busy,
+    canContinue,
+    advance,
+    retreat,
+  } = TransferState.get();
+
+  return (
+    <footer>
+      <button onClick={retreat} disabled={busy}>Back</button>
+      <button onClick={advance} disabled={!canContinue}>Continue</button>
+    </footer>
+  );
+}
+```
+
+Pure presentation components (a `Metric`, a badge) may still take plain props - context replaces drilled state, not every value.
+
+## Presence Boundary
+
+The parent owns whether an optional child exists; the child asserts its requirements with `.get(true)`. Declare the gated field optional (`draft?: T`), not `| null`:
+
+```tsx
+class SettingsState extends State {
+  draft?: SettingsLocation = undefined;
+  saving = false;
+
+  async saveSettings() { ... }
+}
+
+function SettingsContent() {
+  const { draft } = SettingsState.get();
+
+  return (
+    <div className="settings-layout">
+      <LocationList />
+      {draft && <SettingsEditor />}
+    </div>
+  );
+}
+
+function SettingsEditor() {
+  const {
+    saveSettings,
+    saving,
+    draft: {
+      bankAccount,
+      categoryAccounts,
+    },
+  } = SettingsState.get(true);
+
+  return <section className="settings-editor">...</section>;
 }
 ```
 

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -84,17 +84,9 @@ function App() {
 - Component re-renders when any accessed property changes.
 - Instance is destroyed on unmount (context is popped, `set(null)` called).
 - Safe in React strict mode (handles double-mount correctly).
-- Always prefer destructuring `State.use()` / `State.get()`.
-- When the raw instance is needed, destructure `is` and alias it to the state concept (`is: counter`, `is: form`).
-- Nested observable reads are proxied and tracked automatically. Nested destructuring subscribes to child State fields; do not call `use(child)` when the child was reached through the parent proxy.
-
-```tsx
-const {
-  comment: {
-    value: comment,
-  },
-} = Counter.use();
-```
+- Open the component with a dependency snapshot: destructure the exact values it renders, nested ones included (see [Dependency Snapshots](#dependency-snapshots) below).
+- Writes pass through the proxy transparently; `is` is only for retaining the root object alongside sibling destructuring (see [Transparent Writes](#transparent-writes--is) below).
+- Nested observable reads are proxied and tracked automatically; do not call `use(child)` when the child was reached through the parent proxy.
 
 ### Constructor arguments
 
@@ -172,11 +164,40 @@ function Profile() {
 const app = AppState.get(false); // undefined if not in context
 ```
 
-### Required values
+### Required values & presence boundaries
 
 ```tsx
 const app = AppState.get(true); // Required<T>, throws if an accessed value is undefined
 ```
+
+`get(true)` is the child half of a **presence boundary**: the parent owns whether the child renders, and the child asserts that its required values exist. This gives the child a strong contract - no fallback values threaded through its body:
+
+```tsx
+function SettingsContent() {
+  const { draft } = SettingsState.get();
+
+  return (
+    <div className="settings-layout">
+      <LocationList />
+      {draft && <SettingsEditor />}
+    </div>
+  );
+}
+
+function SettingsEditor() {
+  const {
+    saveSettings,
+    saving,
+    draft: {
+      bankAccount,
+      categoryAccounts,
+    },
+  } = SettingsState.get(true);
+  ...
+}
+```
+
+Declare gateable fields **optional** (`draft?: SettingsLocation`), not explicitly nullable (`draft: SettingsLocation | null`). The runtime check rejects only strict `undefined`, and TypeScript's `Required<T>` removes `?` optionality but does not strip `null` from a union - an explicitly nullable field silently defeats `get(true)` on both fronts.
 
 ### Computed selector
 
@@ -221,6 +242,55 @@ const data = AppState.get(($, refresh) => {
 ### Reactive context
 
 If the upstream instance is replaced in context (e.g., Provider re-created), the hook automatically resubscribes to the new instance and refreshes.
+
+---
+
+## Dependency Snapshots
+
+Open every subscribing component by destructuring the exact reactive values it renders - nested levels included, optional objects defaulted in place:
+
+```tsx
+function ReviewNotices() {
+  const {
+    blocking,
+    hasBlocking,
+    result: {
+      wssDownload: {
+        selectedLocationId,
+        usedLogin,
+      } = {},
+    },
+  } = ReviewStep.get();
+  ...
+}
+```
+
+This is the architectural norm, not a formatting preference:
+
+1. The component's complete dependency surface is visible at the top - reviewable at a glance.
+2. Trapped getters are traversed once, instead of re-walking `review.result.wssDownload.usedLogin` in every expression.
+3. Reads create subscriptions. A deep read inside a conditional branch subscribes only on renders where that branch executes (a **conditional subscription**), and reads inside event handlers never subscribe at all. Hoisting reads into the snapshot makes the dependency surface deterministic.
+
+The same rule applies to `this` inside `Component.render()` and subcomponents - rendering shares its subscription plumbing with the hooks.
+
+**Known gap:** updates originating in a *child State* reached through nested destructuring currently refresh `State.use()` but not `State.get()` ([#243](https://github.com/gabeklein/expressive-mvc/issues/243)). Until fixed, values a `.get()` component must react to should surface through getters on the parent state.
+
+## Transparent Writes & `is`
+
+Subscription proxies pass assignments through to the real instance. Three shapes cover every case:
+
+```tsx
+const form = LoginForm.get();                    // whole object is the only need
+onChange={(e) => (form.username = e.target.value)}
+
+const { transfer, confirmed } = ReviewStep.get(); // nested object from a snapshot -
+onClick={() => (transfer.step = 'generate')}      // writes are transparent
+
+const { is: review, confirmed } = ReviewStep.get(); // root object + sibling values:
+                                                     // only here does `is` earn its place
+```
+
+Do not alias `is` merely because something will be written - writes never need the raw instance. Unwrapping nested objects through `is` is noise.
 
 ---
 

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -119,7 +119,7 @@ Audit rule: **delete any method whose body is only `this.field = value`.** It ad
 
 ## 6. Getters: shared and semantic only
 
-A derived value earns a getter on shared state when it is read by multiple consumers, expresses domain or workflow meaning, is expensive enough to merit memoized tracking, or is part of the state's API:
+A derived value earns a getter on shared state when it is read by multiple consumers, expresses domain or workflow meaning, is expensive enough to merit memoized tracking, is a deliberate part of the state's API, or makes the state usefully introspectable (debugging, devtools):
 
 ```tsx
 get hasBlocking() {        // read by notices, actions, and header
@@ -148,6 +148,8 @@ function StepIndicator() {
   ...
 }
 ```
+
+Judge meaning, not reference counts. A getter with one JSX consumer today may still earn its place as a domain capability or an introspectable part of the state surface - a locality finding needs a semantic argument ("this is JSX formatting, not workflow meaning"), never a static count alone.
 
 ## 7. Kill prop drilling
 
@@ -303,16 +305,32 @@ function Exceptions() {
 
 When an early return would skip most of a declared snapshot, that is a signal the gated content wants its own component.
 
+The line/depth threshold is a signal, never grounds for a finding by itself. To fail a branch, name the concrete cost: a conditional subscription, multiple independent decisions in one branch, mixed ownership, a duplicated dependency snapshot, or navigation that a well-named scope would materially improve. "A separate component would be slightly nicer" is optional polish, not a defect.
+
 ## 12. Audit with this checklist
 
-- Is each state field owned at the narrowest useful scope?
-- Does every getter have multiple consumers or semantic API value?
-- Does every method do more than assign one field?
-- Are contextual values still being drilled through props?
-- Does every `.get()` / `.use()` show the exact nested dependency surface?
-- Are any reactive deep reads hidden in conditional branches or handlers?
-- Are nested destructures placed after direct properties?
-- Is `is` used only where the root object must be retained alongside sibling destructuring?
-- Can an optional child be gated by its parent and use `.get(true)`?
-- Are Component subcomponents genuine extension points?
-- Are large JSX branches named without fragmenting trivial shared logic?
+Rules carry different weights - classify every finding by severity:
+
+- **Invariant** - fail unless a real constraint is documented.
+- **Default** - follow unless the alternative has clearer ownership or API value.
+- **Heuristic** - investigate, but never fail on the numerical signal alone; the finding must name a concrete cost.
+- **Style** - apply by default per [style.md](style.md), but report separately from architectural correctness.
+
+The checklist:
+
+- Is each state field owned at the narrowest useful scope? *(invariant)*
+- Does every method do more than assign one field? *(invariant)*
+- Are contextual values still being drilled through props? *(invariant)*
+- Does every `.get()` / `.use()` show the exact nested dependency surface? *(invariant)*
+- Are any reactive deep reads hidden in conditional branches or handlers? *(invariant)*
+- Is `is` used only where the root object must be retained alongside sibling destructuring? *(invariant)*
+- Can an optional child be gated by its parent and use `.get(true)`? *(invariant)*
+- Are Component subcomponents genuine extension points? *(invariant)*
+- Does every getter on shared state earn its place - multiple consumers, domain meaning, expensive computation, deliberate API, or introspection value? *(default - judge meaning, not reference counts)*
+- Are large JSX branches named without fragmenting trivial shared logic? *(heuristic - name the cost)*
+- Are nested destructures placed after direct properties? *(style)*
+
+Auditing notes:
+
+- Compare ownership, dependency surfaces, and write behavior - never filenames, file counts, or similarity to a particular reference implementation. File size and consolidation are project preferences: supplied by the project, scored separately.
+- Report two verdicts - architectural conformance and style-profile adherence - so a formatting miss cannot obscure correct structure, or vice versa.

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -1,0 +1,318 @@
+# Refactoring React to Expressive MVC - The Golden Path
+
+Read this in full before converting hook-based React code. The most common failure is knowing every API yet still translating hooks one-for-one - producing setter methods, drilled props, and over-promoted getters that mirror the old architecture instead of replacing it. Ownership comes first, translation second, and the checklist at the end audits the result.
+
+Examples follow the conventions in [style.md](style.md).
+
+## 1. Identify owners before touching hooks
+
+List the stateful concerns in the code being converted - not the hooks, the *concerns*: a multi-step workflow, a settings draft, a preview toggle, a network resource. Each concern gets exactly one owner. Only after the owner list is stable should any hook be touched.
+
+## 2. Separate headless workflow from display-intrinsic state
+
+Network operations, domain rules, and cross-view coordination are headless - they would exist without this UI. Preview modes, confirmation checkboxes, and selections that only drive one subtree are display-intrinsic. These end up in different classes even when the original component held them in adjacent `useState` calls.
+
+## 3. Choose `State`, `Component`, or a plain FC
+
+- Headless workflow -> `State`, provided via context.
+- Display-intrinsic state -> `Component` owning that subtree, acquiring the workflow through an instruction.
+- Simple presentation -> plain function component.
+
+```tsx
+export class TransferState extends State {
+  step: WizardStep = 'location';
+  busy = false;
+  result: GenerateResponse | null = null;
+
+  get selectedLocation() {
+    return this.locations.find((l) => l.site === this.selectedSite);
+  }
+
+  async generate() { /* network + coordination */ }
+}
+
+export class ReviewStep extends Component {
+  transfer = get(TransferState);
+  previewMode: 'table' | 'raw' = 'table';
+  confirmed = false;
+
+  render() {
+    return (
+      <article className="panel review">
+        <ReviewSummary />
+        <ReviewNotices />
+        <ReviewActions />
+      </article>
+    );
+  }
+}
+```
+
+**Anti-pattern - the reflexive split.** Creating `ReviewState` plus a `ReviewView` FC because the old code had hooks. If the fields exist only to support one rendered surface, they belong on the `Component` that renders it.
+
+**Anti-pattern - subcomponent overuse.** The sections composed in `render()` above are freestanding FCs, not PascalCase methods on the class. Subcomponents (`<this.Header />`) are extension points - machinery for subclasses to replace or wrap. The test: **would a subclass reasonably replace or wrap this renderer?** For ordinary implementation scopes the answer is no, and a freestanding FC calling `ReviewStep.get()` is clearer. See [component.md](component.md).
+
+## 4. Provide classes directly
+
+```tsx
+// Wrong: instance created only to be provided
+function App() {
+  const transfer = TransferState.use();
+  return (
+    <Provider for={transfer}>
+      <TransferPage />
+    </Provider>
+  );
+}
+
+// Right: the class is the Provider target
+function App() {
+  return (
+    <Provider for={TransferState}>
+      <TransferPage />
+    </Provider>
+  );
+}
+```
+
+Provide an instance only when preconfiguration or external ownership genuinely requires it.
+
+## 5. Move source state and behavior; do not translate setters
+
+Mapping for what remains after ownership is settled:
+
+- Values written by user input, browser events, timers, or network callbacks -> mutable class fields.
+- `useMemo` values and effects that only sync state -> class getters.
+- `useEffect` setup/teardown -> `protected new()` returning cleanup.
+- `useCallback` handlers -> auto-bound class methods.
+
+Reactive fields are assigned directly - do not manufacture setters:
+
+```tsx
+// Wrong: hook setters mechanically translated
+class TransferState extends State {
+  username = '';
+
+  setUsername(value: string) {
+    this.username = value;
+  }
+}
+
+// Right: assignment is the API
+onChange={(event) => (transfer.username = event.target.value)}
+```
+
+Keep a method when the write enforces policy - validation, normalization, coordinating fields, triggering behavior:
+
+```tsx
+setStartDate(startDate: string) {
+  this.range = {
+    startDate,
+    endDate: this.range.endDate && this.range.endDate < startDate
+      ? startDate
+      : this.range.endDate,
+  };
+}
+```
+
+Audit rule: **delete any method whose body is only `this.field = value`.** It adds vocabulary without adding policy.
+
+## 6. Getters: shared and semantic only
+
+A derived value earns a getter on shared state when it is read by multiple consumers, expresses domain or workflow meaning, is expensive enough to merit memoized tracking, or is part of the state's API:
+
+```tsx
+get hasBlocking() {        // read by notices, actions, and header
+  return this.blocking > 0;
+}
+
+get hasSavedWssAccess() {  // domain meaning, multiple consumers
+  ...
+}
+```
+
+A calculation feeding a single view belongs in that view, next to its snapshot:
+
+```tsx
+// Wrong: display-only value promoted to shared state
+class TransferState extends State {
+  get selectedStepIndex() {
+    return STEPS.indexOf(this.step);
+  }
+}
+
+// Right: the one consumer derives it locally
+function StepIndicator() {
+  const { step } = TransferState.get();
+  const index = STEPS.indexOf(step);
+  ...
+}
+```
+
+## 7. Kill prop drilling
+
+Contextual children declare their own dependencies with `.get()`. Do not preserve the prop contracts the hook implementation needed:
+
+```tsx
+// Wrong: converted, but still carries the old plumbing
+function ReviewActions({
+  confirmed,
+  hasBlocking,
+  busy,
+  onConfirm,
+  onDownload,
+  onBack,
+}: ReviewActionsProps) { ... }
+
+// Right: dependencies are local
+function ReviewActions() {
+  const {
+    confirmed,
+    hasBlocking,
+    downloadIif,
+    transfer,
+  } = ReviewStep.get();
+  ...
+}
+```
+
+Pure presentation components (a `Metric`, a `StatusCallout`) may still take plain props - context replaces drilled *state*, not every value.
+
+## 8. Destructure an exact dependency snapshot
+
+Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place:
+
+```tsx
+// Wrong: deep reads scattered through JSX, one hidden in a branch
+function JournalOverview() {
+  const review = ReviewStep.get();
+
+  return (
+    <section>
+      <dd>{review.result.artifact.config.accountFile}</dd>
+      <dd>{new Date(review.result.artifact.generatedAt).toLocaleString()}</dd>
+      {review.showRaw && <pre>{review.result.iif}</pre>}
+    </section>
+  );
+}
+
+// Right: the full dependency surface, declared once at the top
+function JournalOverview() {
+  const {
+    showRaw,
+    result: {
+      iif,
+      artifact: {
+        generatedAt,
+        config: {
+          accountFile,
+        },
+      },
+    },
+  } = ReviewStep.get();
+  ...
+}
+```
+
+Three reasons this is the norm:
+
+1. A reviewer sees the component's complete dependency surface at the top.
+2. Trapped getters are traversed once instead of re-walked per expression.
+3. Reads create subscriptions - a deep read inside a branch subscribes only on renders where the branch runs (a **conditional subscription**), and reads inside event handlers never subscribe at all. The snapshot makes the surface deterministic.
+
+The same applies to `this` inside `Component.render()` and subcomponents: destructure what the section reads at the top - the rendering shares its subscription plumbing with the hooks.
+
+## 9. Write through the proxy; use `is` sparingly
+
+Subscription proxies pass assignments through to the real instance. Three shapes cover every case:
+
+```tsx
+const transfer = TransferState.get();            // whole object is the only need
+
+const { transfer, confirmed } = ReviewStep.get(); // nested object from a snapshot -
+onClick={() => (transfer.step = 'generate')}      // writes are transparent
+
+const { is: review, confirmed } = ReviewStep.get(); // root object + sibling values:
+                                                     // only here does `is` earn its place
+```
+
+**Anti-pattern:** aliasing `is` whenever anything will be written. Writes do not need the raw instance - unwrapping nested objects through `is` is noise.
+
+## 10. Put presence gates at the call site
+
+When content requires values that may not exist yet, the parent owns the render gate and the child asserts its invariant with `.get(true)`:
+
+```tsx
+// Wrong: child destructures a maybe-value and bails internally
+function SettingsEditor() {
+  const { draft, saving } = SettingsState.get();
+  if (!draft) return null;
+  ...
+}
+
+// Right: parent gates, child asserts
+function SettingsContent() {
+  const { draft } = SettingsState.get();
+
+  return (
+    <div className="settings-layout">
+      <LocationList />
+      {draft && <SettingsEditor />}
+    </div>
+  );
+}
+
+function SettingsEditor() {
+  const {
+    saveSettings,
+    saving,
+    draft: {
+      bankAccount,
+      categoryAccounts,
+    },
+  } = SettingsState.get(true);
+  ...
+}
+```
+
+Declare gateable fields optional (`draft?: SettingsLocation`), not `| null` - `get(true)` rejects only `undefined`, and `Required<T>` does not strip `null` from unions.
+
+## 11. Extract, then consolidate
+
+A conditional JSX branch above roughly ten lines or five component levels is a signal to give it its own named scope - a heuristic, not a mandate. Then apply the inverse: **recombine scopes that share the same dependencies, read locally, and contain no nested decision logic.** Splitting every fragment creates navigation overhead without clarifying ownership.
+
+```tsx
+// Consolidated: both branches read the same ReviewStep context,
+// neither contains nested logic - one scope, not three
+function Exceptions() {
+  const {
+    exceptions,
+    feeExceptions,
+    hasBlocking,
+  } = ReviewStep.get();
+
+  if (hasBlocking) {
+    return <section className="exceptions">...</section>;
+  }
+
+  if (feeExceptions.length) {
+    return <section className="fees">...</section>;
+  }
+}
+```
+
+When an early return would skip most of a declared snapshot, that is a signal the gated content wants its own component.
+
+## 12. Audit with this checklist
+
+- Is each state field owned at the narrowest useful scope?
+- Does every getter have multiple consumers or semantic API value?
+- Does every method do more than assign one field?
+- Are contextual values still being drilled through props?
+- Does every `.get()` / `.use()` show the exact nested dependency surface?
+- Are any reactive deep reads hidden in conditional branches or handlers?
+- Are nested destructures placed after direct properties?
+- Is `is` used only where the root object must be retained alongside sibling destructuring?
+- Can an optional child be gated by its parent and use `.get(true)`?
+- Are Component subcomponents genuine extension points?
+- Are large JSX branches named without fragmenting trivial shared logic?

--- a/skills/react/style.md
+++ b/skills/react/style.md
@@ -1,0 +1,63 @@
+# Style Profile
+
+These are conventions, not library semantics. They ship with the golden path because they materially improve the auditability of reactive dependency snapshots - the refactor algorithm in [refactor.md](refactor.md) applies them by default. A project may override them; when it does, keep the architectural rules and swap only the formatting.
+
+## Snapshot formatting
+
+- When a destructure contains multiple values, put every binding on its own line.
+- Direct properties come first; nested destructures go at the bottom.
+- Expand nested levels vertically - one key per line, closing braces aligned.
+- Optional nested objects take in-place defaults, not a separate unwrap:
+
+```tsx
+const {
+  blocking,
+  hasBlocking,
+  result: {
+    wssDownload: {
+      selectedLocationId,
+      usedLogin,
+    } = {},
+  },
+} = ReviewStep.get();
+```
+
+## Declaration spacing
+
+- Blank line after a declaration group, before the logic that uses it.
+- Blank line before a standalone `if` that follows other statements.
+- No blank line when an `if` is the first statement of a function or block.
+- Do not separate a chain of consecutive `if` statements.
+
+## Conditions
+
+- Prefer affirmative conditions: test for the state that renders content, not the absence that skips it.
+- Conditional JSX uses `condition && <Node />`, not `condition ? <Node /> : null`.
+- Nullish fallback uses `??` where the distinction from `||` matters.
+
+## Render fallthrough vs operational guards
+
+React accepts `undefined` as an empty render result. A small optional FC uses an affirmative condition and simply falls through when there is nothing to show - no `return null`, no bare terminal `return`:
+
+```tsx
+function ResolvedFeeClassifications() {
+  const { classifications } = ReviewStep.get();
+
+  if (classifications?.length) {
+    return <ul>{classifications.map(...)}</ul>;
+  }
+}
+```
+
+Do not annotate these components as returning `void` - allow inference.
+
+Operational guards are different: a method controlling a workflow uses explicit `return`, because it guards behavior rather than producing a render result:
+
+```tsx
+downloadIif() {
+  if (!this.confirmed || this.hasBlocking) return;
+  ...
+}
+```
+
+If a render guard would skip past most of an already-declared snapshot, the gated content is a candidate for its own component - see step 11 of [refactor.md](refactor.md).

--- a/skills/state/computed.md
+++ b/skills/state/computed.md
@@ -132,6 +132,10 @@ Errors inside a getter are warned and rethrown:
 - On the **initial** compute, the error is logged via `console.warn` with `An exception was thrown while initializing {state}.{key}.` and rethrown to the caller.
 - On a **subsequent** compute (after a dependency change), the error is logged via both `console.warn` (refreshing) and `console.error`. The cached value is not updated, but the read does not throw.
 
+## When to Promote a Derivation
+
+A derived value earns a getter on shared state when it is read by **multiple consumers**, expresses **domain or workflow meaning**, is **expensive** enough to merit memoized tracking, or is part of the state's API. A calculation feeding a single view - a formatted label, a step index, a `canSubmit` for one button - belongs in that component, next to its dependency snapshot. Promoting single-consumer display derivations widens the state's surface without adding meaning; see [../react/refactor.md](../react/refactor.md) step 6.
+
 ## When NOT a Computed
 
 A class-syntax getter is left as a plain JS accessor (not promoted) when:

--- a/skills/state/computed.md
+++ b/skills/state/computed.md
@@ -134,7 +134,7 @@ Errors inside a getter are warned and rethrown:
 
 ## When to Promote a Derivation
 
-A derived value earns a getter on shared state when it is read by **multiple consumers**, expresses **domain or workflow meaning**, is **expensive** enough to merit memoized tracking, or is part of the state's API. A calculation feeding a single view - a formatted label, a step index, a `canSubmit` for one button - belongs in that component, next to its dependency snapshot. Promoting single-consumer display derivations widens the state's surface without adding meaning; see [../react/refactor.md](../react/refactor.md) step 6.
+A derived value earns a getter on shared state when it is read by **multiple consumers**, expresses **domain or workflow meaning**, is **expensive** enough to merit memoized tracking, is a **deliberate part of the state's API**, or makes the state usefully **introspectable** (debugging, devtools). A calculation feeding a single view - a formatted label, a step index, a `canSubmit` for one button - belongs in that component, next to its dependency snapshot. Promoting single-consumer display derivations widens the state's surface without adding meaning - but judge meaning, not reference counts; see [../react/refactor.md](../react/refactor.md) step 6.
 
 ## When NOT a Computed
 


### PR DESCRIPTION
## Why

Dogfooding the library in a production refactor showed the skill contained most of the necessary API information but did not lead an agent to the preferred architecture on a first pass. The failure was ordering and depth, not missing facts: architecture guidance sat below the API catalogue, high-leverage tools (`get(true)`, nested tracking rationale) lived only in deep references that were never consulted, and broad rules ("derived values become getters", "use `is` for the raw instance") lacked the counter-rules that bound them.

## What

**SKILL.md restructured, architecture first.** Ownership decision framework and a 12-step golden-path refactor algorithm now precede the API catalogue, with an explicit directive to read `react/refactor.md` before any hook-migration task. Instruction overload tables are compressed into a one-line-per-helper table pointing at `field/*.md` (they were duplicated verbatim). Three patterns promoted into the entry doc: **dependency snapshots** (exact nested destructure at every `.get()`/`.use()`, conditional-subscription footgun), **presence boundaries** (`get(true)`, optional-over-nullable), and **transparent writes** (restrained `is`). Every broad rule is paired with its locality counter-rule.

**New `react/refactor.md`** - the algorithm in full, each step carrying its before/after anti-pattern (mechanical setters, prop drilling, reflexive State+View splits, subcomponent overuse, single-consumer getters, scattered deep reads, internal nullable bailouts, unnecessary `is`), extract-then-consolidate heuristics for conditional JSX, and the 11-point review checklist.

**New `react/style.md`** - the style profile (snapshot formatting, affirmative conditions, render fallthrough vs operational guards). Labeled as convention rather than library semantics, but applied by default by the golden path: the formatting exists to keep reactive dependency surfaces auditable.

**Reference updates.** `react.md`: presence-boundary expansion of `get(true)` with the null-vs-undefined nuance (#241), dependency-snapshot and transparent-writes sections, known-gap note for #243. `component.md`: subcomponent extension-point decision test ("would a subclass reasonably replace or wrap this renderer?") with contextual-FC alternative; destructure-`this` doctrine in render. `patterns.md`: contextual-children and presence-boundary recipes; examples aligned with snapshots. `computed.md`: when to promote a derivation. `audit.md`: cross-link to the algorithm.

## Verification

Library behaviors the docs now assert were verified against source and locked by tests in #242 (transparent proxy writes). `get(true)` undefined-only semantics traced to `touch()` in `packages/mvc/src/observable.ts`; the open design question is #241. The nested-`get()` refresh gap is #243 and is flagged inline where nested snapshots are taught.

Acceptance test (running separately): a fresh agent against the dogfood project's pre-MVC baseline with only this revised skill, scored on whether the preferred architecture emerges unprompted - direct class Providers, headless workflow State + display-owned Component, contextual FCs, no mechanical setters, no single-consumer getters, exact snapshots, parent-owned presence gating, restrained `is`.

No changeset: `skills/` is not an npm-published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
