### PR TITLE
fix(react): populate Runtime in runtime test regardless of file order

### DIFF
--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -4,6 +4,7 @@ import { State } from '@expressive/mvc';
 import { event, observer, touch } from '@expressive/mvc/observable';
 import { act, renderHook, waitFor } from '@testing-library/react';
 
+import './index';
 import { Runtime, useHook, use } from './runtime';
 
 // useHook calls useRef, useState, useEffect once each per render. Stub Runtime


### PR DESCRIPTION
## Problem

`packages/react/src/runtime.test.ts` imports only `./runtime` — the bare `Runtime` registry object — and never `./index`, which is the module that installs React's hook implementations (`useRef`, `useState`, `useEffect`, `createElement`, …) onto `Runtime` via `Object.assign`.

Its `use()` / `renderHook` tests therefore depend on *some other* test file having imported `./index` first. bun evaluates each test file's top-level imports only when that file's turn to run comes, so whether `Runtime` was populated in time depended on **test-file execution order** — which differs between CI (Linux) and local dev (macOS).

In CI's ordering the five `use()` tests ran against an unpopulated `Runtime`, surfacing as `waitFor` timeouts / stale `hook.result.current` (or `Runtime.useRef is not a function` when fully empty). `main` is currently red for exactly this reason; it is unrelated to any feature branch.

## Fix

Add `import './index'` at the top of the test so it installs the adapter itself and is self-sufficient regardless of file order.

## Verification

- Isolated (`bun test src/runtime.test.ts`), full react suite, and full suite with `--coverage` — all **223 pass / 0 fail** — under **both** bun 1.3.1 (CI's `packageManager` pin) and 1.3.14 (local).
- `tsc --noEmit` clean.
- Before the fix, the isolated run reproduced CI's 5 failures.

Test-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)