### PR TITLE
feat(website): code-styled example titles, collapsible nav groups, instruction reorder

### DIFF
--- a/examples/pages/instructions/index.ts
+++ b/examples/pages/instructions/index.ts
@@ -1,11 +1,11 @@
 export default {
   ref: '`ref()` Single',
-  'ref-multiple': '`ref()` Multiple',
+  'ref-multiple': '`ref()` Multi',
   set: '`set()`',
   get: '`get()`',
-  has: '`has()` Pool',
   'has-list': '`has()` List',
-  map: '`map()` Create',
+  has: '`has()` Pool',
   'map-insert': '`map()` Insert',
+  map: '`map()` Factory',
   def: '`def()`'
 };

--- a/website/app/components/CodeLabel.tsx
+++ b/website/app/components/CodeLabel.tsx
@@ -1,0 +1,20 @@
+const CHIP =
+  'mr-[3px] rounded-sm border border-fd-border bg-fd-muted px-1 py-px font-mono text-[0.85em] font-normal';
+
+export default function CodeLabel({
+  label,
+  className,
+}: {
+  label: string;
+  className?: string;
+}) {
+  return label.split('`').map((part, i) =>
+    i % 2 ? (
+      <code key={i} className={className ? `${CHIP} ${className}` : CHIP}>
+        {part}
+      </code>
+    ) : (
+      part
+    )
+  );
+}

--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -21,6 +21,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 
+import CodeLabel from './CodeLabel';
 import { createSandboxTs, type SandboxTs } from './sandbox/client';
 import { intellisense } from './sandbox/intellisense';
 
@@ -306,11 +307,13 @@ function Layout({
         tabs &&
         createPortal(
           <button
-            aria-label={`Open examples navigation for ${label}`}
-            className="order-first mr-1 flex max-w-40 shrink-0 items-center gap-1.5 self-stretch pr-4 pl-3 text-sm font-medium text-fd-muted-foreground hover:text-fd-foreground"
+            aria-label={`Open examples navigation for ${label.replace(/`/g, '')}`}
+            className="order-first mr-1 flex max-w-56 shrink-0 items-center gap-1.5 self-stretch pr-4 pl-3 text-sm font-medium text-fd-muted-foreground hover:text-fd-foreground"
             onClick={onOpenNavigation}>
             <PanelLeftOpen className="size-4 shrink-0" />
-            <span className="truncate">{label}</span>
+            <span className="truncate">
+              <CodeLabel label={label} />
+            </span>
           </button>,
           tabs
         )}

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -1,7 +1,9 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { PanelLeftClose } from 'lucide-react';
+import { ChevronRight, PanelLeftClose } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { NavLink, Outlet } from 'react-router';
+
+import CodeLabel from '@/components/CodeLabel';
 
 import { layoutOptions } from '../home';
 import { GROUPS } from './loader';
@@ -111,6 +113,8 @@ export default function ExamplesLayout() {
 }
 
 function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
   return (
     <aside
       aria-hidden={!open}
@@ -128,20 +132,31 @@ function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
       <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">
         {GROUPS.map((group) => (
           <div className="flex flex-col gap-1" key={group.slug}>
-            <GroupLabel label={group.label} />
-            <div className="ml-2.5 flex flex-col gap-0.5 border-l border-fd-border">
-              {(group.children ?? []).map((e) => (
-                <ExampleLink
-                  key={e.slug}
-                  path={e.path}
-                  label={e.label}
-                  onNavigate={() => {
-                    if (window.matchMedia('(max-width: 1279px)').matches)
-                      onClose();
-                  }}
-                />
-              ))}
-            </div>
+            <GroupLabel
+              label={group.label}
+              expanded={!collapsed[group.slug]}
+              onToggle={() =>
+                setCollapsed((state) => ({
+                  ...state,
+                  [group.slug]: !state[group.slug],
+                }))
+              }
+            />
+            {!collapsed[group.slug] && (
+              <div className="ml-2.5 flex flex-col gap-0.5 border-l border-fd-border">
+                {(group.children ?? []).map((e) => (
+                  <ExampleLink
+                    key={e.slug}
+                    path={e.path}
+                    label={e.label}
+                    onNavigate={() => {
+                      if (window.matchMedia('(max-width: 1279px)').matches)
+                        onClose();
+                    }}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         ))}
       </nav>
@@ -162,16 +177,35 @@ function ExampleLink({
     <NavLink
       to={`/examples/${path}`}
       onClick={onNavigate}
-      className="-ml-px rounded-r-sm border-l-2 border-l-transparent py-1.5 px-3 text-sm no-underline text-fd-muted-foreground select-none whitespace-nowrap hover:border-l-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground aria-[current=page]:border-l-(--accent) aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] aria-[current=page]:text-(--accent)">
-      {label}
+      className="group -ml-px rounded-r-sm border-l-2 border-l-transparent py-1.5 px-3 text-sm no-underline text-fd-muted-foreground select-none whitespace-nowrap hover:border-l-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground aria-[current=page]:border-l-(--accent) aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] aria-[current=page]:text-(--accent)">
+      <CodeLabel
+        label={label}
+        className="group-aria-[current=page]:border-transparent group-aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] group-aria-[current=page]:text-(--accent)"
+      />
     </NavLink>
   );
 }
 
-function GroupLabel({ label }: { label: string }) {
+function GroupLabel({
+  label,
+  expanded,
+  onToggle,
+}: {
+  label: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
   return (
-    <span className="mb-1.5 pl-2 text-xs font-semibold uppercase tracking-widest text-fd-muted-foreground whitespace-nowrap">
+    <button
+      type="button"
+      aria-expanded={expanded}
+      onClick={onToggle}
+      className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-fd-muted-foreground select-none whitespace-nowrap hover:text-fd-foreground">
+      <ChevronRight
+        aria-hidden
+        className={`${expanded ? 'rotate-90' : ''} ml-[3px] size-3.5 shrink-0 transition-transform duration-150 ease-out motion-reduce:transition-none`}
+      />
       {label}
-    </span>
+    </button>
   );
 }

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -1,5 +1,8 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { Navigate, useOutletContext, useParams } from 'react-router';
+
+import CodeLabel from '@/components/CodeLabel';
+
 import type { ExamplesOutletContext } from './layout';
 import { examples, EXAMPLE_LABELS, getFiles, REDIRECT } from './loader';
 
@@ -37,7 +40,9 @@ function SourceListing({ name }: { name: string }) {
 
   return (
     <article className="min-h-0 flex-1 overflow-y-auto">
-      <h1 className="text-2xl font-semibold">{label}</h1>
+      <h1 className="text-2xl font-semibold">
+        <CodeLabel label={EXAMPLE_LABELS[name]} />
+      </h1>
       <p className="mt-2 text-fd-muted-foreground">
         {label} demo built with Expressive MVC - the complete source below
         runs as an editable sandbox when JavaScript is enabled.


### PR DESCRIPTION
Three scoped changes to the examples navigation.

## 1. Backticked titles render as `<code>`

Example labels already carried backticks (`` `ref()` Single ``) but rendered them literally. A new `CodeLabel` component splits on backticks and wraps the odd spans in an inline `<code>` chip, bringing the website on-par with the examples app. Applied at all three sites that show a label: the sidebar links, the sandbox tab-bar title, and the no-JS source listing heading.

`aria-label` and `<title>`/meta text keep using the stripped form, so assistive tech and search results don't read backticks.

## 2. Collapsible nav groups

Group headings are now `<button aria-expanded>` and hide their children when collapsed. A `lucide-react` `ChevronRight` sits left of the title and rotates 90° when open.

Alignment was the point here, and it's derived rather than eyeballed: the children rail sits at x=10px (`ml-2.5`), so the caret is `ml-[3px] size-3.5` to land its center exactly on that border, and `gap-1.5` puts the group title at 23px — matching the child links' text (`10 − 1 + 2 + 12` from `ml-2.5` / `-ml-px` / `border-l-2` / `px-3`).

**Decision:** groups start expanded and collapse state is ephemeral (no localStorage). All-expanded-by-default makes "auto-expand the active group" moot, and avoids the alternative's wart — force-expanding the active group means you can't collapse the one you're looking at.

## 3. Instruction examples reordered and renamed

| Before | After |
| --- | --- |
| `ref()` Multiple | `ref()` Multi |
| `map()` Create | `map()` Factory |
| Pool above List | **List** above Pool |
| Create above Insert | **Insert** above Factory |

Each pair now leads with the simpler shape. Ordering lives in `examples/pages/instructions/index.ts`, which drives both the website sidebar and the examples dev shell.

## Notes

- No changeset: website chrome and example labels only, nothing in a published package.
- The `CodeLabel` implementation is lifted verbatim from an unpushed local branch that had bundled it together with unrelated sandbox-persistence work; carving it out here so it lands independently off `main`.

## Verification

- `bun run --filter website types:check` — clean.
- Server-rendered sidebar HTML confirmed against a live dev server: code chips present, new order and names correct, `rotate-90` caret on all five groups.
- Not browser-verified: the click-to-collapse interaction and the caret/rail alignment by eye.
