### PR TITLE
fix: nested-read reactivity in State.get and activation over foreign props

### DIFF
--- a/.changeset/activation-non-configurable.md
+++ b/.changeset/activation-non-configurable.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix a crash when a bare-constructed instance (`new X()`, not `X.new()`) activates after a foreign non-configurable own property has been installed on it - for example a React element internal like `_owner`, added by the render facade when a not-yet-activated `Component` is dropped into JSX and activated in place. Activation's field sweep now converts only *configurable* value properties into reactive ones, leaving anything non-configurable untouched instead of throwing on `defineProperty`.

--- a/.changeset/get-nested-reactivity.md
+++ b/.changeset/get-nested-reactivity.md
@@ -1,0 +1,5 @@
+---
+"@expressive/react": patch
+---
+
+Fix `State.get()` failing to re-render a component when it reads a *nested* reactive value - a child State's field, or a `map`/`has` entry - through the returned instance. The refresh was gated on the root instance's own change events, which are empty when only a nested value changes, so those updates were dropped (regressed by an earlier "optimized State.get" refactor that replaced a first-run flag with an `if (changed.length)` guard). It now refreshes on any observed change after the initial render, restoring the prior behavior. This lets a function component subscribe to a single nested value (e.g. one map entry) and repaint in isolation.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -5,6 +5,7 @@ import { get } from './field/get';
 import { ref } from './field/ref';
 import { set } from './field/set';
 import { State, update } from './state';
+import { event } from './observable';
 
 it('will extend custom class', () => {
   class Subject extends State {
@@ -2544,6 +2545,31 @@ describe('new method (static)', () => {
 
     expect(test).not.toHaveProperty('notManaged');
     expect(test).not.toHaveProperty('notMethod');
+  });
+});
+
+describe('activation', () => {
+  // A foreign non-configurable own property (e.g. React element internals
+  // like `_owner`, installed on the instance by the render facade before a
+  // bare-constructed Component activates) must not crash activation: the
+  // field sweep can only convert configurable value properties, and should
+  // leave anything else untouched rather than throw on defineProperty.
+  it('will ignore non-configurable own value properties', () => {
+    class Test extends State {
+      value = 1;
+    }
+
+    const test = new Test();
+
+    Object.defineProperty(test, '_foreign', {
+      value: {},
+      enumerable: true,
+      configurable: false,
+      writable: false
+    });
+
+    expect(() => event(test)).not.toThrow();
+    expect(test.value).toBe(1);
   });
 });
 

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -493,7 +493,7 @@ function init(state: State, ...args: State.Args) {
   function observe() {
     for (const key in state) {
       const desc = Object.getOwnPropertyDescriptor(state, key)!;
-      if ('value' in desc) apply(state, key, desc, true);
+      if ('value' in desc && desc.configurable) apply(state, key, desc, true);
     }
   }
 

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -1101,3 +1101,36 @@ describe('State.get - computed dependency', () => {
     expect(hook.result.current).toBe('3/6');
   });
 });
+
+describe('State.get - nested dependency', () => {
+  // Reading a nested reactive value through get() - a child State's field
+  // (or a map entry) - used to never refresh: the nested change fires with
+  // the root's own events empty, and the refresh guard keyed on those events
+  // (`if (changed.length)`, added by c0dffdbf) dropped it. Restored to
+  // refresh on any observed change after the initial run.
+  it('will refresh when observing a nested state field', async () => {
+    class Child extends State {
+      value = 0;
+    }
+
+    class Parent extends State {
+      child = new Child();
+    }
+
+    const parent = Parent.new();
+    const didRender = mock();
+    const hook = renderWith(parent, () => {
+      didRender();
+      return Parent.get().child.value;
+    });
+
+    expect(hook.result.current).toBe(0);
+
+    await act(async () => {
+      parent.child.value = 5;
+    });
+
+    expect(hook.result.current).toBe(5);
+    expect(didRender).toBeCalledTimes(2);
+  });
+});

--- a/packages/react/src/state.get.ts
+++ b/packages/react/src/state.get.ts
@@ -110,9 +110,11 @@ State.get = function get<T extends State>(
         return release;
       }
 
+      let first = true;
+
       unwatch = watch(
         next,
-        (current, changed) => {
+        (current) => {
           if (typeof argument === 'function') {
             const next = argument.call(current, current, refresh);
             if (next === value) return;
@@ -121,7 +123,8 @@ State.get = function get<T extends State>(
             value = current;
           }
 
-          if (changed.length) update();
+          if (!first) update();
+          first = false;
         },
         argument === true
       );


### PR DESCRIPTION
Two reactivity defects surfaced while building the `map` examples (extracted to ship independently of that work).

## `State.get()` dropped nested-read updates (`@expressive/react`)
A component reading a **nested** reactive value through `Model.get()` — a child State's field, or a `map`/`has` entry — never re-rendered when only that nested value changed. The hook gated its refresh on the root instance's own change events, which are empty when the change originates in a nested observable.

Regressed by `c0dffdbf` ("optimized State.get method"), which replaced a first-run flag with an `if (changed.length)` guard. This restores the flag: refresh on any observed change after the initial render. `watch()` only fires on real watched-key changes, so there are no spurious renders to suppress.

## Activation crashed over foreign non-configurable props (`@expressive/mvc`)
A bare-constructed instance (`new X()`, not `X.new()`) that activated **after** a foreign non-configurable own property was installed on it — e.g. a React element internal like `_owner`, added by the render facade when a not-yet-activated `Component` is dropped into JSX and activated in place — threw from activation's field sweep (`defineProperty` collision). Activation now converts only *configurable* value properties to reactive ones, leaving anything else untouched.

## Tests
Each fix ships a regression test that fails without it:
- `packages/react/src/state.get.test.tsx` — "nested dependency"
- `packages/mvc/src/state.test.ts` — "activation > will ignore non-configurable own value properties"

Full suite green: mvc 505 · router 214 · react 219 · preact 140 (off `main`). Changesets: `@expressive/react` patch, `@expressive/mvc` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)