### PR TITLE
fix(examples): spreadsheet cell keeps its size when focused

### DIFF
--- a/examples/pages/apps/spreadsheet/App.css
+++ b/examples/pages/apps/spreadsheet/App.css
@@ -25,6 +25,7 @@
 }
 
 .sheet td {
+  position: relative;
   border: 1px solid var(--border);
   padding: 0;
   height: 2.25rem;
@@ -47,17 +48,17 @@
   background: var(--accent-soft);
 }
 
+/* The editor overlays the cell exactly, so focusing never changes its size. */
 .sheet td input {
-  width: 100%;
-  height: 100%;
-  min-width: 0;
+  position: absolute;
+  inset: 0;
   padding: 0 var(--s2);
   font: inherit;
   font-size: var(--t-sm);
   text-align: right;
   color: var(--fg);
   background: var(--bg);
-  border: 2px solid var(--accent);
-  border-radius: 0;
+  border: none;
+  box-shadow: inset 0 0 0 2px var(--accent);
   outline: none;
 }

--- a/examples/pages/apps/spreadsheet/App.css
+++ b/examples/pages/apps/spreadsheet/App.css
@@ -54,6 +54,7 @@
   inset: 0;
   padding: 0 var(--s2);
   font: inherit;
+  border-radius: 0;
   font-size: var(--t-sm);
   text-align: right;
   color: var(--fg);


### PR DESCRIPTION
Focusing a spreadsheet cell resized it — the editor `<input>` sat inside the cell with its own 2px border and an unresolved `height: 100%`, so the cell changed height and the column widened when the input appeared.

The input now overlays the cell exactly (`position: absolute; inset: 0`) with an **inset box-shadow** focus ring instead of a border, so it occupies the cell's full box without adding to it. Focusing no longer changes cell height or column width.

Verified with Playwright against the dev server: focused input is 35px vs the 36px cell (the 1px border), formulas still compute (`=A1*2+B1` → 13, `=A1/0` → `#ERR`), no console errors.

Examples-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)