### PR TITLE
Refine homepage copy and add rainbow text

### DIFF
--- a/website/app/routes/home/Burst.css
+++ b/website/app/routes/home/Burst.css
@@ -1,0 +1,43 @@
+@keyframes rainbow-burst {
+  0% {
+    opacity: 0;
+    background-position: 100% 50%;
+  }
+  14%, 72% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    background-position: -100% 50%;
+  }
+}
+
+.rainbow-burst-overlay {
+  color: transparent;
+  background: linear-gradient(
+    90deg,
+    #ff375f,
+    #ff9f0a,
+    #ffd60a,
+    #30d158,
+    #64d2ff,
+    #0a84ff,
+    #bf5af2,
+    #ff375f
+  );
+  background-size: 300% 100%;
+  background-clip: text;
+  opacity: 0;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.rainbow-burst-active .rainbow-burst-overlay {
+  animation: rainbow-burst 1100ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rainbow-burst-overlay {
+    animation: none !important;
+  }
+}

--- a/website/app/routes/home/Burst.tsx
+++ b/website/app/routes/home/Burst.tsx
@@ -1,0 +1,43 @@
+import { Component, ref } from '@expressive/react';
+import type React from 'react';
+import './Burst.css';
+
+export class RainbowText extends Component {
+  duration: number | string = 2000;
+  rootMargin = '0px 0px -40% 0px';
+  threshold: number | number[] = 0.75;
+
+  element = ref<HTMLSpanElement>((el) => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        el.classList.add('rainbow-burst-active');
+        observer.disconnect();
+      },
+      { rootMargin: this.rootMargin, threshold: this.threshold }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  });
+
+  render({ children } = {} as { children?: React.ReactNode; }) {
+    const animationDuration = typeof this.duration === 'number'
+      ? `${this.duration}ms`
+      : this.duration;
+
+    return (
+      <span ref={this.element} className="relative inline-block">
+        {children}
+        <span
+          aria-hidden
+          className="rainbow-burst-overlay absolute inset-0"
+          style={{ animationDuration }}>
+          {children}
+        </span>
+      </span>
+    );
+  }
+}

--- a/website/app/routes/home/Component.tsx
+++ b/website/app/routes/home/Component.tsx
@@ -11,9 +11,9 @@ export function ComponentSection() {
             Component is renderable State.
           </h2>
           <p className="text-fd-muted-foreground text-lg mb-4">
-            <code>Component</code> is for self-contained{" "}
+            <code>Component</code> extends <code>State</code> for self-contained{" "}
             (<a href="#molecules" className="underline-offset-2 underline">or extensible</a>) display logic.
-            Fields drive getters and <code>render()</code>{' '} directly -
+            It's renderable in JSX. Fields drive getters and <code>render()</code>{' '} method directly -
             destructure <code>this</code> as you would use hook.
           </p>
           <p className="text-fd-muted-foreground text-lg">

--- a/website/app/routes/home/Rails.tsx
+++ b/website/app/routes/home/Rails.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import Reveal from '@/components/Reveal';
+import { RainbowText } from './Burst';
 
 const SHED = [
   'swr', 'react-error-boundary', 'immer', 'use-context-selector',
@@ -41,12 +42,15 @@ export function Rails() {
         </div>
 
         <div className="max-w-2xl mb-10">
-          <h3 className="font-display text-2xl md:text-3xl font-bold tracking-tight mb-3">
-            Better architecture, better output.
+          <h3 className="font-display text-2xl md:text-3xl font-bold tracking-tight mb-1">
+            <RainbowText>Vibe code</RainbowText> you can work with.
           </h3>
+          <p className="text-fd-muted-foreground mb-5">
+            How often do you <i>actually</i> review the code? LGTM too.
+          </p>
           <p className="text-fd-muted-foreground text-lg">
             Clear conventions mean a good feature looks the same, whether
-            written by you, your team, or an agent. AI-generated code stays readable and high quality.
+            written by you, your team, or an agent. Generated code stays readable so you can engage too.
           </p>
         </div>
 
@@ -55,13 +59,13 @@ export function Rails() {
             State, derived values, async, and lifecycle live together.
             Composition helps separate concerns into readable chunks.
           </Point>
-          <Point title="Type-safe as a rule" delay={100}>
-            Classes pair naturally with TypeScript and JSDoc, so editors
-            surface types and intent where the work is.
-          </Point>
           <Point title="Less to trace when things break" delay={200}>
             No dependency arrays, stale closures, or complicated interactions.
             A fix starts at the class, not a hunt through wiring.
+          </Point>
+          <Point title="Type-safe as a rule" delay={100}>
+            Classes pair naturally with TypeScript and JSDocs, to
+            surface types and intent where the work is.
           </Point>
           <Point title="Class instances are just objects" delay={300}>
             The instance is the source of truth. Log it, assert on it, or bind


### PR DESCRIPTION
## What changed

- sharpen the homepage Component and architecture messaging
- add the “Vibe code” rainbow text treatment
- reorder and refine the supporting architecture points

## Impact

The homepage messaging is clearer and gives the generated-code pitch a more distinctive visual moment. This is website-only and does not change any published package API.

## Validation

- `bun run --filter website types:check`
- `bun run --filter website build`