### PR TITLE
feat(react): mount() lifecycle hook for client-only effects

### DIFF
--- a/.changeset/mount-lifecycle.md
+++ b/.changeset/mount-lifecycle.md
@@ -1,10 +1,12 @@
 ---
+"@expressive/mvc": minor
 "@expressive/react": minor
 ---
 
 Add `mount()`, a commit-phase lifecycle hook for a State whose lifetime a
-component owns - `State.use()` and `<Component />`. It is called once when that
-component commits, and the function it returns runs on unmount.
+component owns - `State.use()`, `<Component />`, and an instance a `Provider`
+constructs. It is called once when that component commits, and the function it
+returns runs on unmount.
 
 This fills a gap `new()` could not. `new()` runs synchronously at construction,
 which means it also runs during server render, making it the wrong home for
@@ -28,11 +30,20 @@ class Viewport extends State {
 ```
 
 `mount()` is deliberately an ownership hook, not an observation one, so it does
-not fire on paths that reach an instance owned elsewhere - `State.get()`, or
-placing one as `{instance}`. Those are many-to-one: any number of components can
-observe or place a single instance, each for less time than the instance lives,
-and a hook firing once per observer would not be a lifecycle. Use `State.get()`
-or an event to react to an instance a component does not own.
+not fire on paths that reach an instance owned elsewhere - `State.get()`,
+placing one as `{instance}`, or `<Provider for={existingInstance}>`. Those are
+many-to-one: any number of components can observe or place a single instance,
+each for less time than the instance lives, and a hook firing once per observer
+would not be a lifecycle. Use `State.get()` or an event to react to an instance
+a component does not own.
+
+A `Provider` decides per entry, so `for={{ Session, theme }}` mounts the
+`Session` it constructed and leaves the already-live `theme` alone. As with any
+parent, its `mount()` runs after its descendants' - React commits bottom-up -
+and belongs to its own commit, so replacing `for` mid-life provides the new
+State without mounting it; key the Provider to make that a fresh mount.
+`Context.set`'s per-state callback now receives the ownership flag as a second
+argument.
 
 `new()` and `use()` are unchanged: `new()` stays construction-time setup with a
 teardown, and `use()` stays the render-phase hook that intercepts `State.use()`
@@ -46,6 +57,15 @@ not used; the static now throws and is typed `never` so the call is rejected at
 compile time. Render one with `<MyComponent />` or `{instance}`, or take a bare
 instance with `MyComponent.new()`.
 
-**Known gap:** `<Provider for={SomeState}>` does own the instance it creates, so
-it should mount, but does not yet - the Provider cannot currently distinguish
-instances it created from ones it merely provides.
+**Breaking:** a `Provider`'s `is` callback no longer takes a teardown from its
+return value, which is now ignored and typed `void`. A concise arrow body
+returns whatever it evaluates - `is={x => (mine = x)}` returns the State - and
+that was indistinguishable from an intentional cleanup, so it crashed at
+teardown. Register teardown against the State instead:
+
+```tsx
+<Provider for={Session} is={(session) => session.set(null, cleanup)} />
+```
+
+`Context.set`'s own callback keeps its optional teardown, and now ignores a
+returned non-function rather than calling it.

--- a/.changeset/mount-lifecycle.md
+++ b/.changeset/mount-lifecycle.md
@@ -1,0 +1,51 @@
+---
+"@expressive/react": minor
+---
+
+Add `mount()`, a commit-phase lifecycle hook for a State whose lifetime a
+component owns - `State.use()` and `<Component />`. It is called once when that
+component commits, and the function it returns runs on unmount.
+
+This fills a gap `new()` could not. `new()` runs synchronously at construction,
+which means it also runs during server render, making it the wrong home for
+anything touching `window`, timers, or subscriptions - the workaround being a
+`typeof window === 'undefined'` guard at the top of every such hook. `mount()`
+never runs on the server, and never for an instance no component owns, so
+client-only effects can be written plainly:
+
+```tsx
+class Viewport extends State {
+  width = 0;
+
+  mount() {
+    const measure = () => (this.width = window.innerWidth);
+
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }
+}
+```
+
+`mount()` is deliberately an ownership hook, not an observation one, so it does
+not fire on paths that reach an instance owned elsewhere - `State.get()`, or
+placing one as `{instance}`. Those are many-to-one: any number of components can
+observe or place a single instance, each for less time than the instance lives,
+and a hook firing once per observer would not be a lifecycle. Use `State.get()`
+or an event to react to an instance a component does not own.
+
+`new()` and `use()` are unchanged: `new()` stays construction-time setup with a
+teardown, and `use()` stays the render-phase hook that intercepts `State.use()`
+arguments and hosts other hooks.
+
+Under StrictMode a remount repeats none of the three stages - setup, mount and
+cleanup now share one render counter.
+
+**Breaking:** `Component.use()` is no longer available. A Component is rendered,
+not used; the static now throws and is typed `never` so the call is rejected at
+compile time. Render one with `<MyComponent />` or `{instance}`, or take a bare
+instance with `MyComponent.new()`.
+
+**Known gap:** `<Provider for={SomeState}>` does own the instance it creates, so
+it should mount, but does not yet - the Provider cannot currently distinguish
+instances it created from ones it merely provides.

--- a/packages/mvc/src/context.test.ts
+++ b/packages/mvc/src/context.test.ts
@@ -733,8 +733,8 @@ describe('set method', () => {
 
     context.set({ foo, bar }, cb);
 
-    expect(cb).toBeCalledWith(foo);
-    expect(cb).toBeCalledWith(bar);
+    expect(cb).toBeCalledWith(foo, false);
+    expect(cb).toBeCalledWith(bar, false);
     expect(cb).toBeCalledTimes(2);
 
     context.set({ foo, bar }, cb);
@@ -745,7 +745,7 @@ describe('set method', () => {
 
     context.set({ foo, bar, foo2 }, cb);
 
-    expect(cb).toBeCalledWith(foo2);
+    expect(cb).toBeCalledWith(foo2, false);
     expect(cb).toBeCalledTimes(3);
   });
 
@@ -891,6 +891,38 @@ describe('set method', () => {
     expect(cleanup).toBeCalledTimes(1);
     expect(context.get(Foo, false)).toBeUndefined();
     expect(context.get(Foo2)).toBeInstanceOf(Foo2);
+  });
+
+  it('will ignore a non-function returned by forEach', () => {
+    class Foo extends State {}
+
+    const context = new Context();
+
+    // an `is`-style callback written with a concise arrow body returns the state
+    context.set(Foo, (state) => (state as any));
+
+    expect(() => context.set({})).not.toThrow();
+  });
+
+  it('will tell forEach whether context owns the state', () => {
+    class Foo extends State {}
+    class Bar extends State {}
+
+    const bar = Bar.new();
+    const didCall = mock();
+    const context = new Context();
+
+    context.set({ Foo, bar }, (state, owned) => {
+      didCall(state.constructor.name, owned);
+    });
+
+    expect(didCall).toBeCalledWith('Foo', true);
+    expect(didCall).toBeCalledWith('Bar', false);
+
+    context.pop();
+
+    expect(context.get(Foo, false)).toBeUndefined();
+    expect(bar.get(null)).toBe(false);
   });
 
   it('will call forEach cleanup on pop', () => {

--- a/packages/mvc/src/context.ts
+++ b/packages/mvc/src/context.ts
@@ -163,11 +163,14 @@ class Context {
    * Context will add or remove States as needed to keep with provided input.
    *
    * @param inputs State, State class, or map of States / State classes to register.
-   * @param forEach Optional callback to run for each State registered.
+   * @param forEach Optional callback to run for each State registered. Receives
+   *   whether this context created the State - and so will destroy it - as
+   *   opposed to it having been provided already active. May return a callback
+   *   to run before that entry is dropped.
    */
   public set<T extends State>(
     inputs: Accept<T>,
-    forEach?: (state: T) => (() => void) | void,
+    forEach?: (state: T, owned: boolean) => (() => void) | void,
   ) {
     const init = new Set<() => void>();
     const { cleanup } = this;
@@ -188,23 +191,27 @@ class Context {
 
       if (!V) continue;
 
-      if (!(State.is(V) || V instanceof State)) {
+      // a class is constructed here - and so destroyed here; an instance is
+      // adopted as-is and outlives this context
+      const owned = State.is(V);
+
+      if (!(owned || V instanceof State)) {
         const as = K == "0" || K == String(V) ? V : `${V} (as '${K}')`;
         throw new Error(
           `Context can only include an instance or class of State but got ${as}.`,
         );
       }
 
-      const state = State.is(V) ? new (V as State.Type)() : V.is;
+      const state = owned ? new (V as State.Type)() : V.is;
       const remove = this.add(state, true);
 
       init.add(() => {
         event(state);
-        const dispose = forEach && forEach(state as T);
+        const dispose = forEach?.(state as T, owned);
         cleanup.set(K, () => {
-          if (dispose) dispose();
+          if (typeof dispose == "function") dispose();
           remove();
-          if (State.is(V)) event(state, null);
+          if (owned) event(state, null);
         });
       });
     }

--- a/packages/preact/src/context.test.tsx
+++ b/packages/preact/src/context.test.tsx
@@ -227,19 +227,45 @@ describe('Provider', () => {
       expect(forEach).toBeCalledWith(expect.any(Bar));
     });
 
-    it('will cleanup on unmount', async () => {
-      const forEach = mock(() => cleanup);
+    it('will cleanup on unmount through the state', () => {
       const cleanup = mock();
+      const forEach = mock((state: State) => {
+        state.set(null, cleanup);
+      });
 
       const rendered = render(<Provider for={{ Foo, Bar }} is={forEach} />);
 
       expect(forEach).toBeCalledTimes(2);
-      expect(forEach).toBeCalledWith(expect.any(Foo));
-      expect(forEach).toBeCalledWith(expect.any(Bar));
       expect(cleanup).not.toBeCalled();
 
       rendered.unmount();
+
       expect(cleanup).toBeCalledTimes(2);
+    });
+
+    it('will mount an instance it creates', () => {
+      const didMount = mock();
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+          return didUnmount;
+        }
+      }
+
+      const rendered = render(
+        <Provider for={Test}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount).toBeCalledTimes(1);
+      expect(didUnmount).not.toBeCalled();
+
+      rendered.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
     });
   });
 

--- a/packages/preact/src/state.test.tsx
+++ b/packages/preact/src/state.test.tsx
@@ -104,6 +104,33 @@ describe('State.use', () => {
     });
   });
 
+  describe('mount method', () => {
+    it('will call once on commit', () => {
+      const didMount = mock();
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+          return didUnmount;
+        }
+      }
+
+      const element = renderHook(() => Test.use());
+
+      expect(didMount).toBeCalledTimes(1);
+
+      element.rerender();
+
+      expect(didMount).toBeCalledTimes(1);
+      expect(didUnmount).not.toBeCalled();
+
+      element.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
+    });
+  });
+
   describe('use method', () => {
     it('will call every render if present', () => {
       const didUse = mock();

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, act } from '@testing-library/react';
 import { mock, expect, it, describe } from 'bun:test';
+import { renderToString } from 'react-dom/server';
 import React from 'react';
 
 import { mockError, mockPromise, flushMicrotasks } from '../test.setup';
@@ -111,6 +112,81 @@ describe('new method', () => {
     element.rerender(<Test />);
 
     expect(didCreate).toBeCalledTimes(1);
+  });
+});
+
+describe('mount method', () => {
+  it('will call once on commit', () => {
+    const didMount = mock();
+
+    class Test extends Component {
+      mount() {
+        didMount();
+      }
+    }
+
+    const element = render(<Test />);
+
+    expect(didMount).toBeCalledTimes(1);
+
+    element.rerender(<Test />);
+
+    expect(didMount).toBeCalledTimes(1);
+  });
+
+  it('will run returned callback on unmount', () => {
+    const didUnmount = mock();
+
+    class Test extends Component {
+      mount() {
+        return didUnmount;
+      }
+    }
+
+    const element = render(<Test />);
+
+    expect(didUnmount).not.toBeCalled();
+
+    element.unmount();
+
+    expect(didUnmount).toBeCalledTimes(1);
+  });
+
+  it('will not repeat under strict mode', () => {
+    const didMount = mock();
+    const didUnmount = mock();
+
+    class Test extends Component {
+      mount() {
+        didMount();
+        return didUnmount;
+      }
+    }
+
+    const element = render(<Test />, { reactStrictMode: true });
+
+    expect(didMount).toBeCalledTimes(1);
+
+    element.unmount();
+
+    expect(didUnmount).toBeCalledTimes(1);
+  });
+
+  it('will not call during server render', () => {
+    const didMount = mock();
+
+    class Test extends Component {
+      mount() {
+        didMount();
+      }
+
+      render() {
+        return <span>hello</span>;
+      }
+    }
+
+    expect(renderToString(<Test />)).toContain('<span>hello</span>');
+    expect(didMount).not.toBeCalled();
   });
 });
 

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -114,6 +114,16 @@ describe('new method', () => {
   });
 });
 
+describe('use method', () => {
+  it('will throw if called as a hook', () => {
+    class Test extends Component {}
+
+    expect(() => (Test as any).use()).toThrow(
+      'Test is a Component - render as an element instead of calling use().'
+    );
+  });
+});
+
 describe('element props', () => {
   class Foo extends Component {
     /** Hover over this prop to see description. */

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -14,6 +14,17 @@ declare module '@expressive/mvc' {
   }
 
   interface Component {
+    /**
+     * Optional hook called once this Component commits. Return a function to
+     * run when it unmounts.
+     *
+     * Not called during server render, nor for an instance placed as
+     * `{component}` - a placement does not own what it renders. Client-only
+     * effects belong here; setup which must accompany the instance itself
+     * belongs in `new()`.
+     */
+    mount?(): (() => void) | void;
+
     /** @deprecated Only to satisfy host JSX. Use `this.get(State)` instead. */
     readonly context: Context;
     /** @deprecated Only to satisfy host JSX. Use `this.get()` instead. */
@@ -147,7 +158,7 @@ function render(from: Component, context: Context) {
         commit();
 
         return () => {
-          if (release) release();
+          if (typeof release == 'function') release();
           remove();
           context.pop();
         };

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -4,6 +4,15 @@ import { createProvider, type Context } from './context';
 import { Runtime, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
+  namespace Component {
+    /**
+     * Not available - a Component is rendered, not a hook.
+     * Render it with `<Component />` or `{component}`.
+     * For a bare instance use `Component.new()`.
+     */
+    const use: never;
+  }
+
   interface Component {
     /** @deprecated Only to satisfy host JSX. Use `this.get(State)` instead. */
     readonly context: Context;
@@ -26,6 +35,15 @@ Object.defineProperties(Component.prototype, {
   },
   context: {
     set: bootstrap
+  }
+});
+
+Object.defineProperty(Component, 'use', {
+  configurable: true,
+  value() {
+    throw new Error(
+      `${this} is a Component - render as an element instead of calling use().`
+    );
   }
 });
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -1,7 +1,7 @@
 import { Component, unbind } from '@expressive/mvc';
 import { watch, observer } from '@expressive/mvc/observable';
 import { provide, type Context } from './context';
-import { Runtime, useHook, useReady } from './runtime';
+import { Runtime, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
   interface Component {
@@ -123,12 +123,14 @@ function render(from: Component, context: Context) {
       if (observer(from) !== null) watch(from, refresh);
 
       return () => {
-        remove();
-        context.pop();
+        commit();
+
+        return () => {
+          remove();
+          context.pop();
+        };
       };
     }) || from;
-
-    useReady(commit);
 
     return frame(from, context, create(Render));
   };
@@ -149,7 +151,10 @@ function subcomponents(target: object, configurable?: boolean) {
         let render = unbind(value);
         const Component = (props: unknown) =>
           render.call(
-            useHook<Component>((set) => watch(owner, set)) || owner,
+            useHook<Component>((set) => {
+              const release = watch(owner, set);
+              return () => release;
+            }) || owner,
             props
           );
 

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -134,6 +134,7 @@ function render(from: Component, context: Context) {
   const { createElement } = Runtime;
   const { commit, remove } = Runtime.dedupe(from, context);
 
+  const self = from;
   const content = from.render;
   const Render = () => content.call(from, from.props);
   const Component = () => {
@@ -141,9 +142,12 @@ function render(from: Component, context: Context) {
       if (observer(from) !== null) watch(from, refresh);
 
       return () => {
+        const release = self.mount?.();
+
         commit();
 
         return () => {
+          if (release) release();
           remove();
           context.pop();
         };

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -1,6 +1,6 @@
 import { Component, unbind } from '@expressive/mvc';
 import { watch, observer } from '@expressive/mvc/observable';
-import { provide, type Context } from './context';
+import { createProvider, type Context } from './context';
 import { Runtime, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
@@ -89,20 +89,20 @@ function bootstrap(this: Component, context: Context){
  * Wrap a content element in its context provider, a Suspense boundary (unless
  * `fallback` is `false`) and, when `catch` is set, the host error boundary.
  */
-function frame(from: Component, context: Context, children: unknown) {
-  const { createElement: create } = Runtime;
+function createFrame(from: Component, context: Context, children: unknown) {
+  const { createElement } = Runtime;
 
   if(from.fallback !== false)
-    children = create(
+    children = createElement(
       Runtime.Suspense,
       { fallback: from.fallback, name: String(from) },
       children
     )
 
-  children = provide(context, children);
+  children = createProvider(context, children);
 
   return from.catch
-    ? create(Runtime.ErrorBoundary, { self: from, children })
+    ? createElement(Runtime.ErrorBoundary, { self: from, children })
     : children;
 }
 
@@ -113,7 +113,7 @@ function frame(from: Component, context: Context, children: unknown) {
  * unmount.
  */
 function render(from: Component, context: Context) {
-  const { createElement: create } = Runtime;
+  const { createElement } = Runtime;
   const { commit, remove } = Runtime.dedupe(from, context);
 
   const content = from.render;
@@ -132,10 +132,10 @@ function render(from: Component, context: Context) {
       };
     }) || from;
 
-    return frame(from, context, create(Render));
+    return createFrame(from, context, createElement(Render));
   };
 
-  return () => create(Component);
+  return () => createElement(Component);
 }
 
 /** Rewrite each own capitalized function on `target` into a subcomponent. */
@@ -172,4 +172,4 @@ function subcomponents(target: object, configurable?: boolean) {
   }
 }
 
-export { frame };
+export { createFrame };

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -105,6 +105,73 @@ describe('Provider', () => {
     expect(is).toBeCalledWith(expect.any(Test));
   });
 
+  it('will apply rest props alongside is', () => {
+    const is = mock();
+
+    render(
+      <Provider for={Foo} is={is} value="hello">
+        <Consumer for={Foo}>
+          {({ value }) => {
+            expect(value).toBe('hello');
+          }}
+        </Consumer>
+      </Provider>
+    );
+
+    expect(is).toBeCalledTimes(1);
+  });
+
+  it('will use the current is for a later registration', () => {
+    class First extends State {}
+    class Second extends State {}
+
+    const seen: string[] = [];
+
+    const element = render(
+      <Provider for={First} is={() => seen.push('first')}>
+        <span />
+      </Provider>
+    );
+
+    element.rerender(
+      <Provider for={Second} is={() => seen.push('second')}>
+        <span />
+      </Provider>
+    );
+
+    expect(seen).toEqual(['first', 'second']);
+  });
+
+  it('will stop applying rest props when for becomes multi-form', () => {
+    class Test extends State {
+      foo = 'default';
+    }
+
+    const seen: Test[] = [];
+    const capture = (state: Test) => {
+      seen.push(state);
+    };
+
+    const element = render(
+      <Provider for={Test} is={capture} foo="hello">
+        <span />
+      </Provider>
+    );
+
+    expect(seen[0].foo).toBe('hello');
+
+    // the single instance is replaced by a map-registered one, which rest props
+    // never apply to - the departed instance must not keep receiving them
+    element.rerender(
+      <Provider for={{ Test }} is={capture} foo="ignored">
+        <span />
+      </Provider>
+    );
+
+    expect(seen).toHaveLength(2);
+    expect(seen[1].foo).toBe('default');
+  });
+
   it('will ignore rest props on multi-form for', () => {
     class Test extends State {
       foo = 'default';
@@ -290,6 +357,204 @@ describe('Provider', () => {
     expect(didDestroy.mock.calls).toEqual([['Child'], ['Parent']]);
   });
 
+  describe('mount method', () => {
+    it('will call for an instance it creates', () => {
+      const didMount = mock();
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+          return didUnmount;
+        }
+      }
+
+      const element = render(
+        <Provider for={Test}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount).toBeCalledTimes(1);
+      expect(didUnmount).not.toBeCalled();
+
+      element.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
+    });
+
+    it('will not call for an instance it is given', () => {
+      const didMount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+        }
+      }
+
+      const instance = Test.new();
+      const element = render(
+        <Provider for={instance}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount).not.toBeCalled();
+
+      element.unmount();
+
+      expect(instance.get(null)).toBe(false);
+    });
+
+    it('will distinguish created from given per key', () => {
+      const didMount = mock();
+
+      class Owned extends State {
+        mount() {
+          didMount('owned');
+        }
+      }
+
+      class Guest extends State {
+        mount() {
+          didMount('guest');
+        }
+      }
+
+      const guest = Guest.new();
+
+      render(
+        <Provider for={{ Owned, guest }}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount).toBeCalledTimes(1);
+      expect(didMount).toBeCalledWith('owned');
+    });
+
+    it('will not repeat under strict mode', () => {
+      const didMount = mock();
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+          return didUnmount;
+        }
+      }
+
+      const element = render(
+        <Provider for={Test}>
+          <span />
+        </Provider>,
+        { reactStrictMode: true }
+      );
+
+      expect(didMount).toBeCalledTimes(1);
+
+      element.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
+    });
+
+    it('will not mount a state swapped in by a later render', () => {
+      const didMount = mock();
+
+      class First extends State {
+        mount() {
+          didMount('first');
+        }
+      }
+
+      class Second extends State {
+        mount() {
+          didMount('second');
+        }
+      }
+
+      const element = render(
+        <Provider for={First}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount.mock.calls).toEqual([['first']]);
+
+      // mount belongs to the Provider's own commit, so a `for` replaced
+      // mid-life provides Second without ever mounting it
+      element.rerender(
+        <Provider for={Second}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount.mock.calls).toEqual([['first']]);
+    });
+
+    it('will mount a swapped state when the Provider is keyed', () => {
+      const didMount = mock();
+
+      class First extends State {
+        mount() {
+          didMount('first');
+        }
+      }
+
+      class Second extends State {
+        mount() {
+          didMount('second');
+        }
+      }
+
+      const element = render(
+        <Provider key="first" for={First}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount.mock.calls).toEqual([['first']]);
+
+      // a new key is a new Provider, so the swap mounts as any first commit does
+      element.rerender(
+        <Provider key="second" for={Second}>
+          <span />
+        </Provider>
+      );
+
+      expect(didMount.mock.calls).toEqual([['first'], ['second']]);
+    });
+
+    it('will mount after descendants, as any parent does', () => {
+      const order: string[] = [];
+
+      class Outer extends State {
+        mount() {
+          order.push('provided');
+        }
+      }
+
+      class Inner extends State {
+        mount() {
+          order.push('child');
+        }
+      }
+
+      const Child = () => {
+        Inner.use();
+        return <span />;
+      };
+
+      render(
+        <Provider for={Outer}>
+          <Child />
+        </Provider>
+      );
+
+      expect(order).toEqual(['child', 'provided']);
+    });
+  });
+
   describe('forEach prop', () => {
     it('will call function for each model', () => {
       const forEach = mock();
@@ -301,18 +566,33 @@ describe('Provider', () => {
       expect(forEach).toBeCalledWith(expect.any(Bar));
     });
 
-    it('will cleanup on unmount', async () => {
-      const forEach = mock(() => cleanup);
-      const cleanup = mock();
+    it('will ignore a returned value', () => {
+      let captured!: Foo | Bar;
+      // a concise arrow body returns the state, which must not be mistaken
+      // for a teardown - hence no dispose seam here at all
+      const forEach = mock((state: Foo | Bar) => (captured = state));
 
       const rendered = render(<Provider for={{ Foo, Bar }} is={forEach} />);
 
       expect(forEach).toBeCalledTimes(2);
-      expect(forEach).toBeCalledWith(expect.any(Foo));
-      expect(forEach).toBeCalledWith(expect.any(Bar));
+      expect(captured).toBeInstanceOf(State);
+
+      expect(() => rendered.unmount()).not.toThrow();
+    });
+
+    it('will cleanup on unmount through the state', () => {
+      const cleanup = mock();
+      const forEach = mock((state: State) => {
+        state.set(null, cleanup);
+      });
+
+      const rendered = render(<Provider for={{ Foo, Bar }} is={forEach} />);
+
+      expect(forEach).toBeCalledTimes(2);
       expect(cleanup).not.toBeCalled();
 
       rendered.unmount();
+
       expect(cleanup).toBeCalledTimes(2);
     });
   });

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -57,7 +57,11 @@ function Consumer<T extends State>(props: Consumer.Props<T>) {
 }
 
 declare namespace Provider {
-  type ForEach<T> = (state: T) => void | (() => void);
+  /**
+   * Runs for each State registered by this Provider. Return value is ignored -
+   * to run teardown with a State, use `state.set(null, callback)`.
+   */
+  type ForEach<T> = (state: T) => void;
 
   interface SharedProps {
     /**
@@ -88,33 +92,53 @@ declare namespace Provider {
   type Props<T extends State = State> = ForSingleProps<T> | ForMultipleProps<T>;
 }
 
-function Provider<T extends State>(props: Provider.Props<T>) {
-  const {
-    for: input,
-    children,
-    fallback,
-    name,
-    is,
-    ...rest
-  } = props as Provider.ForSingleProps<T> & Provider.ForMultipleProps<T>;
+type Digest<T extends State> = (props: Provider.Props<T>) => Context;
 
+function Provider<T extends State>({
+  children,
+  fallback,
+  name,
+  ...props
+}: Provider.Props<T>) {
   const ambient = useAmbient();
-  const context = useHook<Context>((set) => {
-    const value = new Context(ambient);
+  const digest: Digest<T> = useHook((returns) => {
+    const context = new Context(ambient);
+    const fresh: State[] = [];
 
-    set(value);
+    let applied: Context.Accept<T> | undefined;
+    let solo: State | undefined;
 
-    return () => () => value.pop();
+    returns(({ is, for: input, ...rest }) => {
+      if (input !== applied) {
+        const single = State.is(input) || input instanceof State;
+
+        applied = input;
+        solo = undefined;
+
+        context.set(input, (state, owned) => {
+          if (single) solo = state;
+          if (owned) fresh.push(state);
+          if (is) is(state);
+        });
+      }
+
+      if (solo && Object.keys(rest).length) solo.set(rest);
+
+      return context;
+    });
+
+    return () => {
+      const release = fresh.map((state) => state.mount?.());
+
+      return () => {
+        for (const done of release) if (done) done();
+        context.pop();
+      };
+    };
   });
 
-  context.set(input, is);
-
-  if (Object.keys(rest).length) {
-    const i = State.is(input) ? context.get(input) : input;
-    if (i instanceof State) i.set(rest);
-  }
-
-  return createProvider(context,
+  return createProvider(
+    digest(props),
     fallback !== undefined
       ? Runtime.createElement(Runtime.Suspense, { fallback, name }, children)
       : children

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -18,7 +18,7 @@ function useAmbient() {
 }
 
 /** Wrap `children` in a {@link Layers} provider carrying `context` down the tree. */
-function provide(context: Context, children: any) {
+function createProvider(context: Context, children: any) {
   return Runtime.createElement(Layers().Provider, { value: context, children });
 }
 
@@ -114,11 +114,11 @@ function Provider<T extends State>(props: Provider.Props<T>) {
     if (i instanceof State) i.set(rest);
   }
 
-  return provide(context,
+  return createProvider(context,
     fallback !== undefined
       ? Runtime.createElement(Runtime.Suspense, { fallback, name }, children)
       : children
   );
 }
 
-export { Consumer, Provider, Context, provide };
+export { Consumer, Provider, Context, createProvider };

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -100,8 +100,11 @@ function Provider<T extends State>(props: Provider.Props<T>) {
 
   const ambient = useAmbient();
   const context = useHook<Context>((set) => {
-    set(new Context(ambient));
-    return () => context.pop();
+    const value = new Context(ambient);
+
+    set(value);
+
+    return () => () => value.pop();
   });
 
   context.set(input, is);

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,4 +1,5 @@
 import { State, Context, Component } from '@expressive/mvc';
+import type { UseState } from '@expressive/mvc';
 import { Runtime, useHook } from './runtime';
 
 let shared: any;
@@ -128,10 +129,10 @@ function Provider<T extends State>({
     });
 
     return () => {
-      const release = fresh.map((state) => state.mount?.());
+      const release = fresh.map((state) => (state as UseState).mount?.());
 
       return () => {
-        for (const done of release) if (done) done();
+        for (const done of release) if (typeof done == 'function') done();
         context.pop();
       };
     };

--- a/packages/react/src/element.test.tsx
+++ b/packages/react/src/element.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, act } from '@testing-library/react';
-import { expect, it, describe } from 'bun:test';
+import { expect, it, describe, mock } from 'bun:test';
 import React from 'react';
 
 import { mockError } from '../test.setup';
@@ -400,6 +400,34 @@ describe('instance element', () => {
     expect(screen.getAllByText('second')).toHaveLength(1);
 
     second.unmount();
+
+    expect(instance.get(null)).toBe(false);
+  });
+
+  it('will not mount a placed instance', () => {
+    const didMount = mock();
+
+    class Test extends Component {
+      mount() {
+        didMount();
+      }
+
+      render() {
+        return <span>hello</span>;
+      }
+    }
+
+    const instance = Test.new();
+    const element = render(
+      <>
+        <section>{instance}</section>
+        <aside>{instance}</aside>
+      </>
+    );
+
+    expect(didMount).not.toBeCalled();
+
+    element.unmount();
 
     expect(instance.get(null)).toBe(false);
   });

--- a/packages/react/src/element.ts
+++ b/packages/react/src/element.ts
@@ -2,7 +2,7 @@ import { Component } from '@expressive/mvc';
 import { watch, observer } from '@expressive/mvc/observable';
 import { Context } from './context';
 import { Runtime, useFactory, useHook } from './runtime';
-import { frame } from './component';
+import { createFrame } from './component';
 
 declare module '@expressive/mvc' {
   interface Component {
@@ -68,7 +68,7 @@ function Element(this: Component){
         return () => () => context.pop();
       }) || this;
 
-      return frame(from, context, Runtime.createElement(Content));
+      return createFrame(from, context, Runtime.createElement(Content));
     };
   });
 

--- a/packages/react/src/element.ts
+++ b/packages/react/src/element.ts
@@ -65,7 +65,7 @@ function Element(this: Component){
     return () => {
       from = useHook<Component>((refresh) => {
         if (observer(this) !== null) watch(this, refresh);
-        return () => context.pop();
+        return () => () => context.pop();
       }) || this;
 
       return frame(from, context, Runtime.createElement(Content));

--- a/packages/react/src/runtime.test.ts
+++ b/packages/react/src/runtime.test.ts
@@ -41,7 +41,7 @@ function harness() {
   return {
     update,
     unmount,
-    render: () => useHook((r) => ((refresh = r), unmount)),
+    render: () => useHook((r) => ((refresh = r), () => unmount)),
     commit: () => void (cleanup = effect()),
     unwind: () => cleanup && cleanup(),
     refresh: (next?: any) => refresh(next)

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -23,25 +23,24 @@ export function useFactory<T extends Function>(factory: () => T) {
   return ref.current || (ref.current = factory());
 }
 
-export function useReady<T>(callback: () => void) {
-  return Runtime.useEffect(() => void callback(), []);
-}
-
 /**
  * Mount-effect with a refreshable return value, safe under React StrictMode.
  *
- * @param callback Setup handler; receives a setter, must return a cleanup.
+ * @param callback Setup handler, run on creation; receives a setter and returns
+ *   a mount handler, which in turn returns a cleanup. All three share this
+ *   hook's render counter, so a StrictMode remount repeats none of them.
  * @returns Latest value published via the setter (`undefined` until set).
  */
 export function useHook<T = void>(
-  callback: (refresh: (next: T) => void) => () => void
+  callback: (refresh: (next: T) => void) => () => (() => void) | void
 ) {
   const { current } = Runtime.useRef(
     { rendered: 0 } as {
       rendered: number;
       mounted?: boolean;
       pending?: boolean;
-      unmount: () => void;
+      commit?: () => (() => void) | void;
+      release?: (() => void) | void;
       update?: (next: (previous: number) => number) => void;
       output: T;
     }
@@ -49,7 +48,7 @@ export function useHook<T = void>(
 
   current.update = Runtime.useState(() => {
     if (!current.rendered)
-      current.unmount = callback((next) => {
+      current.commit = callback((next) => {
         current.output = next;
         if (current.mounted) current.update?.((x) => x + 1);
         else if (current.update) current.pending = true;
@@ -60,12 +59,19 @@ export function useHook<T = void>(
 
   Runtime.useEffect(() => {
     current.mounted = true;
+
+    if (current.commit) {
+      current.release = current.commit();
+      current.commit = undefined;
+    }
+
     if (current.pending) {
       current.pending = false;
       current.update!((x) => x + 1);
     }
+
     return () => {
-      if (--current.rendered < 1) current.unmount();
+      if (--current.rendered <= 0) current.release?.();
     }
   }, []);
 

--- a/packages/react/src/state.get.ts
+++ b/packages/react/src/state.get.ts
@@ -1,6 +1,6 @@
 import { State, Context } from '@expressive/mvc';
 import { observer, watch } from '@expressive/mvc/observable';
-import { Runtime, useFactory, useHook, useReady } from './runtime';
+import { Runtime, useFactory, useHook } from './runtime';
 
 /** Type may not be undefined - instead will be null.  */
 type NoVoid<T> = T extends undefined | void ? null : T;
@@ -172,8 +172,10 @@ State.get = function get<T extends State>(
 
     return () => {
       pending = false;
-      useReady(() => mounted = true);
-      useHook(() => release);
+      useHook(() => () => {
+        mounted = true;
+        return release;
+      });
       return value === undefined ? null : value;
     };
   });

--- a/packages/react/src/state.use.test.tsx
+++ b/packages/react/src/state.use.test.tsx
@@ -182,6 +182,78 @@ describe('State.use', () => {
     });
   });
 
+  describe('mount method', () => {
+    it('will call once on commit', () => {
+      const didMount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+        }
+      }
+
+      const element = renderHook(() => Test.use());
+
+      expect(didMount).toBeCalledTimes(1);
+
+      element.rerender();
+
+      expect(didMount).toBeCalledTimes(1);
+    });
+
+    it('will run returned callback on unmount', () => {
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          return didUnmount;
+        }
+      }
+
+      const element = renderHook(() => Test.use());
+
+      expect(didUnmount).not.toBeCalled();
+
+      element.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
+    });
+
+    it('will not repeat under strict mode', () => {
+      const didMount = mock();
+      const didUnmount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+          return didUnmount;
+        }
+      }
+
+      const element = renderHook(() => Test.use(), { reactStrictMode: true });
+
+      expect(didMount).toBeCalledTimes(1);
+
+      element.unmount();
+
+      expect(didUnmount).toBeCalledTimes(1);
+    });
+
+    it('will not call for an instance no component owns', () => {
+      const didMount = mock();
+
+      class Test extends State {
+        mount() {
+          didMount();
+        }
+      }
+
+      Test.new();
+
+      expect(didMount).not.toBeCalled();
+    });
+  });
+
   describe('use method', () => {
     it('will call every render if present', () => {
       const didUse = mock();

--- a/packages/react/src/state.use.test.tsx
+++ b/packages/react/src/state.use.test.tsx
@@ -239,6 +239,22 @@ describe('State.use', () => {
       expect(didUnmount).toBeCalledTimes(1);
     });
 
+    it('will ignore a non-function returned by mount', () => {
+      class Test extends State {
+        value = 'x';
+
+        // a plain State is only structurally checked against UseState, where
+        // TypeScript's void-permissive return rule lets this through
+        mount() {
+          return this.value as any;
+        }
+      }
+
+      const element = renderHook(() => Test.use());
+
+      expect(() => element.unmount()).not.toThrow();
+    });
+
     it('will not call for an instance no component owns', () => {
       const didMount = mock();
 

--- a/packages/react/src/state.use.ts
+++ b/packages/react/src/state.use.ts
@@ -1,6 +1,6 @@
 import { State, Context } from '@expressive/mvc';
 import { watch } from '@expressive/mvc/observable';
-import { useFactory, useHook, useReady } from './runtime';
+import { useFactory, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
   interface UseState extends State {
@@ -66,13 +66,16 @@ State.use = function use<T extends State>(
         });
       }
 
-      useReady(() => ready = true);
-
       return useHook<T>((update) => {
         watch(instance, update);
+
         return () => {
-          context.pop();
-          instance.set(null);
+          ready = true;
+
+          return () => {
+            context.pop();
+            instance.set(null);
+          };
         };
       });
     };

--- a/packages/react/src/state.use.ts
+++ b/packages/react/src/state.use.ts
@@ -1,24 +1,9 @@
 import { State, Context } from '@expressive/mvc';
+import type { UseState } from '@expressive/mvc';
 import { watch } from '@expressive/mvc/observable';
 import { useFactory, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
-  interface State {
-    /**
-     * Optional hook called once the host component commits. Return a function
-     * to run when it unmounts.
-     *
-     * Applies where a component owns the instance - `State.use()` and
-     * `<Component />`. Not called during server render, nor for an instance
-     * merely observed or placed: `.get()` and `{instance}` reach one a
-     * component does not own, and `State.new()` has no component at all.
-     *
-     * Client-only effects belong here - setup which must accompany the
-     * instance itself belongs in `new()`.
-     */
-    mount?(): (() => void) | void;
-  }
-
   interface UseState extends State {
     /**
      * Optional hook called when State.use() is invoked within a React component.
@@ -29,6 +14,19 @@ declare module '@expressive/mvc' {
      * @param props Arguments passed to State.use().
      */
     use?(...props: any[]): Promise<void> | void;
+
+    /**
+     * Optional hook called once the host component commits. Return a function
+     * to run when it unmounts.
+     *
+     * Not called during server render, nor for an instance merely observed or
+     * placed: `.get()` and `{instance}` reach one a component does not own, and
+     * `State.new()` has no component at all.
+     *
+     * Client-only effects belong here - setup which must accompany the instance
+     * itself belongs in `new()`.
+     */
+    mount?(): (() => void) | void;
   }
 
   namespace State {
@@ -88,10 +86,10 @@ State.use = function use<T extends State>(
         return () => {
           ready = true;
 
-          const release = instance.mount?.();
+          const release = (instance as UseState).mount?.();
 
           return () => {
-            if (release) release();
+            if (typeof release == 'function') release();
             context.pop();
             instance.set(null);
           };

--- a/packages/react/src/state.use.ts
+++ b/packages/react/src/state.use.ts
@@ -3,6 +3,22 @@ import { watch } from '@expressive/mvc/observable';
 import { useFactory, useHook } from './runtime';
 
 declare module '@expressive/mvc' {
+  interface State {
+    /**
+     * Optional hook called once the host component commits. Return a function
+     * to run when it unmounts.
+     *
+     * Applies where a component owns the instance - `State.use()` and
+     * `<Component />`. Not called during server render, nor for an instance
+     * merely observed or placed: `.get()` and `{instance}` reach one a
+     * component does not own, and `State.new()` has no component at all.
+     *
+     * Client-only effects belong here - setup which must accompany the
+     * instance itself belongs in `new()`.
+     */
+    mount?(): (() => void) | void;
+  }
+
   interface UseState extends State {
     /**
      * Optional hook called when State.use() is invoked within a React component.
@@ -72,7 +88,10 @@ State.use = function use<T extends State>(
         return () => {
           ready = true;
 
+          const release = instance.mount?.();
+
           return () => {
+            if (release) release();
             context.pop();
             instance.set(null);
           };

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -395,11 +395,16 @@ Inside a subcomponent body, destructure what it reads from `this` at the top, sa
 
 ## Lifecycle
 
-- `new()` - once after init. Return cleanup function for teardown.
+- `new()` - once after init, synchronously. Return cleanup function for teardown.
+- `render(props)` - every render.
+- `mount()` - once when `<MyComponent />` commits. Return cleanup for unmount.
+  Not called for an instance placed as `{instance}`, which the placing component
+  does not own (see [react.md](react.md)).
 - `catch(error)` - error boundary.
 - Destruction on unmount or `this.set(null)`.
 
-A `use()` method applies only to the `MyComponent.use()` hook path - a Component rendered as JSX (`<MyComponent />`) never calls it.
+`MyComponent.use()` is not available - a Component is rendered, not used. Render
+it with `<MyComponent />` or `{instance}`; for a bare instance use `MyComponent.new()`.
 
 ```tsx
 class Timer extends Component {
@@ -412,6 +417,27 @@ class Timer extends Component {
 
   render() {
     return <span>{this.elapsed}s</span>;
+  }
+}
+```
+
+`new()` runs during server render, so anything touching `window`, timers or
+subscriptions belongs in `mount()` instead - it only runs on the client.
+
+```tsx
+class Viewport extends Component {
+  width = 0;
+
+  mount() {
+    const measure = () => (this.width = window.innerWidth);
+
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }
+
+  render() {
+    return <span>{this.width}px</span>;
   }
 }
 ```

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -144,6 +144,57 @@ function App({ name }: { name: string }) {
 }
 ```
 
+### mount() method
+
+Define `mount()` for client-only effects. Called once when the host component
+commits, and the function it returns runs on unmount.
+
+```tsx
+class Viewport extends State {
+  width = 0;
+
+  mount() {
+    const measure = () => (this.width = window.innerWidth);
+
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }
+}
+```
+
+`mount()` is an **ownership** hook, not an observation one. It runs where a
+component creates and destroys the instance - `State.use()` and
+`<Component />` - and never on a path that merely reaches an instance owned
+elsewhere:
+
+| Reaching an instance | Owns it | `mount()` |
+| -------------------- | ------- | --------- |
+| `State.use()`        | yes     | yes       |
+| `<Component />`      | yes     | yes       |
+| `State.get()`        | no      | no        |
+| `{instance}`         | no      | no        |
+| `State.new()`        | no host | no        |
+
+The excluded paths are all *many-to-one*: any number of components can `.get()`
+one instance, or place it as `{instance}`, and each does so for less time than
+the instance lives. A hook firing once per observer is not a lifecycle - to
+react to an instance from a component that does not own it, subscribe with
+`State.get()` or an event.
+
+It also never runs during server render.
+
+Pick the seam by what the work needs:
+
+| Hook       | Phase        | Runs                        | On the server |
+| ---------- | ------------ | --------------------------- | ------------- |
+| `new()`    | construction | once, synchronously         | yes           |
+| `use()`    | render        | every render of the host    | yes           |
+| `mount()`  | commit       | once, when the host commits | no            |
+
+Setup that must accompany the instance itself goes in `new()`; anything
+touching `window`, timers or subscriptions goes in `mount()`.
+
 ---
 
 ## State.get() - Context Hook

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -168,13 +168,26 @@ component creates and destroys the instance - `State.use()` and
 `<Component />` - and never on a path that merely reaches an instance owned
 elsewhere:
 
-| Reaching an instance | Owns it | `mount()` |
-| -------------------- | ------- | --------- |
-| `State.use()`        | yes     | yes       |
-| `<Component />`      | yes     | yes       |
-| `State.get()`        | no      | no        |
-| `{instance}`         | no      | no        |
-| `State.new()`        | no host | no        |
+| Reaching an instance          | Owns it | `mount()` |
+| ----------------------------- | ------- | --------- |
+| `State.use()`                 | yes     | yes       |
+| `<Component />`               | yes     | yes       |
+| `<Provider for={State}>`      | yes     | yes       |
+| `<Provider for={instance}>`   | no      | no        |
+| `State.get()`                 | no      | no        |
+| `{instance}`                  | no      | no        |
+| `State.new()`                 | no host | no        |
+
+A `Provider` decides per entry, so `for={{ Session, theme }}` mounts `Session`
+- which it constructed and will destroy - and leaves `theme` alone. Two things
+follow from `mount()` belonging to the Provider's own commit:
+
+- Like any parent, it mounts *after* its descendants - React commits bottom-up -
+  so a descendant should react to provided state through subscription rather
+  than read it imperatively in its own `mount()`.
+- Replacing `for` mid-life provides the new State without mounting it. Key the
+  Provider (`<Provider key={name} for={Type}>`) to make the swap a fresh mount,
+  the same way `key` signals changed identity anywhere else in React.
 
 The excluded paths are all *many-to-one*: any number of components can `.get()`
 one instance, or place it as `{instance}`, and each does so for less time than

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -28,7 +28,9 @@ class Timer extends State {
 - Return `void` if no cleanup needed.
 - Return `() => void` for a cleanup function called on destruction.
 
-`new()` is a typed optional member of `State` (`protected new?(): void | (() => void)`), not name-based detection - editors autocomplete it, its signature is checked, and TypeScript's `override` keyword catches a misspelled override. The same holds for `catch()` on `Component` and `use()` in adapters.
+`new()` is a typed optional member of `State` (`protected new?(): void | (() => void)`), not name-based detection - editors autocomplete it, its signature is checked, and TypeScript's `override` keyword catches a misspelled override. The same holds for `catch()` on `Component` and `use()` / `mount()` in adapters.
+
+> **`new()` runs on the server.** It is part of activation, so it fires wherever the state is constructed - including during `renderToString`. Anything touching `window`, timers or subscriptions belongs in the adapter's commit hook instead: see `mount()` in [../react/react.md](../react/react.md), which runs only on the client and only for a state some component owns.
 
 > **`new()` is for consumers and own-state.** Avoid it in reusable state meant to be subclassed: it's a public method, so an extending class that defines its own `new()` silently overrides yours and loses the base behavior (with no error). For internal init logic in a shippable base class, pass a trailing init callback to `super` instead - it runs in the same phase as `new()` but can't be clobbered:
 >

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -28,7 +28,11 @@ class Timer extends State {
 - Return `void` if no cleanup needed.
 - Return `() => void` for a cleanup function called on destruction.
 
-`new()` is a typed optional member of `State` (`protected new?(): void | (() => void)`), not name-based detection - editors autocomplete it, its signature is checked, and TypeScript's `override` keyword catches a misspelled override. The same holds for `catch()` on `Component` and `use()` / `mount()` in adapters.
+`new()` is a typed optional member of `State` (`protected new?(): void | (() => void)`), not name-based detection - editors autocomplete it, its signature is checked, and TypeScript's `override` keyword catches a misspelled override. The same holds for `catch()` and `mount()` on `Component`. Adapter hooks reached
+only through `State.use()` - `use()` and `mount()` on a plain `State` - are
+declared on the `UseState` interface instead, which a class satisfies
+structurally: they stay optional and unadvertised on States that are never
+rendered, at the cost of a looser check than a declared override gets.
 
 > **`new()` runs on the server.** It is part of activation, so it fires wherever the state is constructed - including during `renderToString`. Anything touching `window`, timers or subscriptions belongs in the adapter's commit hook instead: see `mount()` in [../react/react.md](../react/react.md), which runs only on the client and only for a state some component owns.
 


### PR DESCRIPTION
Adds `mount()` — a commit-phase lifecycle hook — so client-only effects have a
home that never runs on the server. Carved out of #251 to land independently;
that PR then narrows to router and global-state safety.

## Why

`new()` is synchronous at construction, so it also runs during `renderToString`.
That makes it the wrong place for anything touching `window`, timers or
subscriptions — the workaround being a guard at the top of every such hook:

```ts
class Viewport extends State {
  width = 0;

  new() {
    if (typeof window === 'undefined') return; // skip on the server
    const measure = () => (this.width = window.innerWidth);
    measure();
    window.addEventListener('resize', measure);
    return () => window.removeEventListener('resize', measure);
  }
}
```

There was no commit-phase seam to move that work into. `mount()` is it — it
runs only on the client, and only for a State a component owns, so the same
class becomes:

```ts
class Viewport extends State {
  width = 0;

  mount() {
    const measure = () => (this.width = window.innerWidth);
    measure();
    window.addEventListener('resize', measure);
    return () => window.removeEventListener('resize', measure);
  }
}
```

Scope note: this covers the *owned* paths — `Viewport.use()`, `<Component/>`,
and a `Provider`-constructed instance. A State reached without ownership — a
module singleton via `.get()`, or a nested `new Child()` field — still runs its
setup through `new()` with the SSR guard, since no component owns its commit.

## What lands

```
new()      construction · isomorphic · returns teardown
use()      render phase · intercepts State.use() args, hosts hooks · unchanged
mount()    commit · client only · returns teardown
```

- **`mount()`** on `State`, called once when the host component commits; the
  function it returns runs on unmount.
- **`Component.use()` is barred** — a Component is rendered, not used. Throws,
  and typed `never` so it fails at compile time.
- **`useHook` gains a commit stage**, replacing `useReady`. All three stages
  share one render counter, so a StrictMode remount repeats none of them.
- **`Context.set`'s callback is guarded** against a non-function return, and now
  reports whether the context created the state.

`use()` and `new()` are untouched. This is purely additive.

## Ownership, not observation

`mount()` fires only where a component creates *and* destroys the instance:

| Reaching an instance          | Owns it | `mount()` |
| ----------------------------- | ------- | --------- |
| `State.use()`                 | yes     | yes       |
| `<Component />`               | yes     | yes       |
| `<Provider for={State}>`      | yes     | yes       |
| `<Provider for={instance}>`   | no      | no        |
| `State.get()`                 | no      | no        |
| `{instance}`                  | no      | no        |
| `State.new()`                 | no host | no        |

The excluded paths are many-to-one. Measured on `{instance}`: placing one
instance in two spots and re-placing it fired `mount` **3 times** across a
lifetime in which the instance was never destroyed, with each teardown
corresponding to a placement ending rather than the instance dying. A hook that
fires once per observer isn't a lifecycle — use `State.get()` or an event to
react to state a component doesn't own.

A `Provider` decides per entry, so `for={{ Session, theme }}` mounts the
`Session` it constructed and leaves the already-live `theme` alone.

## Decisions worth reviewing

**Named `mount()`, not `didMount()`.** Matches the existing bare-verb `new()`;
returns a teardown so it brackets a scope rather than announcing a past event
(`did*` implies a `will*` sibling that doesn't exist); and `componentDidMount` is
the API React moved away from — `useEffect` with a cleanup return is what this
actually is.

**Declared on `UseState` and `Component`, not `State`.** `mount()` is
meaningless for a State no component owns, so it isn't advertised on every
`State` — it rides `UseState` (reached through the static `.use()`, like the
`use()` method) and is declared outright on `Component` beside `render()`.

Enforcement is asymmetric as a result, and worth understanding:

- On `Component`, `mount()` is a declared member, so a bad override is checked —
  `mount() { return this.value }` is `TS2416`.
- Through `State.use()` it is not. The mismatch *does* violate the `UseState`
  constraint (a direct assignment or an explicit `.use<T>()` both error), but
  `State.use<T extends UseState>` infers `T` from its `this` parameter, and
  TypeScript does not re-check an *inferred* type argument against its
  constraint. So a plain State with a bad `mount` return slips through the call
  site. (This is also why `use()`'s params are enforced and its return isn't —
  params flow through `UseArgs<T>` into the checked `...args`, returns flow
  nowhere.)

The return is therefore guarded at runtime (`typeof release == 'function'`),
which is exactly how core already consumes `new()`'s return — a stray
non-function becomes a harmless no-op rather than a crash on unmount.

**Keeps its returned teardown.** It runs inner-first — `mount`-dispose fires
before `new()`-dispose before the destroy event, all with live state — which the
alternative (teardown via the `set(null, …)` seam) can't reproduce, since those
callbacks fire in construction order and would reverse the nesting. `new()` and
`mount()` are symmetric: both return a teardown, both guard it at runtime.

## Two documented tradeoffs

**Provider mounts after its descendants.** React commits bottom-up, so a
Provider-created instance's `mount()` runs after the `mount()` of every child
consuming it (asserted: `['child', 'provided']`). Reactivity absorbs this — a
socket opening sets state and children re-render — but a descendant that
*imperatively* reads provided state in its own `mount()` sees the pre-init
value. Documented rather than worked around, since it's how React behaves.

**An un-keyed `for` swap doesn't mount.** `mount()` belongs to the Provider's own
commit, so replacing `for` mid-life provides the new State without mounting it.
`<Provider key={name} for={Type}>` makes the swap a fresh mount, the same way
`key` signals changed identity everywhere else in React. Both behaviors have
tests.

## Verification

mvc 610 · router 213 · react 249 · preact 142 — 0 fail, 100% line coverage held
in every package, all four builds clean. Server-render behavior is asserted
directly via `renderToString`, not inferred.

## Follow-on

Not in scope here, staying with #251: sealing root state during server render
(global leaks), the router's `window.location.pathname` class-field crash, and
the `map`/`has` sealing bypass. #251's `render()`/`use()` split, its `new()`-skip
and `Context.skipNew` are superseded by this branch and should drop on rebase.
