### PR TITLE
feat(examples): emoji storefront app with a keyed cart map

### DIFF
--- a/examples/pages/apps/index.ts
+++ b/examples/pages/apps/index.ts
@@ -1,1 +1,8 @@
-export default ['forms', 'kanban', 'tictactoe', 'stopwatch', 'spreadsheet'];
+export default [
+  'forms',
+  'kanban',
+  'tictactoe',
+  'stopwatch',
+  'spreadsheet',
+  'store'
+];

--- a/examples/pages/apps/store/App.css
+++ b/examples/pages/apps/store/App.css
@@ -1,0 +1,330 @@
+/* Only this example's iframe loads this file, so these overrides of the shared
+   column are safely scoped to the store: widen it, and pin it to the top
+   (the base rule's `margin: auto` would otherwise center the header
+   vertically on short pages like the product view or an empty cart). */
+body.example #root {
+  max-width: 52rem;
+  margin: 0 auto;
+}
+
+.store {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s5);
+  width: 100%;
+}
+
+/* Header ------------------------------------------------------------------ */
+
+.store-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s4);
+  padding-bottom: var(--s4);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  font-size: var(--t-xl);
+  font-weight: 700;
+  color: var(--fg);
+  letter-spacing: -0.02em;
+}
+
+.brand:hover {
+  text-decoration: none;
+  color: var(--accent);
+}
+
+.cart-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--t-xl);
+  line-height: 1;
+  padding: var(--s2);
+  border-radius: var(--r);
+  border: 1px solid var(--border-2);
+}
+
+.cart-btn:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: grid;
+  place-items: center;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 999px;
+  font-size: var(--t-xs);
+  font-weight: 600;
+  font-family: var(--font-sans);
+}
+
+/* Category chips ---------------------------------------------------------- */
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2);
+  margin-bottom: var(--s5);
+}
+
+.chip {
+  padding: var(--s1) var(--s3);
+  border: 1px solid var(--border-2);
+  border-radius: 999px;
+  color: var(--fg-soft);
+  font-size: var(--t-sm);
+  font-weight: 500;
+}
+
+.chip:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+}
+
+.chip.on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+
+/* Product grid ------------------------------------------------------------ */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8.5rem, 1fr));
+  gap: var(--s3);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s1);
+  padding: var(--s4) var(--s3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--fg);
+  transition:
+    border-color 0.15s,
+    transform 0.15s;
+}
+
+.card:hover {
+  text-decoration: none;
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.card-emoji {
+  font-size: 2.75rem;
+  line-height: 1.1;
+}
+
+.card-name {
+  font-weight: 600;
+}
+
+.card-price {
+  color: var(--muted);
+  font-size: var(--t-sm);
+  font-family: var(--font-mono);
+}
+
+/* Breadcrumbs ------------------------------------------------------------- */
+
+.crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s2);
+  font-size: var(--t-sm);
+  color: var(--muted);
+  margin-bottom: var(--s5);
+}
+
+.crumbs .sep {
+  color: var(--border-2);
+}
+
+.crumbs [aria-current='page'] {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+/* Product page ------------------------------------------------------------ */
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s6);
+  align-items: center;
+}
+
+.hero-emoji {
+  font-size: 8rem;
+  line-height: 1;
+  flex: 0 0 auto;
+}
+
+.hero-info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+  min-width: 12rem;
+  flex: 1;
+}
+
+.hero-price {
+  margin: 0;
+  font-size: var(--t-xl);
+  font-family: var(--font-mono);
+  color: var(--fg-soft);
+}
+
+/* Quantity stepper (shared by product page + cart lines) ------------------ */
+
+.qty {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s2);
+}
+
+.qty button {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  font-size: var(--t-lg);
+}
+
+.qty-val {
+  min-width: 1.5rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+  font-weight: 600;
+  align-self: flex-start;
+}
+
+.primary:hover {
+  border-color: var(--accent);
+  filter: brightness(1.08);
+}
+
+/* Cart -------------------------------------------------------------------- */
+
+.cart {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s4);
+}
+
+.lines {
+  gap: var(--s2);
+}
+
+.line {
+  display: flex;
+  align-items: center;
+  gap: var(--s4);
+  padding: var(--s3);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  cursor: default;
+}
+
+.line:hover {
+  background: none;
+}
+
+.line-emoji {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.line-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 6rem;
+}
+
+.line-info a {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.line-sub {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  min-width: 5rem;
+  text-align: right;
+}
+
+.remove {
+  padding: var(--s1) var(--s2);
+  color: var(--muted);
+  border-color: transparent;
+}
+
+.remove:hover {
+  color: var(--fg);
+  border-color: var(--border-2);
+}
+
+.summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-top: var(--s3);
+  border-top: 1px solid var(--border);
+  font-weight: 600;
+}
+
+.summary .total {
+  font-size: var(--t-xl);
+  font-family: var(--font-mono);
+}
+
+.checkout {
+  align-self: stretch;
+  text-align: center;
+  padding: var(--s3);
+  font-size: var(--t-lg);
+}
+
+/* Empty / confirmation / 404 states --------------------------------------- */
+
+.notice {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  text-align: center;
+  padding: var(--s6) var(--s4);
+}
+
+.big-emoji {
+  font-size: 4rem;
+  line-height: 1;
+}

--- a/examples/pages/apps/store/App.tsx
+++ b/examples/pages/apps/store/App.tsx
@@ -1,0 +1,62 @@
+import './App.css';
+
+import { type ReactNode } from 'react';
+
+import { Provider } from '@expressive/react';
+import { Link, Route, Router } from '@expressive/router';
+
+import { CartPage } from './Cart';
+import { ProductPage } from './Product';
+import { Cart } from './Store';
+import { Storefront } from './Storefront';
+
+// Persistent chrome: the brand + cart button stay put while the matched page
+// arrives as `children`. Purely presentational - it reads nothing reactive
+// itself, so a plain function (the badge subscribes inside CartButton).
+const Layout = ({ children }: { children?: ReactNode }) => (
+  <div className="store">
+    <header className="store-head">
+      <Link to="/" className="brand">
+        🛍️ Emoji Store
+      </Link>
+      <CartButton />
+    </header>
+    <div className="store-body">{children}</div>
+  </div>
+);
+
+// Reads just `count` off the shared cart, so it re-renders only when the item
+// count changes - not on every unrelated cart mutation.
+const CartButton = () => {
+  const { count } = Cart.get();
+
+  return (
+    <Link to="/cart" className="cart-btn" aria-label="Cart">
+      🛒
+      {count > 0 && <span className="badge">{count}</span>}
+    </Link>
+  );
+};
+
+const NotFound = () => (
+  <div className="notice">
+    <span className="big-emoji">🧭</span>
+    <h1>Nothing here</h1>
+    <Link to="/">Back to the store</Link>
+  </div>
+);
+
+// One in-memory Router; the Cart is provided above it so every page shares it.
+export default () => (
+  <Provider for={Cart}>
+    <Router>
+      <Route as={Layout}>
+        <Route as={Storefront} />
+        <Route to="category/:cat" as={Storefront} />
+        <Route to="product/:id" as={ProductPage} />
+        <Route to="cart" as={CartPage} />
+        <Route default as={NotFound} />
+      </Route>
+    </Router>
+  </Provider>
+);

--- a/examples/pages/apps/store/Breadcrumbs.tsx
+++ b/examples/pages/apps/store/Breadcrumbs.tsx
@@ -1,0 +1,36 @@
+import { Link } from '@expressive/router';
+
+export interface Crumb {
+  label: string;
+  to?: string;
+}
+
+// A data-driven trail. The product page owns the hierarchy (Store > Category >
+// Product) and passes it in, because a flat `product/:id` route can't express
+// those ancestors lexically for the matcher to derive.
+export const Breadcrumbs = ({ trail }: { trail: Crumb[] }) => {
+  return (
+    <nav className="crumbs" aria-label="Breadcrumb">
+      {trail.map((crumb, i) => {
+        const last = i === trail.length - 1;
+
+        return (
+          <span key={i} className="crumb">
+            {crumb.to && !last ? (
+              <Link to={crumb.to}>{crumb.label}</Link>
+            ) : (
+              <span aria-current={last ? 'page' : undefined}>
+                {crumb.label}
+              </span>
+            )}
+            {!last && (
+              <span className="sep" aria-hidden="true">
+                ›
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+};

--- a/examples/pages/apps/store/Cart.tsx
+++ b/examples/pages/apps/store/Cart.tsx
@@ -1,0 +1,75 @@
+import { Link } from '@expressive/router';
+
+import { usd } from './catalog';
+import { Cart } from './Store';
+
+// Each slice below does its own Cart.get() and subscribes only to what it
+// reads - the page just picks a branch. Receipt wins over Empty: checkout
+// clears the items, so both are true at once.
+export const CartPage = () => {
+  const { receipt, count } = Cart.get();
+
+  if (receipt) return <Receipt />;
+  if (!count) return <Empty />;
+
+  return (
+    <div className="cart">
+      <h1>Your Cart</h1>
+      <Lines />
+      <Checkout />
+    </div>
+  );
+};
+
+// Post-checkout confirmation. `reset()` clears it back to the live cart.
+const Receipt = () => {
+  const { is: cart, receipt } = Cart.get();
+
+  if (!receipt) return null;
+
+  return (
+    <div className="notice">
+      <span className="big-emoji">✅</span>
+      <h1>Order placed!</h1>
+      <p>
+        {receipt.count} {receipt.count === 1 ? 'item' : 'items'} ·{' '}
+        {usd(receipt.total)}
+      </p>
+      <Link to="/" onClick={() => cart.reset()}>
+        Continue shopping
+      </Link>
+    </div>
+  );
+};
+
+const Empty = () => (
+  <div className="notice">
+    <span className="big-emoji">🛒</span>
+    <h1>Your cart is empty</h1>
+    <Link to="/">Browse the store</Link>
+  </div>
+);
+
+// Dropping the map in renders its values, and each Line renders its own row -
+// so this is the entire list body.
+const Lines = () => {
+  const { items } = Cart.get();
+
+  return <ul className="lines">{items}</ul>;
+};
+
+const Checkout = () => {
+  const { is: cart, total } = Cart.get();
+
+  return (
+    <>
+      <div className="summary">
+        <span>Total</span>
+        <span className="total">{usd(total)}</span>
+      </div>
+      <button className="primary checkout" onClick={() => cart.checkout()}>
+        Checkout · {usd(total)}
+      </button>
+    </>
+  );
+};

--- a/examples/pages/apps/store/Line.tsx
+++ b/examples/pages/apps/store/Line.tsx
@@ -1,0 +1,70 @@
+import { Component } from '@expressive/react';
+import { Link } from '@expressive/router';
+
+import { getProduct, usd } from './catalog';
+
+// A cart line is a Component the cart's map spawns, keyed by product id. It
+// owns its quantity and renders its own row, so the cart page drops the map
+// straight into the tree - no <CartLine>, no props, no key.
+export class Line extends Component {
+  // Spawns at zero; `Cart.add` bumps it, so one code path covers both the
+  // first add and every repeat.
+  qty = 0;
+
+  constructor(readonly sku: string) {
+    super();
+  }
+
+  get product() {
+    return getProduct(this.sku)!;
+  }
+
+  get subtotal() {
+    return this.product.price * this.qty;
+  }
+
+  // Stepping to zero is a removal; destroying itself evicts it from the map.
+  step(by: number) {
+    const qty = this.qty + by;
+
+    if (qty > 0) this.qty = qty;
+    else this.set(null);
+  }
+
+  remove() {
+    this.set(null);
+  }
+
+  render() {
+    const { product, qty, subtotal } = this;
+    const to = `/product/${product.id}`;
+
+    return (
+      <li className="line">
+        <Link to={to} className="line-emoji">
+          {product.emoji}
+        </Link>
+        <div className="line-info">
+          <Link to={to}>{product.name}</Link>
+          <small>{usd(product.price)} each</small>
+        </div>
+        <div className="qty">
+          <button onClick={() => this.step(-1)} aria-label="Decrease quantity">
+            −
+          </button>
+          <span className="qty-val">{qty}</span>
+          <button onClick={() => this.step(1)} aria-label="Increase quantity">
+            +
+          </button>
+        </div>
+        <span className="line-sub">{usd(subtotal)}</span>
+        <button
+          className="remove"
+          onClick={this.remove}
+          aria-label={`Remove ${product.name}`}>
+          ✕
+        </button>
+      </li>
+    );
+  }
+}

--- a/examples/pages/apps/store/Product.tsx
+++ b/examples/pages/apps/store/Product.tsx
@@ -1,0 +1,96 @@
+import { Component, get } from '@expressive/react';
+import { Link, Route } from '@expressive/router';
+
+import { Breadcrumbs } from './Breadcrumbs';
+import { categoryLabel, getProduct, usd } from './catalog';
+import { Cart } from './Store';
+
+export class ProductPage extends Component {
+  route = get(Route);
+  cart = get(Cart);
+
+  // The "buy N" stepper - reactive field on the component itself. Assigning it
+  // re-renders, no useState needed.
+  qty = 1;
+
+  // Getters derive from route + qty and recompute only when those change -
+  // render() stays thin markup over them.
+  get product() {
+    const id = this.route.match?.id;
+    return id ? getProduct(id) : undefined;
+  }
+
+  get subtotal() {
+    return this.product ? this.product.price * this.qty : 0;
+  }
+
+  quantity(by: number) {
+    this.qty = Math.max(1, this.qty + by);
+  }
+
+  addToCart() {
+    this.cart.add(this.product!.id, this.qty);
+    this.qty = 1;
+  }
+
+  render() {
+    const { product, qty, subtotal } = this;
+
+    if (!product) return <NotFound />;
+
+    return (
+      <div className="product">
+        <Breadcrumbs
+          trail={[
+            { label: 'Store', to: '/' },
+            {
+              label: categoryLabel(product.category),
+              to: `/category/${product.category}`
+            },
+            { label: product.name }
+          ]}
+        />
+
+        <div className="hero">
+          <span className="hero-emoji">{product.emoji}</span>
+          <div className="hero-info">
+            <h1>{product.name}</h1>
+            <p className="hero-price">{usd(product.price)}</p>
+
+            <Stepper />
+
+            <button className="primary" onClick={this.addToCart}>
+              Add {qty} to cart · {usd(subtotal)}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+// A Component provides itself to context, so dumb slices under it pull state
+// the same way they would from any State - no props, no subclass seam.
+const Stepper = () => {
+  const { qty, quantity } = ProductPage.get();
+
+  return (
+    <div className="qty">
+      <button onClick={() => quantity(-1)} aria-label="Decrease quantity">
+        −
+      </button>
+      <span className="qty-val">{qty}</span>
+      <button onClick={() => quantity(1)} aria-label="Increase quantity">
+        +
+      </button>
+    </div>
+  );
+};
+
+const NotFound = () => (
+  <div className="notice">
+    <span className="big-emoji">🫥</span>
+    <h1>Product not found</h1>
+    <Link to="/">Back to the store</Link>
+  </div>
+);

--- a/examples/pages/apps/store/Store.ts
+++ b/examples/pages/apps/store/Store.ts
@@ -1,0 +1,49 @@
+import State, { map } from '@expressive/react';
+
+import { Line } from './Line';
+
+// One cart, provided at the app root and read by every page via Cart.get().
+export class Cart extends State {
+  // Keyed by product id, spawning a Line per entry. The key is the retrieval
+  // handle, so `add` finds an existing line and bumps it instead of rebuilding
+  // a record - and a line that steps to zero evicts itself.
+  items = map((id: string) => new Line(id));
+
+  // After checkout we stash a receipt to show the confirmation, then empty.
+  receipt: null | { count: number; total: number } = null;
+
+  add(id: string, qty = 1) {
+    const line = this.items.get(id) ?? this.items.set(id).get(id)!;
+
+    line.qty += qty;
+  }
+
+  checkout() {
+    if (!this.count) return;
+
+    this.receipt = { count: this.count, total: this.total };
+    this.items.clear();
+  }
+
+  reset() {
+    this.receipt = null;
+  }
+
+  // `values(fn)` tracks the map's shape plus each line it visits, so these
+  // recompute when a line is added, evicted, or restepped.
+  get count() {
+    return sum(this.items.values((line) => line.qty));
+  }
+
+  get total() {
+    return sum(this.items.values((line) => line.subtotal));
+  }
+}
+
+const sum = (values: Iterable<number>) => {
+  let total = 0;
+
+  for (const value of values) total += value;
+
+  return total;
+};

--- a/examples/pages/apps/store/Storefront.tsx
+++ b/examples/pages/apps/store/Storefront.tsx
@@ -1,0 +1,42 @@
+import { Link, Route } from '@expressive/router';
+
+import { categories, inCategory, products, usd } from './catalog';
+
+// Reads its own Route to tell which listing to show; holds no state and
+// provides nothing, so a plain function that consumes Route.get(). It does
+// double duty: the index route (all products) AND `category/:cat` (filtered).
+export const Storefront = () => {
+  // `cat` is present on /category/:cat, absent on the index route. Same-pattern
+  // navigation (food -> animals) reconciles in place, re-reading match.
+  const { match } = Route.get();
+  const cat = match?.cat;
+  const shown = cat ? inCategory(cat) : products;
+
+  return (
+    <div className="storefront">
+      <nav className="chips">
+        <Link to="/" className={cat ? 'chip' : 'chip on'}>
+          All
+        </Link>
+        {categories.map((c) => (
+          <Link
+            key={c.slug}
+            to={`/category/${c.slug}`}
+            className={cat === c.slug ? 'chip on' : 'chip'}>
+            {c.label}
+          </Link>
+        ))}
+      </nav>
+
+      <div className="grid">
+        {shown.map((p) => (
+          <Link key={p.id} to={`/product/${p.id}`} className="card">
+            <span className="card-emoji">{p.emoji}</span>
+            <span className="card-name">{p.name}</span>
+            <span className="card-price">{usd(p.price)}</span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/examples/pages/apps/store/catalog.ts
+++ b/examples/pages/apps/store/catalog.ts
@@ -1,0 +1,94 @@
+export interface Product {
+  id: string;
+  emoji: string;
+  name: string;
+  category: string;
+  price: number;
+}
+
+export interface Category {
+  slug: string;
+  label: string;
+}
+
+// The "inventory": emoji grouped by category. One source of truth that the
+// storefront grid, product page, and breadcrumbs all read from.
+const INVENTORY = {
+  Food: {
+    Pizza: '🍕',
+    Burger: '🍔',
+    Taco: '🌮',
+    Sushi: '🍣',
+    Donut: '🍩',
+    IceCream: '🍦'
+  },
+  Animals: {
+    Dog: '🐶',
+    Cat: '🐱',
+    Fox: '🦊',
+    Panda: '🐼',
+    Lion: '🦁',
+    Penguin: '🐧'
+  },
+  Faces: {
+    Grinning: '😀',
+    Cool: '😎',
+    Robot: '🤖',
+    Ghost: '👻',
+    Cowboy: '🤠',
+    Party: '🥳'
+  },
+  Nature: {
+    Cactus: '🌵',
+    Wave: '🌊',
+    Fire: '🔥',
+    Rainbow: '🌈',
+    Star: '⭐',
+    Moon: '🌙'
+  }
+};
+
+// Keys are PascalCase identifiers; split into words for display ("IceCream"
+// -> "Ice Cream"), then kebab for ids/urls ("ice-cream").
+const label = (key: string) => key.replace(/([a-z])([A-Z])/g, '$1 $2');
+
+const slug = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
+
+// Prices are rolled once, at module load, from a fixed range - so they stay
+// stable while you browse but differ run-to-run.
+const roll = () => Math.round((2 + Math.random() * 48) * 100) / 100;
+
+export const categories: Category[] = Object.keys(INVENTORY).map((key) => ({
+  slug: slug(key),
+  label: label(key)
+}));
+
+export const products: Product[] = Object.entries(INVENTORY).flatMap(
+  ([category, items]) =>
+    Object.entries(items).map(([key, emoji]) => {
+      const name = label(key);
+
+      return {
+        id: slug(name),
+        emoji,
+        name,
+        category: slug(category),
+        price: roll()
+      };
+    })
+);
+
+const byId = new Map(products.map((p) => [p.id, p]));
+
+export const getProduct = (id: string) => byId.get(id);
+
+export const inCategory = (cat: string) =>
+  products.filter((p) => p.category === cat);
+
+export const categoryLabel = (cat: string) => {
+  const found = categories.find((c) => c.slug === cat);
+  return found ? found.label : cat;
+};
+
+export const usd = (n: number) =>
+  n.toLocaleString('en-US', { style: 'currency', currency: 'USD' });


### PR DESCRIPTION
## Scope

Adds an advanced example under `examples/pages/apps/store/` — a fake **emoji storefront** with a shopping cart — registered in the apps manifest as `store`. It's the showcase for **a keyed spawning `map` as the cart**, with self-rendering, self-evicting `Component` line items, wired through nested `@expressive/router` routing and a context-provided `Cart`.

## What it does

- **Grid** of emoji products across categories (`catalog.ts`); a **category filter** — the storefront serves both the index route and `category/:cat`, branching on the route match.
- **Product page** with data-driven **breadcrumbs** (`Store › Category › Product`) and a quantity stepper for buying multiples.
- **Dedicated `/cart` route**: line items with per-line qty controls, per-line subtotals, a running total, and **checkout → receipt** confirmation.
- Persistent header (brand + cart badge) via a `Layout` route; the badge subscribes to `count` only, so it re-renders on count changes but not on unrelated cart mutations.

## Key decisions

- **`Cart.items = map((id) => new Line(id))` — a keyed spawning map**, keyed by product id. `add` finds an existing line and bumps its qty or spawns one, so a single code path covers first-add and every repeat. `count` / `total` are memoized getters over `items.values(fn)`, which tracks the map's shape plus each line it visits, so they recompute on add/evict/restep.
- **`Line` is a self-rendering `Component`** the map spawns, keyed by product id. It owns its `qty` and renders its own row, so the cart page drops the map straight into the tree — no `<CartLine>`, no props, no key. Stepping a line to zero destroys it (`this.set(null)`), which evicts it from the map; `checkout` stashes a receipt then `items.clear()`.
- **Context-provided `Cart`** (`<Provider for={Cart}>`) above one in-memory `Router`, so every page shares the same cart via `Cart.get()` and navigation stays inside the iframe.
- **Categories (not flat)** so breadcrumbs have a meaningful hierarchy and the routing tree exercises nested/param matching.
- Scoped `App.css`; components split into `Store.ts` (cart model), `Line.tsx`, `Storefront.tsx`, `Product.tsx`, `Cart.tsx`, `Breadcrumbs.tsx`, and `catalog.ts` (data).

## Verification

Type-checks clean against the examples project (`tsc --noEmit`); the one pre-existing, unrelated `packages/router/src/route.tsx` error is present on `main` regardless. No leftover logs/TODOs. Runtime behavior not re-exercised in this pass — happy to drive it in the dev server (grid, category filter, breadcrumbs, cart math, checkout receipt) if you want that on the record.

## Changeset

None — the `@expressive/examples` package is private and changeset-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
