### PR TITLE
feat(website): line numbers + TypeScript IntelliSense in the sandbox

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,10 +106,15 @@
       "name": "website",
       "version": "0.77.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.43.4",
         "@codesandbox/sandpack-react": "^2",
         "@expressive/react": "workspace:*",
         "@orama/orama": "^3.1.18",
         "@react-router/node": "^7.13.0",
+        "@typescript/ata": "^0.9",
+        "@typescript/vfs": "^1",
         "fumadocs-core": "16.6.3",
         "fumadocs-mdx": "14.2.7",
         "fumadocs-ui": "16.6.3",
@@ -685,6 +690,10 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/ata": ["@typescript/ata@0.9.8", "", { "peerDependencies": { "typescript": ">=4.4.4" } }, "sha512-+M815CeDRJS5H5ciWfhFCKp25nNfF+LFWawWAaBhNlquFb2wS5IIMDI+2bKWN3GuU6mpj+FzySsOD29M4nG8Xg=="],
+
+    "@typescript/vfs": ["@typescript/vfs@1.6.4", "", { "dependencies": { "debug": "^4.4.3" }, "peerDependencies": { "typescript": "*" } }, "sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -95,6 +95,28 @@ figure[data-rehype-pretty-code-figure] pre code,
   outline-offset: -2px;
 }
 
+/* IntelliSense signature/doc popover (completion detail + hover). */
+.sp-ts-tooltip {
+  max-width: 34rem;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.sp-ts-signature {
+  display: block;
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+}
+
+.sp-ts-doc {
+  margin-top: 0.375rem;
+  padding-top: 0.375rem;
+  border-top: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  white-space: pre-wrap;
+}
+
 /* Comparison blocks opt out of wrapping - they scroll horizontally instead. */
 .code-nowrap .shiki .line,
 .code-nowrap .shiki code,

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -100,7 +100,114 @@ figure[data-rehype-pretty-code-figure] pre code,
   font-size: 0.85em !important;
 }
 
-/* IntelliSense signature/doc popover (completion detail + hover). */
+/* IntelliSense surfaces live in <body> (see intellisense.ts), so they're styled
+   here rather than through a CodeMirror theme. */
+.cm-tooltip.cm-tooltip-autocomplete,
+.cm-tooltip.cm-completionInfo,
+.cm-tooltip.cm-tooltip-hover {
+  z-index: 60;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 0.5rem;
+  background: var(--color-fd-popover);
+  color: var(--color-fd-popover-foreground);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 0.08),
+    0 12px 32px -12px rgb(0 0 0 / 0.45);
+}
+
+.cm-tooltip.cm-tooltip-autocomplete {
+  padding: 0.25rem;
+  overflow: hidden;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul {
+  max-height: 17rem;
+  min-width: 15rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-fd-border) transparent;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 0.3125rem;
+  line-height: 1.6;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.cm-tooltip-autocomplete .cm-completionLabel {
+  flex: 1;
+  min-width: 0;
+}
+
+/* CM underlines the matched span; weight + color reads cleaner at this size. */
+.cm-tooltip-autocomplete .cm-completionMatchedText {
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.cm-tooltip-autocomplete .cm-completionDetail {
+  flex-shrink: 0;
+  font-style: normal;
+  font-size: 0.9em;
+  color: var(--color-fd-muted-foreground);
+}
+
+.cm-tooltip-autocomplete .cm-completionIcon {
+  width: 1.125em;
+  padding: 0;
+  font-size: 0.9em;
+  opacity: 1;
+  text-align: center;
+}
+
+.cm-completionIcon-function,
+.cm-completionIcon-method {
+  color: #a371f7;
+}
+
+.cm-completionIcon-property,
+.cm-completionIcon-variable,
+.cm-completionIcon-constant {
+  color: #4a9eff;
+}
+
+.cm-completionIcon-class,
+.cm-completionIcon-interface,
+.cm-completionIcon-type,
+.cm-completionIcon-enum {
+  color: #d0a24c;
+}
+
+.cm-completionIcon-keyword,
+.cm-completionIcon-namespace {
+  color: var(--color-fd-muted-foreground);
+}
+
+.cm-tooltip.cm-completionInfo {
+  max-width: 30rem;
+  padding: 0;
+}
+
+.cm-tooltip.cm-completionInfo-right,
+.cm-tooltip.cm-completionInfo-right-narrow {
+  margin-left: 0.375rem;
+}
+
+.cm-tooltip.cm-completionInfo-left,
+.cm-tooltip.cm-completionInfo-left-narrow {
+  margin-right: 0.375rem;
+}
+
 .sp-ts-tooltip {
   max-width: 34rem;
   padding: 0.5rem 0.625rem;

--- a/website/app/app.css
+++ b/website/app/app.css
@@ -95,6 +95,11 @@ figure[data-rehype-pretty-code-figure] pre code,
   outline-offset: -2px;
 }
 
+/* Sandpack sets line numbers to .6em, which reads as tiny beside the code. */
+.sp-code-editor .cm-gutter.cm-lineNumbers {
+  font-size: 0.85em !important;
+}
+
 /* IntelliSense signature/doc popover (completion detail + hover). */
 .sp-ts-tooltip {
   max-width: 34rem;

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -15,8 +15,8 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { createSandboxTs, type SandboxTs } from './sandbox/client';
 import { intellisense } from './sandbox/intellisense';
-import { createTsEnv, type TsEnv } from './sandbox/tsEnv';
 
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
@@ -210,25 +210,43 @@ function Layout({
     },
   };
 
-  // A per-sandbox virtual TS language service powers editor completions and
-  // hovers. Build it once, keep it fed as files change, and hand the extension
-  // live accessors so it always targets the currently-open tab.
+  // A per-sandbox TS language service (in a worker) powers editor completions
+  // and hovers. It's spawned on first use - not mount - so the heavy chunk
+  // stays off the critical path; once alive it's kept fed as files change.
   const { files, activeFile } = sandpack.sandpack;
-  const envRef = useRef<Promise<TsEnv> | undefined>(undefined);
+  const clientRef = useRef<SandboxTs | undefined>(undefined);
   const activeFileRef = useRef(activeFile);
+  const filesRef = useRef(files);
   activeFileRef.current = activeFile;
+  filesRef.current = files;
+
+  const asSource = (source: typeof files) => {
+    const out: Record<string, string> = {};
+    for (const [path, file] of Object.entries(source)) out[path] = file.code;
+    return out;
+  };
+
+  const ensureClient = useCallback(() => {
+    if (!clientRef.current)
+      clientRef.current = createSandboxTs(asSource(filesRef.current));
+    return clientRef.current;
+  }, []);
 
   useEffect(() => {
-    const source: Record<string, string> = {};
-    for (const [path, file] of Object.entries(files)) source[path] = file.code;
-
-    if (!envRef.current) envRef.current = createTsEnv(source);
-    else envRef.current.then((holder) => holder.sync(source));
+    clientRef.current?.sync(asSource(files));
   }, [files]);
 
-  const extensions = useMemo(
-    () => [intellisense(() => envRef.current, () => activeFileRef.current)],
+  useEffect(
+    () => () => {
+      clientRef.current?.dispose();
+      clientRef.current = undefined;
+    },
     [],
+  );
+
+  const extensions = useMemo(
+    () => [intellisense(ensureClient, () => activeFileRef.current)],
+    [ensureClient],
   );
 
   // Below the breakpoint the panels can't fit side by side; show one at a time

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -12,8 +12,11 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+
+import { intellisense } from './sandbox/intellisense';
+import { createTsEnv, type TsEnv } from './sandbox/tsEnv';
 
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
@@ -207,6 +210,27 @@ function Layout({
     },
   };
 
+  // A per-sandbox virtual TS language service powers editor completions and
+  // hovers. Build it once, keep it fed as files change, and hand the extension
+  // live accessors so it always targets the currently-open tab.
+  const { files, activeFile } = sandpack.sandpack;
+  const envRef = useRef<Promise<TsEnv> | undefined>(undefined);
+  const activeFileRef = useRef(activeFile);
+  activeFileRef.current = activeFile;
+
+  useEffect(() => {
+    const source: Record<string, string> = {};
+    for (const [path, file] of Object.entries(files)) source[path] = file.code;
+
+    if (!envRef.current) envRef.current = createTsEnv(source);
+    else envRef.current.then((holder) => holder.sync(source));
+  }, [files]);
+
+  const extensions = useMemo(
+    () => [intellisense(() => envRef.current, () => activeFileRef.current)],
+    [],
+  );
+
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
   const { matches: narrow } = MediaQuery.use({ query: '(max-width: 639px)' });
@@ -219,10 +243,12 @@ function Layout({
       style={{ flexDirection: stacked ? 'column' : 'row' }}
       className="relative h-full [--sp-layout-height:100%]">
       <SandpackCodeEditor
+        showLineNumbers
         style={{
           display: showEditor ? 'flex' : 'none',
           flex: narrow ? '1' : `0 0 ${ratio}%`,
         }}
+        extensions={extensions}
         extensionsKeymap={[refreshOnSave]}
       />
       {onOpenNavigation &&

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -123,6 +123,43 @@ export default function Sandbox({
     return deps;
   }, [files]);
 
+  // The provider below is keyed on theme, so a toggle remounts it. The language
+  // service lives out here instead, where it survives that - spawning the worker
+  // and re-acquiring @types on every toggle would leave IntelliSense cold.
+  const filesRef = useRef(files);
+  filesRef.current = files;
+
+  const ts = useMemo(() => {
+    let client: SandboxTs | undefined;
+
+    return {
+      ensure() {
+        if (!client) {
+          const source: Record<string, string> = {};
+
+          for (const [path, entry] of Object.entries(filesRef.current) as [
+            string,
+            string | { code: string },
+          ][])
+            source[path] = typeof entry === 'string' ? entry : entry.code;
+
+          client = createSandboxTs(source);
+        }
+
+        return client;
+      },
+      sync(next: Record<string, string>) {
+        client?.sync(next);
+      },
+      dispose() {
+        client?.dispose();
+        client = undefined;
+      },
+    };
+  }, []);
+
+  useEffect(() => () => ts.dispose(), [ts]);
+
   // The preview is a cross-origin Sandpack iframe, so we can't set its theme
   // from here - bake it into the hidden entry, which global.css honors via
   // :root[data-theme]. Keyed into the provider so a toggle re-applies it.
@@ -151,6 +188,7 @@ export default function Sandbox({
         label={label}
         navigationOpen={navigationOpen}
         onOpenNavigation={onOpenNavigation}
+        ts={ts}
       />
     </SandpackProvider>
   );
@@ -160,10 +198,15 @@ function Layout({
   label,
   navigationOpen,
   onOpenNavigation,
+  ts,
 }: {
   label: string;
   navigationOpen: boolean;
   onOpenNavigation?: () => void;
+  ts: {
+    ensure(): SandboxTs;
+    sync(files: Record<string, string>): void;
+  };
 }) {
   const {
     onSelect,
@@ -215,43 +258,21 @@ function Layout({
     },
   };
 
-  // A per-sandbox TS language service (in a worker) powers editor completions
-  // and hovers. It's spawned on first use - not mount - so the heavy chunk
-  // stays off the critical path; once alive it's kept fed as files change.
+  // The language service is owned by Sandbox (it outlives this remount); keep it
+  // fed as files change, without spawning it if the editor was never used.
   const { files, activeFile } = sandpack.sandpack;
-  const clientRef = useRef<SandboxTs | undefined>(undefined);
   const activeFileRef = useRef(activeFile);
-  const filesRef = useRef(files);
   activeFileRef.current = activeFile;
-  filesRef.current = files;
-
-  const asSource = (source: typeof files) => {
-    const out: Record<string, string> = {};
-    for (const [path, file] of Object.entries(source)) out[path] = file.code;
-    return out;
-  };
-
-  const ensureClient = useCallback(() => {
-    if (!clientRef.current)
-      clientRef.current = createSandboxTs(asSource(filesRef.current));
-    return clientRef.current;
-  }, []);
 
   useEffect(() => {
-    clientRef.current?.sync(asSource(files));
-  }, [files]);
-
-  useEffect(
-    () => () => {
-      clientRef.current?.dispose();
-      clientRef.current = undefined;
-    },
-    [],
-  );
+    const out: Record<string, string> = {};
+    for (const [path, file] of Object.entries(files)) out[path] = file.code;
+    ts.sync(out);
+  }, [files, ts]);
 
   const extensions = useMemo(
-    () => [intellisense(ensureClient, () => activeFileRef.current)],
-    [ensureClient],
+    () => [intellisense(() => ts.ensure(), () => activeFileRef.current)],
+    [ts],
   );
 
   // Below the breakpoint the panels can't fit side by side; show one at a time

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -18,7 +18,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
 } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -138,9 +137,6 @@ export default function Sandbox({
 
   const ts = useMemo(() => {
     let client: SandboxTs | undefined;
-    let warming = false;
-    const listeners = new Set<() => void>();
-    const emit = () => listeners.forEach((l) => l());
 
     return {
       ensure() {
@@ -154,12 +150,6 @@ export default function Sandbox({
             source[path] = typeof entry === 'string' ? entry : entry.code;
 
           client = createSandboxTs(source);
-          warming = true;
-          emit();
-          client.whenReady.finally(() => {
-            warming = false;
-            emit();
-          });
         }
 
         return client;
@@ -170,14 +160,6 @@ export default function Sandbox({
       dispose() {
         client?.dispose();
         client = undefined;
-        warming = false;
-      },
-      get warming() {
-        return warming;
-      },
-      subscribe(listener: () => void) {
-        listeners.add(listener);
-        return () => listeners.delete(listener);
       },
     };
   }, []);
@@ -230,8 +212,6 @@ function Layout({
   ts: {
     ensure(): SandboxTs;
     sync(files: Record<string, string>): void;
-    warming: boolean;
-    subscribe(listener: () => void): () => void;
   };
 }) {
   const {
@@ -301,12 +281,6 @@ function Layout({
     [ts],
   );
 
-  const warming = useSyncExternalStore(
-    ts.subscribe,
-    () => ts.warming,
-    () => false,
-  );
-
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
   const { matches: narrow } = MediaQuery.use({ query: '(max-width: 639px)' });
@@ -327,14 +301,6 @@ function Layout({
         extensions={extensions}
         extensionsKeymap={[refreshOnSave]}
       />
-      {showEditor && warming && (
-        <div
-          role="status"
-          className="pointer-events-none absolute bottom-3 left-3 z-20 flex items-center gap-2 rounded-md border border-fd-border bg-fd-background/90 px-2.5 py-1.5 text-xs text-fd-muted-foreground shadow-sm backdrop-blur-sm">
-          <span className="size-3 animate-spin rounded-full border-2 border-fd-border border-t-fd-primary" />
-          Loading IntelliSense…
-        </div>
-      )}
       {onOpenNavigation &&
         !navigationOpen &&
         tabs &&

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -12,7 +12,14 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { createPortal } from 'react-dom';
 
 import { createSandboxTs, type SandboxTs } from './sandbox/client';
@@ -131,6 +138,9 @@ export default function Sandbox({
 
   const ts = useMemo(() => {
     let client: SandboxTs | undefined;
+    let warming = false;
+    const listeners = new Set<() => void>();
+    const emit = () => listeners.forEach((l) => l());
 
     return {
       ensure() {
@@ -144,6 +154,12 @@ export default function Sandbox({
             source[path] = typeof entry === 'string' ? entry : entry.code;
 
           client = createSandboxTs(source);
+          warming = true;
+          emit();
+          client.whenReady.finally(() => {
+            warming = false;
+            emit();
+          });
         }
 
         return client;
@@ -154,6 +170,14 @@ export default function Sandbox({
       dispose() {
         client?.dispose();
         client = undefined;
+        warming = false;
+      },
+      get warming() {
+        return warming;
+      },
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
       },
     };
   }, []);
@@ -206,6 +230,8 @@ function Layout({
   ts: {
     ensure(): SandboxTs;
     sync(files: Record<string, string>): void;
+    warming: boolean;
+    subscribe(listener: () => void): () => void;
   };
 }) {
   const {
@@ -275,6 +301,12 @@ function Layout({
     [ts],
   );
 
+  const warming = useSyncExternalStore(
+    ts.subscribe,
+    () => ts.warming,
+    () => false,
+  );
+
   // Below the breakpoint the panels can't fit side by side; show one at a time
   // and reveal a toggle. Inline display wins over Sandpack's own layout CSS.
   const { matches: narrow } = MediaQuery.use({ query: '(max-width: 639px)' });
@@ -295,6 +327,14 @@ function Layout({
         extensions={extensions}
         extensionsKeymap={[refreshOnSave]}
       />
+      {showEditor && warming && (
+        <div
+          role="status"
+          className="pointer-events-none absolute bottom-3 left-3 z-20 flex items-center gap-2 rounded-md border border-fd-border bg-fd-background/90 px-2.5 py-1.5 text-xs text-fd-muted-foreground shadow-sm backdrop-blur-sm">
+          <span className="size-3 animate-spin rounded-full border-2 border-fd-border border-t-fd-primary" />
+          Loading IntelliSense…
+        </div>
+      )}
       {onOpenNavigation &&
         !navigationOpen &&
         tabs &&

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -22,6 +22,7 @@ class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
   stacked = false;
   ratio = 50;
+  dragging = false;
 
   // Hold Ctrl and two-finger swipe to nudge split
   layout = ref<HTMLDivElement>((el) => {
@@ -52,6 +53,8 @@ class Panes extends State {
     const rect = event.currentTarget.parentElement!.getBoundingClientRect();
     const pointerId = event.pointerId;
 
+    this.dragging = true;
+
     const move = (e: globalThis.PointerEvent) => {
       if (e.pointerId !== pointerId) return;
       e.preventDefault();
@@ -62,6 +65,7 @@ class Panes extends State {
     };
     const up = (e: globalThis.PointerEvent) => {
       if (e.pointerId !== pointerId) return;
+      this.dragging = false;
       document.removeEventListener('pointermove', move);
       document.removeEventListener('pointerup', up);
       document.removeEventListener('pointercancel', up);
@@ -170,6 +174,7 @@ function Layout({
     adjust,
     toggleSplit,
     layout,
+    dragging,
   } = Panes.use();
   const [layoutElement, setLayoutElement] = useState<HTMLDivElement | null>(
     null
@@ -310,6 +315,13 @@ function Layout({
               stacked ? 'h-1.5 w-12' : 'h-12 w-1.5'
             }`}
           />
+          {dragging && (
+            <div
+              className={`fixed inset-0 z-50 ${
+                stacked ? 'cursor-row-resize' : 'cursor-col-resize'
+              }`}
+            />
+          )}
         </div>
       )}
       <SandpackPreview

--- a/website/app/components/sandbox/client.ts
+++ b/website/app/components/sandbox/client.ts
@@ -1,0 +1,81 @@
+import type {
+  Command,
+  CompleteResult,
+  Detail,
+  QuickInfo,
+  Response,
+} from './protocol';
+
+export interface SandboxTs {
+  sync(files: Record<string, string>): void;
+  complete(
+    path: string,
+    code: string,
+    pos: number,
+  ): Promise<CompleteResult | null>;
+  details(
+    path: string,
+    pos: number,
+    name: string,
+    source: string | undefined,
+    data: unknown,
+  ): Promise<Detail | null>;
+  quickInfo(
+    path: string,
+    code: string,
+    pos: number,
+  ): Promise<QuickInfo | null>;
+  dispose(): void;
+}
+
+/**
+ * Spawns the TypeScript language service in a worker and exposes it as a set of
+ * promise-returning calls. The worker owns `typescript` and every acquired
+ * `.d.ts`, so none of that touches the main thread - only file text out and
+ * plain result objects back.
+ */
+export function createSandboxTs(files: Record<string, string>): SandboxTs {
+  const worker = new Worker(
+    new URL('./tsserver.worker.ts', import.meta.url),
+    { type: 'module' },
+  );
+
+  let seq = 0;
+  const pending = new Map<number, (value: unknown) => void>();
+
+  worker.addEventListener('message', ({ data }: MessageEvent<Response>) => {
+    const resolve = pending.get(data.id);
+    if (resolve) {
+      pending.delete(data.id);
+      resolve(data.result);
+    }
+  });
+
+  const send = <T>(command: Command): Promise<T> =>
+    new Promise<T>((resolve) => {
+      const id = ++seq;
+      pending.set(id, resolve as (value: unknown) => void);
+      worker.postMessage({ ...command, id });
+    });
+
+  void send({ kind: 'init', files });
+
+  return {
+    sync(files) {
+      void send({ kind: 'sync', files });
+    },
+    complete(path, code, pos) {
+      return send({ kind: 'complete', path, code, pos });
+    },
+    details(path, pos, name, source, data) {
+      return send({ kind: 'details', path, pos, name, source, data });
+    },
+    quickInfo(path, code, pos) {
+      return send({ kind: 'quickInfo', path, code, pos });
+    },
+    dispose() {
+      worker.terminate();
+      pending.clear();
+    },
+  };
+}

--- a/website/app/components/sandbox/client.ts
+++ b/website/app/components/sandbox/client.ts
@@ -7,8 +7,6 @@ import type {
 } from './protocol';
 
 export interface SandboxTs {
-  /** Resolves once the worker's language service has loaded its libs. */
-  whenReady: Promise<void>;
   sync(files: Record<string, string>): void;
   complete(
     path: string,
@@ -88,15 +86,11 @@ export function createSandboxTs(files: Record<string, string>): SandboxTs {
       return null;
     });
 
-  const whenReady = send({ kind: 'init', files }).then(
-    () => undefined,
-    (error) => {
-      console.warn('[sandbox] IntelliSense failed to start:', error);
-    },
-  );
+  send({ kind: 'init', files }).catch((error) => {
+    console.warn('[sandbox] IntelliSense failed to start:', error);
+  });
 
   return {
-    whenReady,
     sync(files) {
       void safe({ kind: 'sync', files });
     },

--- a/website/app/components/sandbox/client.ts
+++ b/website/app/components/sandbox/client.ts
@@ -43,42 +43,75 @@ export function createSandboxTs(files: Record<string, string>): SandboxTs {
   );
 
   let seq = 0;
-  const pending = new Map<number, (value: unknown) => void>();
+  const pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  const failAll = (error: Error) => {
+    for (const { reject } of pending.values()) reject(error);
+    pending.clear();
+  };
 
   worker.addEventListener('message', ({ data }: MessageEvent<Response>) => {
-    const resolve = pending.get(data.id);
-    if (resolve) {
-      pending.delete(data.id);
-      resolve(data.result);
-    }
+    const slot = pending.get(data.id);
+    if (!slot) return;
+    pending.delete(data.id);
+    if (data.error) slot.reject(new Error(data.error));
+    else slot.resolve(data.result);
   });
 
+  // A worker that dies (load error, crash) would otherwise leave every caller
+  // hanging forever; reject them so failures surface instead of stalling.
+  worker.addEventListener('error', (e) =>
+    failAll(new Error(e.message || 'sandbox language-service worker error')),
+  );
+  worker.addEventListener('messageerror', () =>
+    failAll(new Error('sandbox language-service message error')),
+  );
+
   const send = <T>(command: Command): Promise<T> =>
-    new Promise<T>((resolve) => {
+    new Promise<T>((resolve, reject) => {
       const id = ++seq;
-      pending.set(id, resolve as (value: unknown) => void);
+      pending.set(id, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
       worker.postMessage({ ...command, id });
     });
 
-  const whenReady = send({ kind: 'init', files }).then(() => undefined);
+  // A failed language service should degrade to "no completions", never a
+  // hang or an unhandled rejection - callers treat null as "nothing to offer".
+  const safe = <T>(command: Command): Promise<T | null> =>
+    send<T>(command).catch((error) => {
+      console.warn('[sandbox] IntelliSense request failed:', error);
+      return null;
+    });
+
+  const whenReady = send({ kind: 'init', files }).then(
+    () => undefined,
+    (error) => {
+      console.warn('[sandbox] IntelliSense failed to start:', error);
+    },
+  );
 
   return {
     whenReady,
     sync(files) {
-      void send({ kind: 'sync', files });
+      void safe({ kind: 'sync', files });
     },
     complete(path, code, pos) {
-      return send({ kind: 'complete', path, code, pos });
+      return safe({ kind: 'complete', path, code, pos });
     },
     details(path, pos, name, source, data) {
-      return send({ kind: 'details', path, pos, name, source, data });
+      return safe({ kind: 'details', path, pos, name, source, data });
     },
     quickInfo(path, code, pos) {
-      return send({ kind: 'quickInfo', path, code, pos });
+      return safe({ kind: 'quickInfo', path, code, pos });
     },
     dispose() {
       worker.terminate();
-      pending.clear();
+      failAll(new Error('sandbox language service disposed'));
     },
   };
 }

--- a/website/app/components/sandbox/client.ts
+++ b/website/app/components/sandbox/client.ts
@@ -7,6 +7,8 @@ import type {
 } from './protocol';
 
 export interface SandboxTs {
+  /** Resolves once the worker's language service has loaded its libs. */
+  whenReady: Promise<void>;
   sync(files: Record<string, string>): void;
   complete(
     path: string,
@@ -58,9 +60,10 @@ export function createSandboxTs(files: Record<string, string>): SandboxTs {
       worker.postMessage({ ...command, id });
     });
 
-  void send({ kind: 'init', files });
+  const whenReady = send({ kind: 'init', files }).then(() => undefined);
 
   return {
+    whenReady,
     sync(files) {
       void send({ kind: 'sync', files });
     },

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -6,29 +6,8 @@ import {
 } from '@codemirror/autocomplete';
 import type { Extension } from '@codemirror/state';
 import { hoverTooltip, type Tooltip } from '@codemirror/view';
-import ts from 'typescript';
 
-import type { TsEnv } from './tsEnv';
-
-const COMPLETION_TYPE: Record<string, Completion['type']> = {
-  [ts.ScriptElementKind.constElement]: 'constant',
-  [ts.ScriptElementKind.letElement]: 'variable',
-  [ts.ScriptElementKind.variableElement]: 'variable',
-  [ts.ScriptElementKind.localVariableElement]: 'variable',
-  [ts.ScriptElementKind.parameterElement]: 'variable',
-  [ts.ScriptElementKind.functionElement]: 'function',
-  [ts.ScriptElementKind.localFunctionElement]: 'function',
-  [ts.ScriptElementKind.memberFunctionElement]: 'method',
-  [ts.ScriptElementKind.memberVariableElement]: 'property',
-  [ts.ScriptElementKind.memberGetAccessorElement]: 'property',
-  [ts.ScriptElementKind.memberSetAccessorElement]: 'property',
-  [ts.ScriptElementKind.classElement]: 'class',
-  [ts.ScriptElementKind.interfaceElement]: 'interface',
-  [ts.ScriptElementKind.enumElement]: 'enum',
-  [ts.ScriptElementKind.moduleElement]: 'namespace',
-  [ts.ScriptElementKind.typeElement]: 'type',
-  [ts.ScriptElementKind.keyword]: 'keyword',
-};
+import type { SandboxTs } from './client';
 
 function tooltipDom(main: string, doc?: string) {
   const dom = document.createElement('div');
@@ -48,25 +27,14 @@ function tooltipDom(main: string, doc?: string) {
 }
 
 /**
- * CodeMirror IntelliSense backed by the virtual TypeScript language service.
- * `getEnv` resolves the (async, lazily-built) env for the current sandbox and
- * `getPath` names the file this editor instance is showing.
+ * CodeMirror IntelliSense backed by the worker language service. `getClient`
+ * resolves (and lazily spawns) the worker for the current sandbox; `getPath`
+ * names the file this editor instance is showing.
  */
 export function intellisense(
-  getEnv: () => Promise<TsEnv> | undefined,
+  getClient: () => SandboxTs | undefined,
   getPath: () => string,
 ): Extension {
-  const sync = async (doc: string) => {
-    const holder = await getEnv();
-    if (!holder) return undefined;
-
-    const path = getPath();
-    if (holder.env.getSourceFile(path)) holder.env.updateFile(path, doc);
-    else holder.env.createFile(path, doc);
-
-    return { env: holder.env, path };
-  };
-
   const complete = async (
     ctx: CompletionContext,
   ): Promise<CompletionResult | null> => {
@@ -75,45 +43,35 @@ export function intellisense(
 
     if (!ctx.explicit && !word && before !== '.') return null;
 
-    const ready = await sync(ctx.state.doc.toString());
-    if (!ready) return null;
+    const client = getClient();
+    if (!client) return null;
 
-    const { env, path } = ready;
-    const info = env.languageService.getCompletionsAtPosition(path, ctx.pos, {
-      includeCompletionsForModuleExports: true,
-      includeCompletionsWithInsertText: true,
-    });
+    const path = getPath();
+    const res = await client.complete(path, ctx.state.doc.toString(), ctx.pos);
 
-    if (!info || !info.entries.length) return null;
+    if (ctx.aborted || !res || !res.entries.length) return null;
 
     let from = word ? word.from : ctx.pos;
     let to = ctx.pos;
 
-    if (info.optionalReplacementSpan) {
-      from = info.optionalReplacementSpan.start;
-      to = from + info.optionalReplacementSpan.length;
+    if (res.replacement) {
+      from = res.replacement.start;
+      to = from + res.replacement.length;
     }
 
-    const options: Completion[] = info.entries.map((entry) => ({
+    const options: Completion[] = res.entries.map((entry) => ({
       label: entry.name,
-      type: COMPLETION_TYPE[entry.kind],
-      info() {
-        const detail = env.languageService.getCompletionEntryDetails(
+      type: entry.type,
+      async info() {
+        const detail = await client.details(
           path,
           ctx.pos,
           entry.name,
-          undefined,
           entry.source,
-          undefined,
           entry.data,
         );
 
-        if (!detail) return null;
-
-        return tooltipDom(
-          ts.displayPartsToString(detail.displayParts),
-          ts.displayPartsToString(detail.documentation),
-        );
+        return detail ? tooltipDom(detail.display, detail.documentation) : null;
       },
     }));
 
@@ -121,21 +79,22 @@ export function intellisense(
   };
 
   const hover = hoverTooltip(async (view, pos): Promise<Tooltip | null> => {
-    const ready = await sync(view.state.doc.toString());
-    if (!ready) return null;
+    const client = getClient();
+    if (!client) return null;
 
-    const { env, path } = ready;
-    const quick = env.languageService.getQuickInfoAtPosition(path, pos);
-    if (!quick) return null;
+    const quick = await client.quickInfo(
+      getPath(),
+      view.state.doc.toString(),
+      pos,
+    );
 
-    const main = ts.displayPartsToString(quick.displayParts);
-    if (!main) return null;
+    if (!quick || !quick.display) return null;
 
     return {
-      pos: quick.textSpan.start,
-      end: quick.textSpan.start + quick.textSpan.length,
+      pos: quick.span.start,
+      end: quick.span.start + quick.span.length,
       create: () => ({
-        dom: tooltipDom(main, ts.displayPartsToString(quick.documentation)),
+        dom: tooltipDom(quick.display, quick.documentation),
       }),
     };
   });

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -1,0 +1,144 @@
+import {
+  autocompletion,
+  type Completion,
+  type CompletionContext,
+  type CompletionResult,
+} from '@codemirror/autocomplete';
+import type { Extension } from '@codemirror/state';
+import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import ts from 'typescript';
+
+import type { TsEnv } from './tsEnv';
+
+const COMPLETION_TYPE: Record<string, Completion['type']> = {
+  [ts.ScriptElementKind.constElement]: 'constant',
+  [ts.ScriptElementKind.letElement]: 'variable',
+  [ts.ScriptElementKind.variableElement]: 'variable',
+  [ts.ScriptElementKind.localVariableElement]: 'variable',
+  [ts.ScriptElementKind.parameterElement]: 'variable',
+  [ts.ScriptElementKind.functionElement]: 'function',
+  [ts.ScriptElementKind.localFunctionElement]: 'function',
+  [ts.ScriptElementKind.memberFunctionElement]: 'method',
+  [ts.ScriptElementKind.memberVariableElement]: 'property',
+  [ts.ScriptElementKind.memberGetAccessorElement]: 'property',
+  [ts.ScriptElementKind.memberSetAccessorElement]: 'property',
+  [ts.ScriptElementKind.classElement]: 'class',
+  [ts.ScriptElementKind.interfaceElement]: 'interface',
+  [ts.ScriptElementKind.enumElement]: 'enum',
+  [ts.ScriptElementKind.moduleElement]: 'namespace',
+  [ts.ScriptElementKind.typeElement]: 'type',
+  [ts.ScriptElementKind.keyword]: 'keyword',
+};
+
+function tooltipDom(main: string, doc?: string) {
+  const dom = document.createElement('div');
+  dom.className = 'sp-ts-tooltip';
+
+  const signature = dom.appendChild(document.createElement('code'));
+  signature.className = 'sp-ts-signature';
+  signature.textContent = main;
+
+  if (doc) {
+    const body = dom.appendChild(document.createElement('div'));
+    body.className = 'sp-ts-doc';
+    body.textContent = doc;
+  }
+
+  return dom;
+}
+
+/**
+ * CodeMirror IntelliSense backed by the virtual TypeScript language service.
+ * `getEnv` resolves the (async, lazily-built) env for the current sandbox and
+ * `getPath` names the file this editor instance is showing.
+ */
+export function intellisense(
+  getEnv: () => Promise<TsEnv> | undefined,
+  getPath: () => string,
+): Extension {
+  const sync = async (doc: string) => {
+    const holder = await getEnv();
+    if (!holder) return undefined;
+
+    const path = getPath();
+    if (holder.env.getSourceFile(path)) holder.env.updateFile(path, doc);
+    else holder.env.createFile(path, doc);
+
+    return { env: holder.env, path };
+  };
+
+  const complete = async (
+    ctx: CompletionContext,
+  ): Promise<CompletionResult | null> => {
+    const before = ctx.state.doc.sliceString(Math.max(0, ctx.pos - 1), ctx.pos);
+    const word = ctx.matchBefore(/[\w$]+/);
+
+    if (!ctx.explicit && !word && before !== '.') return null;
+
+    const ready = await sync(ctx.state.doc.toString());
+    if (!ready) return null;
+
+    const { env, path } = ready;
+    const info = env.languageService.getCompletionsAtPosition(path, ctx.pos, {
+      includeCompletionsForModuleExports: true,
+      includeCompletionsWithInsertText: true,
+    });
+
+    if (!info || !info.entries.length) return null;
+
+    let from = word ? word.from : ctx.pos;
+    let to = ctx.pos;
+
+    if (info.optionalReplacementSpan) {
+      from = info.optionalReplacementSpan.start;
+      to = from + info.optionalReplacementSpan.length;
+    }
+
+    const options: Completion[] = info.entries.map((entry) => ({
+      label: entry.name,
+      type: COMPLETION_TYPE[entry.kind],
+      info() {
+        const detail = env.languageService.getCompletionEntryDetails(
+          path,
+          ctx.pos,
+          entry.name,
+          undefined,
+          entry.source,
+          undefined,
+          entry.data,
+        );
+
+        if (!detail) return null;
+
+        return tooltipDom(
+          ts.displayPartsToString(detail.displayParts),
+          ts.displayPartsToString(detail.documentation),
+        );
+      },
+    }));
+
+    return { from, to, options, validFor: /^[\w$]*$/ };
+  };
+
+  const hover = hoverTooltip(async (view, pos): Promise<Tooltip | null> => {
+    const ready = await sync(view.state.doc.toString());
+    if (!ready) return null;
+
+    const { env, path } = ready;
+    const quick = env.languageService.getQuickInfoAtPosition(path, pos);
+    if (!quick) return null;
+
+    const main = ts.displayPartsToString(quick.displayParts);
+    if (!main) return null;
+
+    return {
+      pos: quick.textSpan.start,
+      end: quick.textSpan.start + quick.textSpan.length,
+      create: () => ({
+        dom: tooltipDom(main, ts.displayPartsToString(quick.documentation)),
+      }),
+    };
+  });
+
+  return [autocompletion({ override: [complete] }), hover];
+}

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -102,8 +102,9 @@ export function intellisense(
   return [
     // Tooltips default to living inside the editor, where they stretch its
     // scrollable area and get clipped at its edge; in <body> they float over
-    // the preview instead.
-    tooltips({ position: 'fixed', parent: document.body }),
+    // the preview instead. Absolute, not the default fixed - fixed sends Safari
+    // down a measure-and-reflip kludge in CodeMirror's positioning code.
+    tooltips({ position: 'absolute', parent: document.body }),
     autocompletion({ override: [complete] }),
     hover,
   ];

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -5,7 +5,12 @@ import {
   type CompletionResult,
 } from '@codemirror/autocomplete';
 import type { Extension } from '@codemirror/state';
-import { hoverTooltip, tooltips, type Tooltip } from '@codemirror/view';
+import {
+  EditorView,
+  hoverTooltip,
+  tooltips,
+  type Tooltip,
+} from '@codemirror/view';
 
 import type { SandboxTs } from './client';
 
@@ -105,6 +110,15 @@ export function intellisense(
     // the preview instead. Absolute, not the default fixed - fixed sends Safari
     // down a measure-and-reflip kludge in CodeMirror's positioning code.
     tooltips({ position: 'absolute', parent: document.body }),
+    // Warm the worker the moment the editor is focused, so its multi-second
+    // first-load (worker chunk + CDN libs) overlaps with the user reading and
+    // typing rather than stalling the first completion.
+    EditorView.domEventHandlers({
+      focus() {
+        getClient();
+        return false;
+      },
+    }),
     autocompletion({ override: [complete] }),
     hover,
   ];

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -106,10 +106,11 @@ export function intellisense(
 
   return [
     // Tooltips default to living inside the editor, where they stretch its
-    // scrollable area and get clipped at its edge; in <body> they float over
-    // the preview instead. Absolute, not the default fixed - fixed sends Safari
-    // down a measure-and-reflip kludge in CodeMirror's positioning code.
-    tooltips({ position: 'absolute', parent: document.body }),
+    // scrollable area and get clipped at its edge. Float them at the document
+    // root instead: <body> hosts the app's own stacking context, which paints
+    // over any tooltip parented there - parenting to <html> escapes it. Absolute,
+    // not fixed - fixed sends Safari into a measure-and-reflip flicker.
+    tooltips({ position: 'absolute', parent: document.documentElement }),
     // Warm the worker the moment the editor is focused, so its multi-second
     // first-load (worker chunk + CDN libs) overlaps with the user reading and
     // typing rather than stalling the first completion.

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -5,7 +5,7 @@ import {
   type CompletionResult,
 } from '@codemirror/autocomplete';
 import type { Extension } from '@codemirror/state';
-import { hoverTooltip, type Tooltip } from '@codemirror/view';
+import { hoverTooltip, tooltips, type Tooltip } from '@codemirror/view';
 
 import type { SandboxTs } from './client';
 
@@ -99,5 +99,12 @@ export function intellisense(
     };
   });
 
-  return [autocompletion({ override: [complete] }), hover];
+  return [
+    // Tooltips default to living inside the editor, where they stretch its
+    // scrollable area and get clipped at its edge; in <body> they float over
+    // the preview instead.
+    tooltips({ position: 'fixed', parent: document.body }),
+    autocompletion({ override: [complete] }),
+    hover,
+  ];
 }

--- a/website/app/components/sandbox/intellisense.ts
+++ b/website/app/components/sandbox/intellisense.ts
@@ -1,13 +1,15 @@
 import {
+  acceptCompletion,
   autocompletion,
   type Completion,
   type CompletionContext,
   type CompletionResult,
 } from '@codemirror/autocomplete';
-import type { Extension } from '@codemirror/state';
+import { Prec, type Extension } from '@codemirror/state';
 import {
   EditorView,
   hoverTooltip,
+  keymap,
   tooltips,
   type Tooltip,
 } from '@codemirror/view';
@@ -111,6 +113,9 @@ export function intellisense(
     // over any tooltip parented there - parenting to <html> escapes it. Absolute,
     // not fixed - fixed sends Safari into a measure-and-reflip flicker.
     tooltips({ position: 'absolute', parent: document.documentElement }),
+    // Tab accepts the highlighted completion (like an editor); acceptCompletion
+    // returns false when no popup is open, so Tab still indents otherwise.
+    Prec.highest(keymap.of([{ key: 'Tab', run: acceptCompletion }])),
     // Warm the worker the moment the editor is focused, so its multi-second
     // first-load (worker chunk + CDN libs) overlaps with the user reading and
     // typing rather than stalling the first completion.

--- a/website/app/components/sandbox/protocol.ts
+++ b/website/app/components/sandbox/protocol.ts
@@ -1,0 +1,43 @@
+export type Command =
+  | { kind: 'init'; files: Record<string, string> }
+  | { kind: 'sync'; files: Record<string, string> }
+  | { kind: 'complete'; path: string; code: string; pos: number }
+  | {
+      kind: 'details';
+      path: string;
+      pos: number;
+      name: string;
+      source?: string;
+      data?: unknown;
+    }
+  | { kind: 'quickInfo'; path: string; code: string; pos: number };
+
+export type Request = Command & { id: number };
+
+export interface Response {
+  id: number;
+  result: unknown;
+}
+
+export interface CompletionEntry {
+  name: string;
+  type?: string;
+  source?: string;
+  data?: unknown;
+}
+
+export interface CompleteResult {
+  replacement?: { start: number; length: number };
+  entries: CompletionEntry[];
+}
+
+export interface Detail {
+  display: string;
+  documentation: string;
+}
+
+export interface QuickInfo {
+  display: string;
+  documentation: string;
+  span: { start: number; length: number };
+}

--- a/website/app/components/sandbox/protocol.ts
+++ b/website/app/components/sandbox/protocol.ts
@@ -16,7 +16,8 @@ export type Request = Command & { id: number };
 
 export interface Response {
   id: number;
-  result: unknown;
+  result?: unknown;
+  error?: string;
 }
 
 export interface CompletionEntry {

--- a/website/app/components/sandbox/tsEnv.ts
+++ b/website/app/components/sandbox/tsEnv.ts
@@ -1,0 +1,99 @@
+import { setupTypeAcquisition } from '@typescript/ata';
+import {
+  createDefaultMapFromCDN,
+  createSystem,
+  createVirtualTypeScriptEnvironment,
+  type VirtualTypeScriptEnvironment,
+} from '@typescript/vfs';
+import ts from 'typescript';
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ESNext,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  jsx: ts.JsxEmit.ReactJSX,
+  esModuleInterop: true,
+  allowJs: true,
+  skipLibCheck: true,
+  strict: true,
+  lib: ['lib.dom.d.ts', 'lib.dom.iterable.d.ts', 'lib.esnext.d.ts'],
+};
+
+const CODE_FILE = /\.[jt]sx?$/;
+
+// CDN lib fetch is version-pinned and localStorage-cached; share it across
+// every sandbox so switching examples never re-downloads lib.*.d.ts.
+let libMap: Promise<Map<string, string>> | undefined;
+
+const getLibMap = () =>
+  (libMap ??= createDefaultMapFromCDN(
+    COMPILER_OPTIONS,
+    ts.version,
+    true,
+    ts,
+  ));
+
+export interface TsEnv {
+  env: VirtualTypeScriptEnvironment;
+  sync(files: Record<string, string>): void;
+}
+
+export async function createTsEnv(
+  files: Record<string, string>,
+): Promise<TsEnv> {
+  const map = new Map(await getLibMap());
+
+  // CSS (and other asset) imports would otherwise surface as phantom missing-module errors.
+  map.set('/globals.d.ts', "declare module '*.css';\n");
+
+  const known = new Set(['/globals.d.ts']);
+  const roots = ['/globals.d.ts'];
+
+  for (const [path, code] of Object.entries(files)) {
+    map.set(path, code);
+    known.add(path);
+    if (CODE_FILE.test(path)) roots.push(path);
+  }
+
+  const env = createVirtualTypeScriptEnvironment(
+    createSystem(map),
+    roots,
+    ts,
+    COMPILER_OPTIONS,
+  );
+
+  // Pull @types for react / @expressive / any other imported package from the
+  // CDN; each resolved file drops into the VFS so completions gain real types.
+  const acquire = setupTypeAcquisition({
+    projectName: 'expressive-sandbox',
+    typescript: ts,
+    delegate: {
+      receivedFile(code, path) {
+        if (env.getSourceFile(path)) env.updateFile(path, code);
+        else env.createFile(path, code);
+      },
+    },
+  });
+
+  const source = () =>
+    Object.entries(files)
+      .filter(([path]) => CODE_FILE.test(path))
+      .map(([, code]) => code)
+      .join('\n');
+
+  acquire(source());
+
+  return {
+    env,
+    sync(next) {
+      for (const [path, code] of Object.entries(next)) {
+        if (!CODE_FILE.test(path)) continue;
+        if (known.has(path)) env.updateFile(path, code);
+        else {
+          env.createFile(path, code);
+          known.add(path);
+        }
+      }
+    },
+  };
+}

--- a/website/app/components/sandbox/tsEnv.ts
+++ b/website/app/components/sandbox/tsEnv.ts
@@ -1,6 +1,5 @@
 import { setupTypeAcquisition } from '@typescript/ata';
 import {
-  createDefaultMapFromCDN,
   createSystem,
   createVirtualTypeScriptEnvironment,
   type VirtualTypeScriptEnvironment,
@@ -21,17 +20,84 @@ const COMPILER_OPTIONS: ts.CompilerOptions = {
 
 const CODE_FILE = /\.[jt]sx?$/;
 
-// CDN lib fetch is version-pinned and localStorage-cached; share it across
-// every sandbox so switching examples never re-downloads lib.*.d.ts.
+// vfs's own cache reaches for localStorage, which a worker doesn't have, and the
+// CDN sends no cache-control - so persist the libs through the Cache API, keyed
+// by TS version, and fall back to a plain fetch where it isn't available.
+let libStore: Promise<Cache> | undefined;
+
+const getLibStore = () =>
+  (libStore ??= (async () => {
+    const name = `ts-lib-${ts.version}`;
+
+    for (const key of await caches.keys())
+      if (key.startsWith('ts-lib-') && key !== name) await caches.delete(key);
+
+    return caches.open(name);
+  })());
+
+const fetchLib = async (url: string) => {
+  try {
+    const cache = await getLibStore();
+    const hit = await cache.match(url);
+
+    if (hit) return hit;
+
+    const response = await fetch(url);
+
+    if (response.ok) await cache.put(url, response.clone());
+
+    return response;
+  } catch {
+    return fetch(url);
+  }
+};
+
+const LIB_REFERENCE = /\/\/\/\s*<reference\s+lib="([^"]+)"\s*\/>/g;
+
+// vfs's knownLibFilesForCompilerOptions guesses the lib set by prefix-cutting a
+// hardcoded list, which yields just lib.d.ts for these options - walk each lib's
+// own `reference lib` graph instead, so the env gets exactly what it needs.
+async function collectLib(
+  map: Map<string, string>,
+  name: string,
+  seen: Set<string>,
+) {
+  if (seen.has(name)) return;
+
+  seen.add(name);
+
+  const response = await fetchLib(
+    `https://playgroundcdn.typescriptlang.org/cdn/${ts.version}/typescript/lib/${name}`,
+  );
+
+  if (!response.ok) return;
+
+  const text = await response.text();
+
+  map.set(`/${name}`, text);
+
+  await Promise.all(
+    [...text.matchAll(LIB_REFERENCE)].map(([, lib]) =>
+      collectLib(map, `lib.${lib}.d.ts`, seen),
+    ),
+  );
+}
+
+// Version-pinned and cached; shared across every sandbox so switching examples
+// never re-downloads lib.*.d.ts.
 let libMap: Promise<Map<string, string>> | undefined;
 
 const getLibMap = () =>
-  (libMap ??= createDefaultMapFromCDN(
-    COMPILER_OPTIONS,
-    ts.version,
-    true,
-    ts,
-  ));
+  (libMap ??= (async () => {
+    const map = new Map<string, string>();
+    const seen = new Set<string>();
+
+    await Promise.all(
+      COMPILER_OPTIONS.lib!.map((name) => collectLib(map, name, seen)),
+    );
+
+    return map;
+  })());
 
 export interface TsEnv {
   env: VirtualTypeScriptEnvironment;

--- a/website/app/components/sandbox/tsserver.worker.ts
+++ b/website/app/components/sandbox/tsserver.worker.ts
@@ -1,0 +1,118 @@
+import ts from 'typescript';
+
+import type { Command } from './protocol';
+import { createTsEnv, type TsEnv } from './tsEnv';
+
+// TS completion kind -> CodeMirror completion `type` (its icon/class).
+const COMPLETION_TYPE: Record<string, string> = {
+  [ts.ScriptElementKind.constElement]: 'constant',
+  [ts.ScriptElementKind.letElement]: 'variable',
+  [ts.ScriptElementKind.variableElement]: 'variable',
+  [ts.ScriptElementKind.localVariableElement]: 'variable',
+  [ts.ScriptElementKind.parameterElement]: 'variable',
+  [ts.ScriptElementKind.functionElement]: 'function',
+  [ts.ScriptElementKind.localFunctionElement]: 'function',
+  [ts.ScriptElementKind.memberFunctionElement]: 'method',
+  [ts.ScriptElementKind.memberVariableElement]: 'property',
+  [ts.ScriptElementKind.memberGetAccessorElement]: 'property',
+  [ts.ScriptElementKind.memberSetAccessorElement]: 'property',
+  [ts.ScriptElementKind.classElement]: 'class',
+  [ts.ScriptElementKind.interfaceElement]: 'interface',
+  [ts.ScriptElementKind.enumElement]: 'enum',
+  [ts.ScriptElementKind.moduleElement]: 'namespace',
+  [ts.ScriptElementKind.typeElement]: 'type',
+  [ts.ScriptElementKind.keyword]: 'keyword',
+};
+
+// DOM lib types `self` as a Window; the Worker view exposes the single-arg
+// postMessage and MessageEvent-shaped onmessage we actually want.
+const ctx = self as unknown as Worker;
+
+let ready: Promise<TsEnv> | undefined;
+
+function feed(env: TsEnv['env'], path: string, code: string) {
+  if (env.getSourceFile(path)) env.updateFile(path, code);
+  else env.createFile(path, code);
+}
+
+ctx.onmessage = async ({ data: msg }: MessageEvent<Command & { id: number }>) => {
+  if (msg.kind === 'init') {
+    ready = createTsEnv(msg.files);
+    await ready;
+    ctx.postMessage({ id: msg.id, result: true });
+    return;
+  }
+
+  const holder = await ready;
+  let result: unknown = null;
+
+  if (holder) {
+    const { env } = holder;
+    const service = env.languageService;
+
+    switch (msg.kind) {
+      case 'sync':
+        holder.sync(msg.files);
+        break;
+
+      case 'complete': {
+        feed(env, msg.path, msg.code);
+
+        const info = service.getCompletionsAtPosition(msg.path, msg.pos, {
+          includeCompletionsForModuleExports: true,
+          includeCompletionsWithInsertText: true,
+        });
+
+        if (info)
+          result = {
+            replacement: info.optionalReplacementSpan && {
+              start: info.optionalReplacementSpan.start,
+              length: info.optionalReplacementSpan.length,
+            },
+            entries: info.entries.map((entry) => ({
+              name: entry.name,
+              type: COMPLETION_TYPE[entry.kind],
+              source: entry.source,
+              data: entry.data,
+            })),
+          };
+        break;
+      }
+
+      case 'details': {
+        const detail = service.getCompletionEntryDetails(
+          msg.path,
+          msg.pos,
+          msg.name,
+          undefined,
+          msg.source,
+          undefined,
+          msg.data as ts.CompletionEntryData | undefined,
+        );
+
+        if (detail)
+          result = {
+            display: ts.displayPartsToString(detail.displayParts),
+            documentation: ts.displayPartsToString(detail.documentation),
+          };
+        break;
+      }
+
+      case 'quickInfo': {
+        feed(env, msg.path, msg.code);
+
+        const quick = service.getQuickInfoAtPosition(msg.path, msg.pos);
+
+        if (quick?.displayParts?.length)
+          result = {
+            display: ts.displayPartsToString(quick.displayParts),
+            documentation: ts.displayPartsToString(quick.documentation),
+            span: { start: quick.textSpan.start, length: quick.textSpan.length },
+          };
+        break;
+      }
+    }
+  }
+
+  ctx.postMessage({ id: msg.id, result });
+};

--- a/website/app/components/sandbox/tsserver.worker.ts
+++ b/website/app/components/sandbox/tsserver.worker.ts
@@ -35,36 +35,34 @@ function feed(env: TsEnv['env'], path: string, code: string) {
   else env.createFile(path, code);
 }
 
-ctx.onmessage = async ({ data: msg }: MessageEvent<Command & { id: number }>) => {
+async function handle(msg: Command): Promise<unknown> {
   if (msg.kind === 'init') {
     ready = createTsEnv(msg.files);
     await ready;
-    ctx.postMessage({ id: msg.id, result: true });
-    return;
+    return true;
   }
 
   const holder = await ready;
-  let result: unknown = null;
+  if (!holder) return null;
 
-  if (holder) {
-    const { env } = holder;
-    const service = env.languageService;
+  const { env } = holder;
+  const service = env.languageService;
 
-    switch (msg.kind) {
-      case 'sync':
-        holder.sync(msg.files);
-        break;
+  switch (msg.kind) {
+    case 'sync':
+      holder.sync(msg.files);
+      return null;
 
-      case 'complete': {
-        feed(env, msg.path, msg.code);
+    case 'complete': {
+      feed(env, msg.path, msg.code);
 
-        const info = service.getCompletionsAtPosition(msg.path, msg.pos, {
-          includeCompletionsForModuleExports: true,
-          includeCompletionsWithInsertText: true,
-        });
+      const info = service.getCompletionsAtPosition(msg.path, msg.pos, {
+        includeCompletionsForModuleExports: true,
+        includeCompletionsWithInsertText: true,
+      });
 
-        if (info)
-          result = {
+      return info
+        ? {
             replacement: info.optionalReplacementSpan && {
               start: info.optionalReplacementSpan.start,
               length: info.optionalReplacementSpan.length,
@@ -75,44 +73,52 @@ ctx.onmessage = async ({ data: msg }: MessageEvent<Command & { id: number }>) =>
               source: entry.source,
               data: entry.data,
             })),
-          };
-        break;
-      }
+          }
+        : null;
+    }
 
-      case 'details': {
-        const detail = service.getCompletionEntryDetails(
-          msg.path,
-          msg.pos,
-          msg.name,
-          undefined,
-          msg.source,
-          undefined,
-          msg.data as ts.CompletionEntryData | undefined,
-        );
+    case 'details': {
+      const detail = service.getCompletionEntryDetails(
+        msg.path,
+        msg.pos,
+        msg.name,
+        undefined,
+        msg.source,
+        undefined,
+        msg.data as ts.CompletionEntryData | undefined,
+      );
 
-        if (detail)
-          result = {
+      return detail
+        ? {
             display: ts.displayPartsToString(detail.displayParts),
             documentation: ts.displayPartsToString(detail.documentation),
-          };
-        break;
-      }
+          }
+        : null;
+    }
 
-      case 'quickInfo': {
-        feed(env, msg.path, msg.code);
+    case 'quickInfo': {
+      feed(env, msg.path, msg.code);
 
-        const quick = service.getQuickInfoAtPosition(msg.path, msg.pos);
+      const quick = service.getQuickInfoAtPosition(msg.path, msg.pos);
 
-        if (quick?.displayParts?.length)
-          result = {
+      return quick?.displayParts?.length
+        ? {
             display: ts.displayPartsToString(quick.displayParts),
             documentation: ts.displayPartsToString(quick.documentation),
             span: { start: quick.textSpan.start, length: quick.textSpan.length },
-          };
-        break;
-      }
+          }
+        : null;
     }
   }
+}
 
-  ctx.postMessage({ id: msg.id, result });
+ctx.onmessage = async ({ data: msg }: MessageEvent<Command & { id: number }>) => {
+  try {
+    ctx.postMessage({ id: msg.id, result: await handle(msg) });
+  } catch (error) {
+    ctx.postMessage({
+      id: msg.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 };

--- a/website/package.json
+++ b/website/package.json
@@ -10,10 +10,15 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/view": "^6.43.4",
     "@codesandbox/sandpack-react": "^2",
     "@expressive/react": "workspace:*",
     "@orama/orama": "^3.1.18",
     "@react-router/node": "^7.13.0",
+    "@typescript/ata": "^0.9",
+    "@typescript/vfs": "^1",
     "fumadocs-core": "16.6.3",
     "fumadocs-mdx": "14.2.7",
     "fumadocs-ui": "16.6.3",

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -10,6 +10,9 @@ import { cp, readFile } from 'fs/promises';
 export default defineConfig({
   optimizeDeps: {
     include: [
+      '@codemirror/autocomplete',
+      '@codemirror/state',
+      '@codemirror/view',
       '@codesandbox/sandpack-react',
       'lucide-react',
       'next-themes',


### PR DESCRIPTION
## Scope

Adds line numbers and type-aware IntelliSense to the Sandpack-based example sandbox on the website.

## Approach

- **`showLineNumbers`** on `SandpackCodeEditor`.
- **Virtual TS language service** (`website/app/components/sandbox/tsEnv.ts`) via `@typescript/vfs`: lib `.d.ts` fetched from CDN once and Cache-API-persisted across sandboxes; `@typescript/ata` acquires `@types` for `react` / `@expressive/*` / any imported package so completions carry real types. A `declare module '*.css'` shim suppresses phantom asset-import errors.
- **CodeMirror extension** (`website/app/components/sandbox/intellisense.ts`): completion popup with lazily-fetched signature/doc detail, plus hover tooltips, both backed by `getCompletionsAtPosition` / `getQuickInfoAtPosition`. The active file stays synced from the live editor doc so completions target whatever tab is open.
- Tooltip styling in `app.css`.

## Off-thread + lazy loading

The language service runs in a **module worker** (`tsserver.worker.ts`), spawned on **first editor use** rather than on mount, behind a small promise-based message protocol (`client.ts` / `protocol.ts`):

- `typescript` and every acquired `.d.ts` live entirely in the worker — the main thread never blocks on type-checking, and only file text out / result objects back cross the boundary.
- `typescript` code-splits into its own worker chunk (**~3.4 MB**) that downloads only when the editor is first used. The `Sandbox` chunk drops from **~4.1 MB → ~650 KB**, so neither page load nor sandbox render pulls TypeScript.

## Fixes on top

- **The libs actually load.** Two silent failures left IntelliSense dead: `vfs`'s CDN helper caches through `localStorage`, which a worker doesn't have (init threw, so every request hung unanswered), and `knownLibFilesForCompilerOptions` picks libs by prefix-cutting a hardcoded list — filename-form `lib` entries match none of it and `ScriptTarget[99]` reverse-maps to `'Latest'`, so it returned `lib.d.ts` alone and the env had no global types. Now: Cache-API persistence, and the lib set comes from walking each lib's own `reference lib` graph. Verified out-of-browser against the real CDN — `hello.` on a `State` subclass yields `get` / `greeting` / `is` / `set` with clean diagnostics once ATA lands (~3–6s on a cold first use), 139 requests / 3.81 MB cold.
- **Line numbers are legible** — Sandpack hard-codes the gutter at `.6em`.

- **The language service survives a theme toggle.** `SandpackProvider` is keyed on theme, so a toggle remounts it — which would take the worker and every acquired `@types` with it, leaving IntelliSense cold and refetching from the CDN on each flip. `Sandbox` now owns the client, above the keyed provider, and hands the editor an accessor that still spawns lazily (worker chunk confirmed still separate).
- **Preview iframe no longer eats the resize drag.** The sandbox's divider is a separate implementation from `layout/Layout.tsx`, so the mask added there in #261 never covered it; mouse pointers get no implicit capture, so dragging into the Sandpack preview froze the split. Same full-window mask idiom, applied here.

## Notes

- Website is a private package, so no changeset.
- Rebased onto current `main` (picks up #261–#242).

Type-check and production build both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
