### PR TITLE
feat(router)!: reactive query as map instead of hot record

### DIFF
--- a/.changeset/router-query-map.md
+++ b/.changeset/router-query-map.md
@@ -1,0 +1,7 @@
+---
+"@expressive/router": minor
+---
+
+**Breaking:** `Router.query` (and the `Route.query` facade) is now a reactive `map` (`map.Insert<string, string>`) rather than a proxied record. Read a param with `query.get('foo')`, write with `query.set('foo', value)`, and remove with `query.delete('foo')` - each write still navigates by pushing a history entry, exactly as before. Reading a key subscribes to just that param, and URL-driven changes reconcile the same map in place.
+
+Migration: replace property access (`query.foo`, `query.foo = x`, `delete query.foo`) with the map methods above. The per-key `declare query: { ... }` narrowing is removed - a `map` cannot carry an object-shaped key type; `query` is uniformly keyed by `string`.

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -62,26 +62,18 @@ const BlogPost = () => {
 
 Read `matched` (boolean) in render so same-pattern navigations (`/blog/a` → `/blog/b`) reconcile in place instead of remounting.
 
-## Navigation state & the `query` record
+## Navigation state & the `query` map
 
-`Router` exposes location as reactive surfaces - `path`, a `query` record, and a derived `url`. The query string **is state**: read a key to subscribe, write one to navigate.
+`Router` exposes location as reactive surfaces - `path`, a `query` map, and a derived `url`. The query string **is state**: read a key to subscribe, write one to navigate.
 
 ```tsx
 router.goto('/posts?page=2');   // push
 router.goto('/posts', true);    // replace
 router.url = '/posts?page=2';   // assigning url navigates
 
-router.query.page;              // read - subscribes to just this param
-router.query.page = '2';        // write - pushes a new entry, like goto
-delete router.query.sort;       // delete - also navigates
-```
-
-Subclass to declare known params for autocomplete and typo-safety:
-
-```tsx
-class Search extends Router {
-  declare query: { q?: string; page?: string };
-}
+router.query.get('page');       // read - subscribes to just this param
+router.query.set('page', '2');  // write - pushes a new entry, like goto
+router.query.delete('sort');    // delete - also navigates
 ```
 
 ## Links

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -49,21 +49,12 @@ describe('Route', () => {
     expect(view.container.textContent).toBe('id: foo');
   });
 
-  it('exposes the router query, narrowable via declare', () => {
-    class Search extends Route {
-      declare query: { q?: string; page?: string };
-    }
-
-    const route = Search.new();
+  it('exposes the router query', () => {
+    const route = Route.new();
     route.router.goto('/posts?q=hi&page=2');
 
-    // Compile-time: declared keys resolve, unknown keys are rejected.
-    const q: string | undefined = route.query.q;
-    // @ts-expect-error - `nope` is not a declared key
-    route.query.nope;
-
-    expect(q).toBe('hi');
-    expect(route.query.page).toBe('2');
+    expect(route.query.get('q')).toBe('hi');
+    expect(route.query.get('page')).toBe('2');
   });
 
   it('updates in place on same-pattern navigation (instance persists)', async () => {

--- a/packages/router/src/route.tsx
+++ b/packages/router/src/route.tsx
@@ -14,10 +14,10 @@ declare namespace Route {
   /**
    * Param-swap argument for `goto` - the route's path params (`:name` segments
    * of its pattern), as overrides merged over the current match. These are the
-   * `match` namespace, distinct from `query` (the `?search` record): path params
+   * `match` namespace, distinct from `query` (the `?search` map): path params
    * are positional and identify the matched resource, query params refine it.
-   * Lenient `string` keys: path params have no per-route declared type (unlike
-   * `query`), so keys aren't statically checked.
+   * Lenient `string` keys: path params have no per-route declared type, so keys
+   * aren't statically checked.
    */
   type Params = Record<string, string>;
 }
@@ -160,15 +160,9 @@ export class Route extends Component {
   }
 
   /**
-   * Live query record from the active Router. Global (not route-scoped) - every
+   * Live query map from the active Router. Global (not route-scoped) - every
    * Route sees the same params, unlike `match` which is this Route's captures.
-   * Narrow known keys in a subclass via `declare`, same as on Router:
-   *
-   * ```ts
-   * class Search extends Route {
-   *   declare query: { q?: string; page?: string };
-   * }
-   * ```
+   * Read `query.get('foo')`; writes navigate, same as on Router.
    */
   query = set(() => this.router.query);
 

--- a/packages/router/src/router.test.tsx
+++ b/packages/router/src/router.test.tsx
@@ -89,10 +89,10 @@ describe('Router (headless)', () => {
     expect(repeated.entries).toEqual(['/', '/x?a=2']);
   });
 
-  it('query exposes params as a record', () => {
+  it('query exposes params as a map', () => {
     const router = Router.new();
     router.goto('/posts?page=2');
-    expect(router.query.page).toBe('2');
+    expect(router.query.get('page')).toBe('2');
   });
 
   it('direct query mutation pushes a new entry', async () => {
@@ -100,7 +100,7 @@ describe('Router (headless)', () => {
     router.goto('/posts');
     await router.set();
 
-    router.query.page = '2';
+    router.query.set('page', '2');
     await router.set();
 
     expect(router.entries).toEqual(['/', '/posts', '/posts?page=2']);
@@ -118,29 +118,12 @@ describe('Router (headless)', () => {
     expect(router.entries).toEqual(['/', '/posts']);
   });
 
-  it('subclass may narrow query keys via declare (type-level)', () => {
-    class Search extends Router {
-      declare query: { q?: string; page?: string };
-    }
-
-    const router = Search.new();
-    router.goto('/posts?q=hi&page=2');
-
-    // Compile-time: known keys resolve, unknown keys are rejected.
-    const q: string | undefined = router.query.q;
-    // @ts-expect-error - `nope` is not a declared key
-    router.query.nope;
-
-    expect(q).toBe('hi');
-    expect(router.query.page).toBe('2');
-  });
-
   it('query updates reactively when search changes', async () => {
     const router = Router.new();
     const seen: (string | undefined)[] = [];
 
     router.get(state => {
-      seen.push(state.query.page);
+      seen.push(state.query.get('page'));
     });
 
     router.goto('/posts?page=1');
@@ -154,7 +137,7 @@ describe('Router (headless)', () => {
   it('writing a query param pushes a new history entry', async () => {
     const router = Router.new();
     router.goto('/posts?page=1');
-    router.query.page = '2';
+    router.query.set('page', '2');
     await router.set();
 
     expect(router.url).toBe('/posts?page=2');
@@ -165,10 +148,10 @@ describe('Router (headless)', () => {
   it('deleting a query param navigates', async () => {
     const router = Router.new();
     router.goto('/posts?page=2&sort=asc');
-    delete router.query.sort;
+    router.query.delete('sort');
     await router.set();
 
-    expect(router.query.sort).toBeUndefined();
+    expect(router.query.get('sort')).toBeUndefined();
     expect(router.path).toBe('/posts');
   });
 
@@ -178,7 +161,7 @@ describe('Router (headless)', () => {
     router.url = '/b?x=1';
 
     expect(router.path).toBe('/b');
-    expect(router.query.x).toBe('1');
+    expect(router.query.get('x')).toBe('1');
     expect(router.entries).toEqual(['/', '/a', '/b?x=1']);
   });
 
@@ -243,7 +226,7 @@ describe('BrowserRouter', () => {
     expect(window.location.search).toBe('?q=hello');
     expect(router.current.path).toBe('/results');
     expect(router.current.url).toBe('/results?q=hello');
-    expect(router.current.query.q).toBe('hello');
+    expect(router.current.query.get('q')).toBe('hello');
   });
 
   it('clears the query when navigation drops it', () => {
@@ -262,14 +245,14 @@ describe('BrowserRouter', () => {
     act(() => window.history.pushState(null, '', '/enc?q=a%20b'));
     await router.current.set();
 
-    expect(router.current.query.q).toBe('a b');
+    expect(router.current.query.get('q')).toBe('a b');
     // The query listener must treat %20 and + as equal, not push a corrected dup.
     expect(window.history.length).toBe(len + 1);
   });
 
   it('writing a query param pushes to window.history', async () => {
     act(() => router.current.goto('/page?x=1'));
-    router.current.query.x = '9';
+    router.current.query.set('x', '9');
     await router.current.set();
 
     expect(window.location.search).toBe('?x=9');

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,4 @@
-import { Component, hot } from '@expressive/mvc';
+import { Component, map } from '@expressive/mvc';
 import { listener } from '@expressive/mvc/observable';
 
 import { Route } from './route';
@@ -22,20 +22,14 @@ export class Router extends Component {
   rejected = '';
 
   /**
-   * Canonical query state - a reactive record. Read `query.foo` to track a
-   * param; write `query.foo = ...` (or delete) to navigate: a direct mutation
-   * pushes a new history entry, same as if it arrived via `goto`.
+   * Canonical query state - a reactive map. Read `query.get('foo')` to track a
+   * param; write `query.set('foo', ...)` (or `delete`) to navigate: a direct
+   * mutation pushes a new history entry, same as if it arrived via `goto`.
    *
-   * Values are always `string | undefined` (URL params carry no other type).
-   * A subclass may narrow the known keys by redeclaring with `declare`:
-   *
-   * ```ts
-   * class Search extends Router {
-   *   declare query: { q?: string; page?: string };
-   * }
-   * ```
+   * Keys and values are `string` (URL params carry no other type); a param
+   * that is absent reads back as `undefined`.
    */
-  query = hot({} as Record<string, string | undefined>);
+  query = map<string, string>();
 
   /** In-memory history: visited urls (path + query) and the cursor into them. */
   entries: string[] = [];
@@ -98,13 +92,10 @@ export class Router extends Component {
     this.path = q < 0 ? url : url.slice(0, q);
 
     const { query } = this;
-    const next = Object.fromEntries(
-      new URLSearchParams(q < 0 ? '' : url.slice(q + 1))
-    );
+    const next = new Map(new URLSearchParams(q < 0 ? '' : url.slice(q + 1)));
 
-    for (const key in query) if (!(key in next)) delete query[key];
-
-    Object.assign(query, next);
+    for (const key of [...query.keys()]) if (!next.has(key)) query.delete(key);
+    for (const [key, value] of next) query.set(key, value);
   }
 
   segment(to: string): string {
@@ -213,7 +204,7 @@ function normalize(to: string): string {
 }
 
 /**
- * Re-serialize a url's query through the record model (last value per key,
+ * Re-serialize a url's query through the map model (last value per key,
  * `URLSearchParams` encoding) so it is identical to what the `url` getter emits.
  * This is what makes the history-dedup a sound string comparison.
  */
@@ -221,18 +212,16 @@ function canonicalize(url: string): string {
   const q = url.indexOf('?');
   if (q < 0) return url;
 
-  const search = searchOf(Object.fromEntries(new URLSearchParams(url.slice(q + 1))));
+  const search = searchOf(new Map(new URLSearchParams(url.slice(q + 1))));
   return search ? url.slice(0, q) + '?' + search : url.slice(0, q);
 }
 
 /** Canonical query serialization: skips `undefined`, last-value-per-key, form encoding. */
-function searchOf(query: Record<string, string | undefined>): string {
+function searchOf(entries: Iterable<readonly [string, string | undefined]>): string {
   const params = new URLSearchParams();
 
-  for (const key in query) {
-    const value = query[key];
+  for (const [key, value] of entries)
     if (value !== undefined) params.append(key, value);
-  }
 
   return params.toString();
 }

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -8,7 +8,7 @@ import { Route, Link, NavLinks, Redirect, Router, BrowserRouter } from '@express
 
 ## Mental model
 
-- **`Router`** - the navigation State: current `path`, reactive `query` record, derived `url`, and an in-memory history stack. Headless; touches no browser globals, so it runs and tests anywhere. It is also the memory-router substrate.
+- **`Router`** - the navigation State: current `path`, reactive `query` map, derived `url`, and an in-memory history stack. Headless; touches no browser globals, so it runs and tests anywhere. It is also the memory-router substrate.
 - **`BrowserRouter`** - binds the core to `window.location`/`history`, syncing `path`/`query` on navigation (`goto`, `popstate`, external `pushState`/`replaceState`).
 - **`Route`** - a `Component` that matches part of the URL and renders a page. Routes nest to mirror the URL hierarchy. Each `Route` is a scoped facade over the active `Router` (`path`, `match`, `query`, `goto`, `resolve`).
 - **`Link` / `NavLinks` / `Redirect`** - navigation UI built on `Route`.
@@ -104,7 +104,7 @@ const BlogPost = () => (
 | `route.match`     | `Record<string,string> \| undefined` | Captured params from the current match (`undefined` when unmatched). Stable identity across reads when captures are unchanged. |
 | `route.matched`   | `boolean`                         | Whether this route is active. Read this in render (not `match`) so same-pattern navigations reconcile in place instead of remounting. |
 | `route.path`      | `string`                          | This route's own absolute path (base + segment).                        |
-| `route.query`     | `Record<string,string\|undefined>` | Live query record from the active Router (global, not route-scoped - see below). |
+| `route.query`     | `map.Insert<string,string>`       | Live query map from the active Router (global, not route-scoped - see below). |
 | `route.anchor`    | `string`                          | Directory-style anchor for relative navigation.                         |
 | `route.goto(to)`  | -                                 | Navigate. A string resolves relative to this route; a params object swaps route params in place (see below). |
 | `route.resolve(to)` | `string`                        | Resolve a (possibly relative) url to an absolute pathname.              |
@@ -133,7 +133,7 @@ Param changes do not remount: like `query`, `match` updates reactively and the p
 | Member            | Type                                | Notes                                                                |
 | ----------------- | ----------------------------------- | -------------------------------------------------------------------- |
 | `path`            | `string`                            | Pathname only.                                                       |
-| `query`           | `Record<string,string\|undefined>` | Canonical query state - a reactive record (see below).               |
+| `query`           | `map.Insert<string,string>`         | Canonical query state - a reactive map (see below).                  |
 | `url`             | `string`                            | Full URL (path + `?query`), canonically serialized. Assigning navigates. |
 | `goto(to, replace?)` | -                                | Navigate to an absolute path; `replace` overwrites the current entry instead of pushing. |
 | `back()` / `forward()` | -                              | Move the history cursor.                                             |
@@ -145,40 +145,23 @@ router.url = '/posts?page=2';   // same as goto (push); use goto(to, true) to re
 router.back();
 ```
 
-## The `query` record
+## The `query` map
 
-`query` is the canonical query state as a reactive record - not a string. Read a param to track it; **write** a param (or delete it) to navigate.
+`query` is the canonical query state as a reactive `map` - not a string. Read a param to track it; **write** a param (or delete it) to navigate.
 
 ```tsx
-router.query.page;          // read - subscribes to just this param
-router.query.page = '2';    // write - pushes a new history entry, like goto
-delete router.query.sort;   // delete - also navigates
+router.query.get('page');       // read - subscribes to just this param
+router.query.set('page', '2');  // write - pushes a new history entry, like goto
+router.query.delete('sort');    // delete - also navigates
 ```
 
-Writing or deleting a param pushes a new history entry, exactly as if it arrived via `goto`. URL-driven changes (navigation, popstate) reconcile the same record, so consumers reading `query.foo` re-render only when that param changes.
+Writing or deleting a param pushes a new history entry, exactly as if it arrived via `goto`. URL-driven changes (navigation, popstate) reconcile the same map, so consumers reading `query.get('foo')` re-render only when that param changes.
 
 Notes:
-- Values are always `string | undefined` - URL params carry no other type. Reading an absent key is `undefined`.
+- Keys and values are `string` - URL params carry no other type. Reading an absent key is `undefined`.
 - Single-valued: repeated keys (`?a=1&a=2`) collapse to the last value.
-- `query` is **global** to the Router. On a `Route` it is the same record for every route, unlike `match` which is that route's own captures. (Query strings are not path-scoped.)
+- `query` is **global** to the Router. On a `Route` it is the same map for every route, unlike `match` which is that route's own captures. (Query strings are not path-scoped.)
 - `url` is always canonically serialized (space as `+`, last-value-per-key), so navigation never pushes a spurious duplicate entry due to encoding differences.
-
-### Narrowing known params with `declare`
-
-The default record accepts any string key. A subclass can declare the known params for autocomplete and typo safety - on both `Router` and `Route`:
-
-```tsx
-class Search extends Router {
-  declare query: { q?: string; page?: string };
-}
-
-class SearchRoute extends Route {
-  declare query: { q?: string; page?: string };
-}
-// query.q -> string | undefined; query.unknown -> compile error
-```
-
-Use `declare` (not a re-initializer) so it only retypes the inherited field. Keep declared values `string`-typed - there is no coercion, so `{ page: number }` would be a lie.
 
 ## Links and navigation UI
 


### PR DESCRIPTION
## Summary

Migrates `Router.query` (and the `Route.query` facade) from a `hot`-proxied record to a reactive `map` (`map.Insert<string, string>`). This drops the router's dependency on the `hot` instruction — the first step toward retiring `hot` entirely.

## API change (breaking)

| before | after |
| --- | --- |
| `router.query.foo` | `router.query.get('foo')` |
| `router.query.foo = '2'` | `router.query.set('foo', '2')` |
| `delete router.query.foo` | `router.query.delete('foo')` |

Semantics are unchanged: reading a key subscribes to just that param, and each write still navigates by pushing a history entry. URL-driven changes (navigation, popstate) reconcile the same map in place.

**Removed:** the per-key `declare query: { q?: string }` narrowing. A `map` cannot carry an object-shaped key type, so `query` is now uniformly keyed by `string`. The two type-level tests asserting that narrowing are dropped.

## Internals

- `locate` and `canonicalize` reconcile through the map; last-value-per-key collapse is preserved via `new Map(new URLSearchParams(...))`.
- `searchOf` now takes an entries iterable (the map itself, or a collapsed `Map`).
- `listener(query, …)` is unchanged — the map is observable and drives history pushes exactly as the `hot` proxy did.

## Verification

- 213 router tests pass; 100% line coverage held.
- `tsc --noEmit` clean (the `Route.query = set(() => this.router.query)` type flows through as `map.Insert<string, string>`).

Docs updated in the same PR: `packages/router/README.md` and `skills/router/router.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)