### PR TITLE
fix(react): pin element identity to instance across subscriber proxies

### DIFF
--- a/.changeset/stable-facade-identity.md
+++ b/.changeset/stable-facade-identity.md
@@ -1,0 +1,6 @@
+---
+"@expressive/mvc": patch
+"@expressive/react": patch
+---
+
+Fix instances rendered through a subscriber proxy (such as from their owner's own render) losing element identity on every re-render, causing React to remount their placement and context teardown to destroy the live instance. The element facade now installs on the real instance so all proxies share one identity, and context teardown only destroys instances the context itself constructed.

--- a/packages/mvc/src/context.ts
+++ b/packages/mvc/src/context.ts
@@ -204,7 +204,7 @@ class Context {
         cleanup.set(K, () => {
           if (dispose) dispose();
           remove();
-          if (state !== V) event(state, null);
+          if (State.is(V)) event(state, null);
         });
       });
     }

--- a/packages/react/src/element.test.tsx
+++ b/packages/react/src/element.test.tsx
@@ -196,6 +196,53 @@ describe('instance element', () => {
     element.unmount();
   });
 
+  it('will keep a child placement across owner renders', async () => {
+    const error = mockError();
+
+    class Child extends Component {
+      value = 'a';
+
+      render() {
+        return <span>{this.value}</span>;
+      }
+    }
+
+    class Owner extends Component {
+      label = '';
+      child = new Child({});
+
+      render() {
+        return (
+          <>
+            <i>{this.label}</i>
+            {this.child}
+          </>
+        );
+      }
+    }
+
+    const owner = Owner.new({});
+    const { child } = owner;
+    const element = render(<>{owner}</>);
+
+    expect(element.container.textContent).toBe('a');
+
+    await act(async () => {
+      owner.label = '!';
+    });
+
+    expect(child.get(null)).toBe(false);
+
+    await act(async () => {
+      child.value = 'b';
+    });
+
+    expect(element.container.textContent).toBe('!b');
+    expect(error).not.toBeCalled();
+
+    element.unmount();
+  });
+
   it('will warn when rendering one instance twice as siblings', () => {
     const error = mockError();
     const instance = Control.new({ value: 'first' });

--- a/packages/react/src/element.ts
+++ b/packages/react/src/element.ts
@@ -15,6 +15,8 @@ let template: any;
 
 Object.defineProperty(Component.prototype, '$$typeof', {
   get(this: Component) {
+    const self = this.is;
+
     if(!template) template = Runtime.createElement('template');
 
     const descriptors = Object.getOwnPropertyDescriptors(template);
@@ -28,11 +30,11 @@ Object.defineProperty(Component.prototype, '$$typeof', {
         Object.getOwnPropertyDescriptors(store)
       );
 
-    Object.defineProperties(this, {
+    Object.defineProperties(self, {
       ...descriptors,
       $$typeof: { value: template.$$typeof },
-      key: { value: this.key },
-      type: { value: Element.bind(this) }
+      key: { value: self.key },
+      type: { value: Element.bind(self) }
     });
 
     return template.$$typeof;


### PR DESCRIPTION
Fixes a latent #247 defect, surfaced during #240's integration review: **an instance rendered through a subscriber proxy is silently destroyed by its owner's re-renders.**

## The failure

Whenever an owner renders an owned instance from its own `render()` — `{this.child}`, or any read that flows through the subscriber proxy — the value handed to JSX is a *proxy* (`Object.create(instance)`), not the instance. Two compounding faults turned that into destruction:

1. **`element.ts`**: the lazy `$$typeof` getter installed the element rewrite on whatever object read it — the proxy. Each re-render creates a fresh proxy, so each re-render minted a fresh `Element.bind(proxy)` — a new element `type` identity — and React unmounted and remounted the placement every time the owner rendered.
2. **`context.ts`**: the unmounting placement pops its context, whose teardown decides "did I construct this state?" by `state !== V`. A proxy-keyed input fails that identity check the same way a class input does, so teardown destroyed the **live, externally-owned instance**.

Net effect: `owner.label = '!'` → child destroyed. The regression test pins exactly this: an owner rendering `{this.child}` re-renders on an unrelated field, and the child must survive and stay reactive.

## The fix

- `element.ts`: the `$$typeof` getter defers to `this.is` — the rewrite always lands on the real instance, so every proxy (present and future) inherits one stable element identity. No remounts.
- `context.ts`: teardown destroys only when the input was a **class** the context constructed from (`State.is(V)`), the semantic the identity comparison was approximating.

Both #247's borrow contract ("unmount never destroys an externally owned instance") and Provider-owned destruction semantics are preserved — the full workspace suite is green (mvc 561, router 213, react 221, preact 143).

Sequencing: #240 (`feat/map-instruction`) rebases onto this once merged — its spawned-collection rendering exercises this path constantly and its eviction feature is what exposed the destruction (previously the destroyed instances lingered in collections, masking the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
