### PR TITLE
feat(examples): instructions section + polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ await expect(state).not.toHaveUpdated();
 - When starting actual work, switch from any agent-scratch branch (`claude/*`) to a conventional named branch (`feat/...`, `fix/...`, `chore/...`) before the first real commit.
 - Always open PRs against `main` unless explicitly told otherwise. Never assume a PR should target another branch, even when the current work branch is stacked on one. If asked to break a fix out of a larger branch, the intent is to land it independently off `main` - carve out only the change in question and base its branch on `main`.
 - For new features and non-trivial refactors, capture agreed scope, key decisions, and approach in the PR description before implementation - it is the canonical shared plan and review context. (Working notes may live in untracked local scratch; only the PR description is shared.)
+- Prefer more, logically-scoped commits within a branch over one squashed blob - the PR itself squashes on merge, so granular commits cost nothing and give better evolution tracking during review.
 - Write a changeset (`bun run changeset`) when a change is user-facing: new feature, behavior change, API addition, breaking change.
 - No changeset for internal refactors, test-only changes, or fixes with no observable effect. A zero-changeset PR is legitimate.
 

--- a/examples/app/Shell.module.css
+++ b/examples/app/Shell.module.css
@@ -165,6 +165,22 @@
   font-weight: 600;
 }
 
+.codeLabel {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  padding: 1px 4px;
+  margin-right: 3px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+}
+
+.groupItems a[aria-current='page'] .codeLabel {
+  background: var(--accent-soft);
+  border-color: transparent;
+  color: var(--accent);
+}
+
 .logo {
   display: flex;
   align-items: center;

--- a/examples/app/Shell.tsx
+++ b/examples/app/Shell.tsx
@@ -1,5 +1,5 @@
 import { Component, get, Provider, ref } from '@expressive/react';
-import { BrowserRouter, NavLinks, Route, Router } from '@expressive/router';
+import { BrowserRouter, Link, NavLinks, Route, Router } from '@expressive/router';
 
 import Logo from './Logo';
 import Theme, { Toggle } from './Theme';
@@ -46,9 +46,26 @@ function Window(props: { children?: React.ReactNode }) {
   );
 }
 
+// Labels may carry backtick spans (e.g. "`ref()` Single") - render the odd
+// segments as inline <code> so the instruction name reads as monospace.
+const renderLabel = (label: string): React.ReactNode =>
+  label.split('`').map((part, i) =>
+    i % 2 ? <code key={i} className={styles.codeLabel}>{part}</code> : part
+  );
+
 class Navigation extends NavLinks {
   List(props: { children?: React.ReactNode }) {
     return <div className={styles.links}>{props.children}</div>;
+  }
+
+  Item(props: { route: Route; active: boolean; label?: string }) {
+    const { route, active, label } = props;
+
+    return (
+      <Link to={route.path} aria-current={active ? 'page' : undefined}>
+        {label ? renderLabel(label) : route.path}
+      </Link>
+    );
   }
 
   Group(props: { route: Route; children?: React.ReactNode }) {
@@ -67,7 +84,7 @@ function Outlet() {
   if (meta)
     return (
       <Code key={meta.path} path={meta.path}>
-        <ExampleFrame key={meta.file} file={meta.file} label={label} />
+        <ExampleFrame key={meta.file} file={meta.file} label={label?.replace(/`/g, '')} />
       </Code>
     );
 }

--- a/examples/pages.ts
+++ b/examples/pages.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react';
 
 export interface GroupModule {
-  default: string[];
+  default: string[] | Record<string, string>;
   label?: string;
 }
 
@@ -49,10 +49,15 @@ export const tree = (() => {
   for (const key in manifests)
     dirs[strip(key)] = manifests[key];
 
-  const build = (dir: string): Directory[] =>
-    (dirs[dir]?.default ?? []).map((slug): Directory => {
+  const build = (dir: string): Directory[] => {
+    const manifest = dirs[dir]?.default ?? [];
+    const entries = Array.isArray(manifest)
+      ? manifest.map((slug) => [slug, undefined] as [string, string?])
+      : Object.entries(manifest);
+
+    return entries.map(([slug, name]): Directory => {
       const path = dir ? `${dir}/${slug}` : slug;
-      const label = dirs[path]?.label ?? titleCase(slug);
+      const label = name ?? dirs[path]?.label ?? titleCase(slug);
       const children = dirs[path] && build(path);
       const file = `${BASE}${path}/App.tsx`;
 
@@ -64,6 +69,7 @@ export const tree = (() => {
         file: !children && file in apps ? file : undefined,
       };
     });
+  };
 
   return build('');
 })();

--- a/examples/pages/essentials/index.ts
+++ b/examples/pages/essentials/index.ts
@@ -1,1 +1,1 @@
-export default ['counter', 'computed', 'fetch', 'async', 'boundary'];
+export default ['counter', 'computed', 'fetch', 'async', 'suspense', 'boundary'];

--- a/examples/pages/essentials/suspense/App.css
+++ b/examples/pages/essentials/suspense/App.css
@@ -1,0 +1,16 @@
+.result {
+  font-size: var(--t-lg);
+  color: var(--fg);
+}
+
+.status {
+  color: var(--muted);
+}
+
+.status.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  color: var(--fg);
+}

--- a/examples/pages/essentials/suspense/App.tsx
+++ b/examples/pages/essentials/suspense/App.tsx
@@ -1,0 +1,68 @@
+import './App.css';
+
+import { Suspense } from 'react';
+import State, { Component, Provider, set } from '@expressive/react';
+
+// An async `set` factory suspends on read and resolves straight into the
+// field - no `waiting` flag, no `error` state threaded by hand. Compare
+// essentials/fetch, which tracks that same lifecycle manually.
+class Greeter extends State {
+  hello = set(async () => {
+    const res = await fetch('https://randomuser.me/api?nat=us&results=1');
+
+    if (!res.ok) throw new Error(`Server responded ${res.status}.`);
+
+    const { first, last } = (await res.json()).results[0].name;
+    return `Hello, ${first} ${last}.`;
+  });
+}
+
+// Reading `hello` while pending throws the suspense signal <Suspense>
+// catches; a rejected fetch throws past it to the boundary's catch().
+function Hello() {
+  return <p className="result">{Greeter.get().hello}</p>;
+}
+
+// The Greeter is provided *above* <Suspense> so it survives the suspended
+// renders - an instance created inside the boundary would be rebuilt (and
+// refetch) on every retry. Bumping `round` remounts it for a fresh request.
+export default class Demo extends Component {
+  round = 0;
+  resume = () => {};
+
+  catch(error: Error) {
+    this.fallback = (
+      <div className="status error">
+        <p>{error.message}</p>
+        <button onClick={() => this.again()}>Try again</button>
+      </div>
+    );
+
+    return new Promise<void>((resolve) => (this.resume = resolve));
+  }
+
+  again() {
+    this.round++;
+    this.resume();
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <h1>Suspense</h1>
+        <p>
+          The greeting is an async <code>set</code> factory. Reading it
+          suspends until the fetch resolves — no waiting flag, no error field.
+        </p>
+
+        <Provider for={Greeter} key={this.round}>
+          <Suspense fallback={<p className="status">Contacting server…</p>}>
+            <Hello />
+          </Suspense>
+        </Provider>
+
+        <button onClick={() => this.again()}>Say hello again</button>
+      </div>
+    );
+  }
+}

--- a/examples/pages/instructions/def/App.css
+++ b/examples/pages/instructions/def/App.css
@@ -1,0 +1,24 @@
+.container label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s1);
+  text-align: left;
+  width: 100%;
+}
+
+.container label small {
+  font-weight: 400;
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+}
+
+.stepper output {
+  font-family: var(--font-mono);
+  font-size: var(--t-xl);
+  min-width: 2ch;
+  text-align: center;
+}

--- a/examples/pages/instructions/def/App.css
+++ b/examples/pages/instructions/def/App.css
@@ -1,13 +1,18 @@
 .container label {
   display: flex;
   flex-direction: column;
-  gap: var(--s1);
-  text-align: left;
+  gap: var(--s2);
   width: 100%;
+  padding: var(--s4);
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
 }
 
 .container label small {
   font-weight: 400;
+  color: var(--muted);
 }
 
 .stepper {
@@ -16,9 +21,15 @@
   gap: var(--s3);
 }
 
+.stepper button {
+  min-width: 3rem;
+  font-family: var(--font-mono);
+}
+
 .stepper output {
+  flex: 1;
   font-family: var(--font-mono);
   font-size: var(--t-xl);
-  min-width: 2ch;
   text-align: center;
+  color: var(--accent);
 }

--- a/examples/pages/instructions/def/App.tsx
+++ b/examples/pages/instructions/def/App.tsx
@@ -1,0 +1,64 @@
+import './App.css';
+
+import { Component, def } from '@expressive/react';
+
+// `def` is the low-level primitive every other instruction is built on. Its
+// factory runs at init and returns a property descriptor; a `set` that
+// returns a value rewrites each assignment. Two tiny reusable instructions:
+
+// Keeps a number within range.
+function clamped(value: number, min: number, max: number) {
+  return def<number>(() => ({
+    value,
+    set: (next) => Math.min(max, Math.max(min, next))
+  }));
+}
+
+// Coerces every assignment into a URL-safe slug.
+function slug(value = '') {
+  return def<string>(() => ({
+    value,
+    set: (next) => next.toLowerCase().replace(/[^a-z0-9]+/g, '-')
+  }));
+}
+
+class Profile extends Component {
+  volume = clamped(5, 0, 10);
+  handle = slug('');
+
+  render() {
+    const { volume, handle } = this;
+
+    return (
+      <div className="container">
+        <h1>Custom Instruction</h1>
+
+        <p>
+          Both fields are governed by instructions we defined with{' '}
+          <code>def</code> - the same primitive <code>set</code> and{' '}
+          <code>get</code> are built on.
+        </p>
+
+        <label>
+          Volume <small>(clamped to 0–10)</small>
+          <div className="stepper">
+            <button onClick={() => (this.volume -= 3)}>−3</button>
+            <output>{volume}</output>
+            <button onClick={() => (this.volume += 3)}>+3</button>
+          </div>
+        </label>
+
+        <label>
+          Handle <small>(slugified on input)</small>
+          <input
+            value={handle}
+            placeholder="Type A Name"
+            onChange={(e) => (this.handle = e.target.value)}
+          />
+        </label>
+      </div>
+    );
+  }
+}
+
+export default () => <Profile />;

--- a/examples/pages/instructions/get/App.css
+++ b/examples/pages/instructions/get/App.css
@@ -1,0 +1,19 @@
+.ballot {
+  gap: var(--s1);
+}
+
+.candidate {
+  border: 1px solid var(--border);
+  text-align: center;
+  font-weight: 500;
+}
+
+.candidate.chosen {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.tally {
+  color: var(--muted);
+}

--- a/examples/pages/instructions/get/App.css
+++ b/examples/pages/instructions/get/App.css
@@ -1,19 +1,38 @@
 .ballot {
-  gap: var(--s1);
+  gap: var(--s2);
 }
 
 .candidate {
-  border: 1px solid var(--border);
+  padding: var(--s3);
   text-align: center;
   font-weight: 500;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.candidate:hover {
+  border-color: var(--border-2);
+  background: var(--surface-2);
 }
 
 .candidate.chosen {
-  border-color: var(--accent);
-  background: var(--accent-soft);
   color: var(--accent);
+  background: var(--accent-soft);
+  border-color: var(--accent);
 }
 
 .tally {
+  margin: 0;
+  padding: var(--s2) var(--s4);
+  font-size: var(--t-sm);
   color: var(--muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+
+.tally b {
+  color: var(--fg);
 }

--- a/examples/pages/instructions/get/App.css
+++ b/examples/pages/instructions/get/App.css
@@ -36,3 +36,13 @@
 .tally b {
   color: var(--fg);
 }
+
+.add {
+  display: flex;
+  gap: var(--s2);
+  width: 100%;
+}
+
+.add button {
+  flex: 0 0 auto;
+}

--- a/examples/pages/instructions/get/App.tsx
+++ b/examples/pages/instructions/get/App.tsx
@@ -47,12 +47,17 @@ function Tally() {
 
 export default class App extends Component {
   roster = ['Ada', 'Alan', 'Grace'];
+  draft = '';
 
   add() {
-    this.roster = [...this.roster, `Guest ${this.roster.length + 1}`];
+    const name = this.draft.trim() || `Guest ${this.roster.length + 1}`;
+    this.roster = [...this.roster, name];
+    this.draft = '';
   }
 
   render() {
+    const { roster, draft } = this;
+
     return (
       <div className="container">
         <h1>Context Collection</h1>
@@ -60,11 +65,23 @@ export default class App extends Component {
         <Provider for={Poll}>
           <Tally />
           <ul className="ballot">
-            {this.roster.map((name) => (
+            {roster.map((name) => (
               <Candidate key={name} name={name} />
             ))}
           </ul>
-          <button onClick={() => this.add()}>Add candidate</button>
+          <form
+            className="add"
+            onSubmit={(e) => {
+              e.preventDefault();
+              this.add();
+            }}>
+            <input
+              value={draft}
+              placeholder={`Guest ${roster.length + 1}`}
+              onChange={(e) => (this.draft = e.target.value)}
+            />
+            <button type="submit">Add</button>
+          </form>
         </Provider>
       </div>
     );

--- a/examples/pages/instructions/get/App.tsx
+++ b/examples/pages/instructions/get/App.tsx
@@ -1,0 +1,72 @@
+import './App.css';
+
+import State, { Component, get, Provider } from '@expressive/react';
+
+// The same instruction reaches both directions of the context tree.
+// Downstream: get(Candidate, true) collects every Candidate mounted below,
+// and the array tracks them as they mount and unmount - no registration.
+class Poll extends State {
+  candidates = get(Candidate, true);
+  choice = '';
+
+  get leader() {
+    return this.choice || '—';
+  }
+}
+
+// Upstream: get(Poll) hands each Candidate the poll it lives under, so a
+// click writes the shared choice and every candidate restyles.
+class Candidate extends Component {
+  poll = get(Poll);
+  name = '';
+
+  render() {
+    const { poll, name } = this;
+
+    return (
+      <li
+        className={poll.choice === name ? 'candidate chosen' : 'candidate'}
+        onClick={() => (poll.choice = name)}>
+        {name}
+      </li>
+    );
+  }
+}
+
+// A separate consumer reads the collected array - it re-renders as the
+// roster grows or shrinks, and when the shared choice changes.
+function Tally() {
+  const { candidates, leader } = Poll.get();
+
+  return (
+    <p className="tally">
+      {candidates.length} on the ballot · chose <b>{leader}</b>
+    </p>
+  );
+}
+
+export default class App extends Component {
+  roster = ['Ada', 'Alan', 'Grace'];
+
+  add() {
+    this.roster = [...this.roster, `Guest ${this.roster.length + 1}`];
+  }
+
+  render() {
+    return (
+      <div className="container">
+        <h1>Context Collection</h1>
+
+        <Provider for={Poll}>
+          <Tally />
+          <ul className="ballot">
+            {this.roster.map((name) => (
+              <Candidate key={name} name={name} />
+            ))}
+          </ul>
+          <button onClick={() => this.add()}>Add candidate</button>
+        </Provider>
+      </div>
+    );
+  }
+}

--- a/examples/pages/instructions/has-list/App.css
+++ b/examples/pages/instructions/has-list/App.css
@@ -1,0 +1,67 @@
+.log {
+  max-width: 28rem;
+}
+
+.entries {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s1);
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.entries li {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s2) var(--s3);
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  cursor: default;
+}
+
+.entries .idx {
+  flex: 0 0 auto;
+  min-width: 1.5rem;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--muted);
+  text-align: right;
+}
+
+.entries .entry {
+  flex: 1;
+}
+
+.log form {
+  display: flex;
+  gap: var(--s2);
+  width: 100%;
+}
+
+.log form button {
+  flex: 0 0 auto;
+}
+
+.log footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s3);
+  width: 100%;
+}
+
+.log footer .ghost {
+  padding: var(--s1) var(--s3);
+  font-size: var(--t-sm);
+}
+
+.log footer .ghost:disabled {
+  opacity: 0.5;
+  cursor: default;
+  border-color: var(--border);
+}

--- a/examples/pages/instructions/has-list/App.tsx
+++ b/examples/pages/instructions/has-list/App.tsx
@@ -1,0 +1,69 @@
+import './App.css';
+
+import { Component, has } from '@expressive/react';
+
+// `has<string>()` is the list mode: an ordered collection of plain values you
+// push, addressed by index. No spawned members, no keys - just a log. Reads
+// track precisely, so `get(-1)` re-renders on a new tail, `size` on length.
+export default class Editor extends Component {
+  history = has<string>();
+  draft = '';
+
+  protected new() {
+    this.history.push('open document');
+  }
+
+  commit(text = this.draft) {
+    text = text.trim();
+    if (!text) return;
+    this.history.push(text);
+    this.draft = '';
+  }
+
+  undo() {
+    this.history.pop();
+  }
+
+  render() {
+    const { history, draft } = this;
+
+    return (
+      <div className="container log">
+        <h1>Owned List</h1>
+        <p>
+          <code>has&lt;string&gt;()</code> stores values by position. Push to
+          append, pop to undo; <code>get(-1)</code> reads the latest entry.
+        </p>
+
+        <ol className="entries">
+          {[...history].map((entry, i) => (
+            <li key={i}>
+              <span className="idx">{i}</span>
+              <span className="entry">{entry}</span>
+            </li>
+          ))}
+        </ol>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            this.commit();
+          }}>
+          <input
+            value={draft}
+            placeholder="Record an action…"
+            onChange={(e) => (this.draft = e.target.value)}
+          />
+          <button type="submit">Push</button>
+        </form>
+
+        <footer>
+          <small>{history.size} entries · latest: {history.get(-1) ?? '—'}</small>
+          <button className="ghost" onClick={() => this.undo()} disabled={!history.size}>
+            Undo
+          </button>
+        </footer>
+      </div>
+    );
+  }
+}

--- a/examples/pages/instructions/has/App.css
+++ b/examples/pages/instructions/has/App.css
@@ -1,29 +1,159 @@
-ul {
-  list-style: none;
-  padding: 0;
+.todo {
+  max-width: 26rem;
 }
 
-li {
+.card {
+  width: 100%;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  text-align: left;
+}
+
+.card > form {
+  display: flex;
+  gap: var(--s2);
+  margin: 0;
+  padding: var(--s3);
+  border-bottom: 1px solid var(--border);
+}
+
+.card > form input {
+  border: none;
+  background: transparent;
+  padding: var(--s2);
+}
+
+.card > form input:focus {
+  outline: none;
+  border: none;
+}
+
+.card > form button {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  padding: 0;
+  font-size: var(--t-xl);
+  line-height: 1;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: none;
+}
+
+.card > form button:hover {
+  color: var(--accent-fg);
+  background: var(--accent);
+}
+
+.card ul {
+  gap: 0;
+}
+
+.card li {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--s3);
+  padding: var(--s3);
+  border-radius: 0;
+  border-bottom: 1px solid var(--border);
+  cursor: default;
+  transition: background 0.15s;
 }
 
-li span {
-  cursor: pointer;
+.card li:hover {
+  background: var(--surface-2);
+}
+
+.card li span {
   flex: 1;
+  cursor: pointer;
 }
 
-li.done {
-  opacity: 0.55;
+.check {
+  position: relative;
+  flex: 0 0 auto;
+  width: 1.2rem;
+  height: 1.2rem;
+  padding: 0;
+  border: 1.5px solid var(--border-2);
+  border-radius: 50%;
+  background: var(--bg);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.check:hover {
+  border-color: var(--accent);
+}
+
+.done .check {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.done .check::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 6px;
+  width: 4px;
+  height: 8px;
+  border: solid var(--accent-fg);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.done {
+  opacity: 0.6;
+}
+
+.done span {
   text-decoration: line-through;
 }
 
-footer {
+.remove {
+  flex: 0 0 auto;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  font-size: var(--t-lg);
+  line-height: 1;
+  color: var(--muted);
+  background: transparent;
+  border: none;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.card li:hover .remove {
+  opacity: 1;
+}
+
+.remove:hover {
+  color: var(--fg);
+  border: none;
+}
+
+.card footer {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  margin-top: 1rem;
+  justify-content: space-between;
+  gap: var(--s3);
+  padding: var(--s3);
+}
+
+.card footer .ghost {
+  padding: var(--s1) var(--s3);
+  font-size: var(--t-sm);
+  color: var(--muted);
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+.card footer .ghost:hover {
+  color: var(--fg);
+  border-color: var(--border-2);
 }

--- a/examples/pages/instructions/has/App.tsx
+++ b/examples/pages/instructions/has/App.tsx
@@ -33,27 +33,37 @@ export default class TodoList extends Component {
     const { todos, draft, remaining } = this;
 
     return (
-      <div className="container">
+      <div className="container todo">
         <h1>Owned Collections</h1>
+        <p>
+          <code>has(Item)</code> is a pool that spawns and owns its members.
+          Each todo is its own Component, so dropping the pool into the tree
+          is the whole render.
+        </p>
 
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            this.add();
-          }}>
-          <input
-            value={draft}
-            placeholder="Add a todo, press Enter"
-            onChange={(e) => (this.draft = e.target.value)}
-          />
-        </form>
+        <div className="card">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              this.add();
+            }}>
+            <input
+              value={draft}
+              placeholder="Add a task…"
+              onChange={(e) => (this.draft = e.target.value)}
+            />
+            <button type="submit" aria-label="add">+</button>
+          </form>
 
-        <ul>{todos}</ul>
+          <ul>{todos}</ul>
 
-        <footer>
-          <small>{remaining} of {todos.size} remaining</small>
-          <button onClick={() => this.clearDone()}>Clear done</button>
-        </footer>
+          <footer>
+            <small>{remaining} of {todos.size} left</small>
+            <button className="ghost" onClick={() => this.clearDone()}>
+              Clear done
+            </button>
+          </footer>
+        </div>
       </div>
     );
   }
@@ -78,8 +88,9 @@ class Item extends Component {
   render() {
     return (
       <li className={this.done ? 'done' : ''}>
+        <button className="check" onClick={this.toggle} aria-label="toggle" />
         <span onClick={this.toggle}>{this.text}</span>
-        <button onClick={this.remove} aria-label="remove">×</button>
+        <button className="remove" onClick={this.remove} aria-label="remove">×</button>
       </li>
     );
   }

--- a/examples/pages/instructions/index.ts
+++ b/examples/pages/instructions/index.ts
@@ -1,8 +1,8 @@
 export default {
-  ref: 'ref()',
-  set: 'set()',
-  get: 'get()',
-  has: 'has()',
-  map: 'map()',
-  def: 'def()'
+  ref: '`ref()`',
+  set: '`set()`',
+  get: '`get()`',
+  has: '`has()`',
+  map: '`map()`',
+  def: '`def()`'
 };

--- a/examples/pages/instructions/index.ts
+++ b/examples/pages/instructions/index.ts
@@ -1,8 +1,11 @@
 export default {
-  ref: '`ref()`',
+  ref: '`ref()` Single',
+  'ref-multiple': '`ref()` Multiple',
   set: '`set()`',
   get: '`get()`',
-  has: '`has()`',
-  map: '`map()`',
+  has: '`has()` Pool',
+  'has-list': '`has()` List',
+  map: '`map()` Create',
+  'map-insert': '`map()` Insert',
   def: '`def()`'
 };

--- a/examples/pages/instructions/index.ts
+++ b/examples/pages/instructions/index.ts
@@ -1,1 +1,8 @@
-export default ['ref', 'map', 'has'];
+export default {
+  ref: 'ref()',
+  set: 'set()',
+  get: 'get()',
+  has: 'has()',
+  map: 'map()',
+  def: 'def()'
+};

--- a/examples/pages/instructions/map-insert/App.css
+++ b/examples/pages/instructions/map-insert/App.css
@@ -1,0 +1,62 @@
+.inv {
+  max-width: 26rem;
+}
+
+.stock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s2);
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stock li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s3);
+  padding: var(--s2) var(--s3);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  cursor: default;
+}
+
+.stock .name {
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.qty {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+}
+
+.qty button {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  font-family: var(--font-mono);
+  line-height: 1;
+}
+
+.qty output {
+  min-width: 1.5ch;
+  font-family: var(--font-mono);
+  font-size: var(--t-lg);
+  text-align: center;
+  color: var(--accent);
+}
+
+.inv form {
+  display: flex;
+  gap: var(--s2);
+  width: 100%;
+}
+
+.inv form button {
+  flex: 0 0 auto;
+}

--- a/examples/pages/instructions/map-insert/App.tsx
+++ b/examples/pages/instructions/map-insert/App.tsx
@@ -1,0 +1,70 @@
+import './App.css';
+
+import { Component, map } from '@expressive/react';
+
+// `map<K, V>()` is the insert mode: a reactive Map of values you place by
+// key with `set(key, value)` - no factory, no spawning. Bumping one key
+// notifies only that entry; adding or removing a key notifies shape.
+export default class Inventory extends Component {
+  stock = map<string, number>();
+  item = '';
+
+  protected new() {
+    this.stock.set('apples', 3);
+    this.stock.set('bread', 1);
+    this.stock.set('milk', 2);
+  }
+
+  add(name = this.item) {
+    name = name.trim().toLowerCase();
+    if (!name) return;
+    this.stock.set(name, (this.stock.get(name) ?? 0) + 1);
+    this.item = '';
+  }
+
+  render() {
+    const { stock, item } = this;
+    const total = [...stock.values()].reduce((sum, n) => sum + n, 0);
+
+    return (
+      <div className="container inv">
+        <h1>Reactive Map</h1>
+        <p>
+          <code>map&lt;string, number&gt;()</code> keys values you insert with{' '}
+          <code>set(key, value)</code>. Re-adding a name bumps its count in
+          place.
+        </p>
+
+        <ul className="stock">
+          {[...stock].map(([name, qty]) => (
+            <li key={name}>
+              <span className="name">{name}</span>
+              <span className="qty">
+                <button onClick={() => stock.set(name, Math.max(0, qty - 1))}>−</button>
+                <output>{qty}</output>
+                <button onClick={() => stock.set(name, qty + 1)}>+</button>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            this.add();
+          }}>
+          <input
+            value={item}
+            placeholder="Add or bump an item…"
+            onChange={(e) => (this.item = e.target.value)}
+          />
+          <button type="submit">Add</button>
+        </form>
+
+        <footer>
+          <small>{stock.size} items · {total} in stock</small>
+        </footer>
+      </div>
+    );
+  }
+}

--- a/examples/pages/instructions/ref-multiple/App.css
+++ b/examples/pages/instructions/ref-multiple/App.css
@@ -1,0 +1,28 @@
+.form {
+  max-width: 26rem;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+  width: 100%;
+}
+
+.fields label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s1);
+  text-align: left;
+  font-size: var(--t-sm);
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.form footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s3);
+  width: 100%;
+}

--- a/examples/pages/instructions/ref-multiple/App.tsx
+++ b/examples/pages/instructions/ref-multiple/App.tsx
@@ -1,0 +1,61 @@
+import './App.css';
+
+import State, { ref } from '@expressive/react';
+
+const FIELDS = [
+  { key: 'first', label: 'First name' },
+  { key: 'last', label: 'Last name' },
+  { key: 'email', label: 'Email' }
+] as const;
+
+// `ref(this)` is the plural form: one call hands back an imperative handle
+// for *every* field, keyed by name. Each `refs.first` is a callable ref -
+// `refs.first('Ada')` writes the field - so one proxy drives the whole form
+// and a loop can clear every field, with no useRef per input.
+class Profile extends State {
+  first = '';
+  last = '';
+  email = '';
+
+  refs = ref(this);
+
+  clear() {
+    for (const { key } of FIELDS)
+      this.refs[key]('');
+  }
+}
+
+function Form() {
+  const profile = Profile.use();
+  const { refs } = profile;
+  const filled = FIELDS.filter(({ key }) => profile[key]).length;
+
+  return (
+    <div className="container form">
+      <h1>Ref Proxy</h1>
+      <p>
+        <code>ref(this)</code> exposes one callable ref per field. Every input
+        writes through that proxy, and Clear loops it over all three.
+      </p>
+
+      <div className="fields">
+        {FIELDS.map(({ key, label }) => (
+          <label key={key}>
+            {label}
+            <input
+              value={profile[key]}
+              onChange={(e) => refs[key](e.target.value)}
+            />
+          </label>
+        ))}
+      </div>
+
+      <footer>
+        <small>{filled} of {FIELDS.length} filled</small>
+        <button onClick={() => profile.clear()}>Clear all</button>
+      </footer>
+    </div>
+  );
+}
+
+export default () => <Form />;

--- a/examples/pages/instructions/ref/App.css
+++ b/examples/pages/instructions/ref/App.css
@@ -1,7 +1,41 @@
-.container input {
-  display: block;
+.drag {
+  max-width: 30rem;
+}
+
+.surface {
+  position: relative;
   width: 100%;
-  padding: 0.5rem;
-  font: inherit;
-  margin-bottom: 1rem;
+  height: 17rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  background-image: radial-gradient(var(--border) 1px, transparent 1px);
+  background-size: 1.25rem 1.25rem;
+}
+
+.box {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 5rem;
+  height: 5rem;
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--accent-fg);
+  background: var(--accent);
+  border-radius: var(--r);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  transition: box-shadow 0.15s;
+}
+
+.box.dragging {
+  cursor: grabbing;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
 }

--- a/examples/pages/instructions/ref/App.css
+++ b/examples/pages/instructions/ref/App.css
@@ -10,6 +10,7 @@
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   overflow: hidden;
+  user-select: none;
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
   background-size: 1.25rem 1.25rem;
 }

--- a/examples/pages/instructions/ref/App.css
+++ b/examples/pages/instructions/ref/App.css
@@ -10,6 +10,7 @@
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   overflow: hidden;
+  -webkit-user-select: none;
   user-select: none;
   background-image: radial-gradient(var(--border) 1px, transparent 1px);
   background-size: 1.25rem 1.25rem;
@@ -32,6 +33,7 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
   cursor: grab;
   touch-action: none;
+  -webkit-user-select: none;
   user-select: none;
   transition: box-shadow 0.15s;
 }

--- a/examples/pages/instructions/ref/App.tsx
+++ b/examples/pages/instructions/ref/App.tsx
@@ -1,26 +1,74 @@
 import './App.css';
 
 import { Component, ref } from '@expressive/react';
+import type { PointerEvent } from 'react';
 
-// The `ref` instruction is the useRef replacement: a slot for a value
-// outside the render data - here a DOM node. Pass it straight to `ref=`
-// (it's callable) and read `.current` to reach the element imperatively.
-class Field extends Component {
-  input = ref<HTMLInputElement>();
+// `ref` is the useRef replacement: a slot for a value outside the render
+// data - here the DOM node being dragged. Its callable form captures the
+// node; `.current` reaches it to measure geometry. Position is plain x/y
+// state, so the box just follows the numbers.
+class Draggable extends Component {
+  box = ref<HTMLDivElement>();
 
-  focus() {
-    this.input.current?.focus();
+  x = 72;
+  y = 64;
+  dragging = false;
+
+  offset = { x: 0, y: 0 };
+
+  // Pointer events unify mouse and touch; capturing the pointer keeps the
+  // drag tracking even when it outruns the box.
+  grab(e: PointerEvent) {
+    const rect = this.box.current!.getBoundingClientRect();
+
+    this.offset = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    this.dragging = true;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+
+  move(e: PointerEvent) {
+    if (!this.dragging) return;
+
+    const box = this.box.current!;
+    const surface = box.parentElement!.getBoundingClientRect();
+
+    this.x = clamp(e.clientX - surface.left - this.offset.x, 0, surface.width - box.offsetWidth);
+    this.y = clamp(e.clientY - surface.top - this.offset.y, 0, surface.height - box.offsetHeight);
+  }
+
+  drop() {
+    this.dragging = false;
   }
 
   render() {
+    const { x, y, dragging } = this;
+
     return (
-      <div className="container">
+      <div className="container drag">
         <h1>Refs</h1>
-        <input ref={this.input} placeholder="Press the button to focus me" />
-        <button onClick={this.focus}>Focus the input</button>
+        <p>
+          Drag the box. Its position is plain <code>x</code>/<code>y</code>{' '}
+          state; <code>ref</code> holds the node so the handler can measure it.
+        </p>
+
+        <div className="surface">
+          <div
+            ref={this.box}
+            className={dragging ? 'box dragging' : 'box'}
+            style={{ transform: `translate(${x}px, ${y}px)` }}
+            onPointerDown={this.grab}
+            onPointerMove={this.move}
+            onPointerUp={this.drop}>
+            {Math.round(x)}, {Math.round(y)}
+          </div>
+        </div>
       </div>
     );
   }
 }
 
-export default () => <Field />;
+function clamp(n: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, n));
+}
+
+export default () => <Draggable />;

--- a/examples/pages/instructions/set/App.css
+++ b/examples/pages/instructions/set/App.css
@@ -1,18 +1,29 @@
 .container label {
   display: flex;
   flex-direction: column;
-  gap: var(--s1);
-  text-align: left;
+  gap: var(--s2);
   width: 100%;
+  padding: var(--s4);
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
 }
 
 .container label small {
   font-weight: 400;
+  color: var(--muted);
 }
 
 .result {
-  align-self: flex-start;
+  align-self: stretch;
+  margin: 0;
+  padding: var(--s2) var(--s3);
   font-family: var(--font-mono);
   font-size: var(--t-sm);
   color: var(--fg-soft);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  text-align: left;
 }

--- a/examples/pages/instructions/set/App.css
+++ b/examples/pages/instructions/set/App.css
@@ -1,0 +1,18 @@
+.container label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s1);
+  text-align: left;
+  width: 100%;
+}
+
+.container label small {
+  font-weight: 400;
+}
+
+.result {
+  align-self: flex-start;
+  font-family: var(--font-mono);
+  font-size: var(--t-sm);
+  color: var(--fg-soft);
+}

--- a/examples/pages/instructions/set/App.tsx
+++ b/examples/pages/instructions/set/App.tsx
@@ -1,0 +1,51 @@
+import './App.css';
+
+import { Component, set } from '@expressive/react';
+
+// `set` manages a slot beyond a plain field: a default value, a validator,
+// or a change-effect - each just a callback, no useEffect, no deps array.
+class Account extends Component {
+  // A default, plus a callback that vets every assignment. `throw false`
+  // rejects the update - the field never exceeds 12 characters.
+  name = set('guest', (next) => {
+    if (next.length > 12) throw false;
+  });
+
+  // The callback may return a cleanup, run before the next change - so a
+  // debounce falls out for free: each keystroke cancels the previous timer.
+  query = set('', (next) => {
+    this.result = 'typing…';
+
+    const timer = setTimeout(() => {
+      this.result = next ? `searching “${next}”` : 'idle';
+    }, 500);
+
+    return () => clearTimeout(timer);
+  });
+
+  result = 'idle';
+
+  render() {
+    const { name, query, result } = this;
+
+    return (
+      <div className="container">
+        <h1>Managed Slots</h1>
+
+        <label>
+          Display name <small>(max 12 chars — extra input is rejected)</small>
+          <input value={name} onChange={(e) => (this.name = e.target.value)} />
+        </label>
+
+        <label>
+          Search <small>(debounced 500ms by the callback’s cleanup)</small>
+          <input value={query} onChange={(e) => (this.query = e.target.value)} />
+        </label>
+
+        <p className="result">{result}</p>
+      </div>
+    );
+  }
+}
+
+export default () => <Account />;

--- a/skills/field/ref.md
+++ b/skills/field/ref.md
@@ -111,7 +111,7 @@ type ref.CustomProxy<T, R> = { [P in State.Field<T>]-?: R } & { get(): T };
 ## Behavior
 
 - Ref values are exported by `state.get()` (snapshots).
-- Ref values are accessible through tracking proxies in effects.
+- `.current` is imperative: reading it does **not** subscribe the caller, even inside a render or effect. For a reactive read, subscribe with `field.get(callback)`, or read the field through the state's tracking proxy (`state.foo`). Writing `.current` still dispatches.
 - Setting `.current` dispatches an event for the property key.
 - Callback cleanup resets nested effects (same capture semantics as `set` callbacks).
 - `null` callback is skipped by default; pass `false` as second arg to include it.


### PR DESCRIPTION
## Scope

Rounds out the **instructions** example group (one focused demo per instruction) and brings the whole set to a shared visual standard, using the `map` and `kanban` examples as the aesthetic bar.

## What's here

**New / reworked examples**
- **`set`** — managed slots: a default, a `throw false` validator (name capped at 12 chars), and a change-effect whose cleanup debounces a search.
- **`get`** — context collection: downstream `get(Candidate, true)` roster + upstream `get(Poll)` selection; an Add control takes a name via an input with a `Guest N` placeholder, falling back to that default when blank.
- **`def`** — custom instructions (`clamped`, `slug`) built on the low-level primitive.
- **`ref`** — replaced the focus-an-input demo with a pointer-draggable box. Position lives in plain `x`/`y` state; `ref` holds the node so the handler can measure geometry. Pointer events cover mouse and touch; the surface disables text selection during a drag.
- **`has`** — redesigned the todo into a proper card: accent add button, round checkbox with checkmark, hover-reveal remove, live footer count.

**Essentials**
- **`suspense`** — async `set` factory that suspends into the field. `Greeter` is provided *above* `<Suspense>` so a suspended render can't rebuild it and refetch (an earlier arrangement looped ~94 requests/3s).

**Manifest**
- Instruction group exports a `Record<slug, label>` so entries render as `ref()`, `set()`, … instead of title-cased slugs.

## Notes
- Examples app is private and changeset-ignored — no changeset.
- All examples runtime-verified in a browser (both themes): drag moves the box, todo toggle renders the checkmark, get add appends `Guest N`, suspense resolves in one request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)