### PR TITLE
fix: adopt the opt-in global contract in website and examples

### DIFF
--- a/examples/pages/composition/globals/App.tsx
+++ b/examples/pages/composition/globals/App.tsx
@@ -5,8 +5,13 @@ import { Theme } from './Theme';
 import { Viewport } from './Viewport';
 
 // Globals: created once, right here, the way you would at your app's entry
-// point next to the root render. State.new() activates the instance and parks
-// it in the global context, so any component can reach it with State.get().
+// point next to the root render. Two things have to be true for State.get() to
+// find one of these anywhere - the class declares `static global = true`, and
+// something activates it. State.new() is that second half.
+//
+// Activation alone is not enough: a class without the declaration stays private
+// to its creator, which is what keeps a forgotten Provider from quietly
+// installing per-request state into a process-wide registry.
 Viewport.new();
 Session.new();
 Theme.new();
@@ -18,7 +23,10 @@ export default function App() {
       <Size />
       <Account />
       <Appearance />
-      <small>Three globals, each created once - components subscribe with `.get()`.</small>
+      <small>
+        Three classes declaring <code>static global</code>, each activated once -
+        components subscribe with <code>.get()</code> and no Provider anywhere.
+      </small>
     </div>
   );
 }

--- a/examples/pages/composition/globals/Session.ts
+++ b/examples/pages/composition/globals/Session.ts
@@ -2,7 +2,10 @@ import State from '@expressive/react';
 
 // App-wide session. One instance for the whole app - login state lives in
 // exactly one place, and every component reads the same source of truth.
+// The `global` declaration is what makes "the whole app" true of it.
 export class Session extends State {
+  static global = true;
+
   user: string | null = null;
 
   login() {

--- a/examples/pages/composition/globals/Theme.ts
+++ b/examples/pages/composition/globals/Theme.ts
@@ -1,8 +1,11 @@
 import State from '@expressive/react';
 
-// Theme is global by nature - there is only one document to paint. The effect
-// in new() writes the active theme to the root element, retinting everything.
+// Theme is global by nature - there is only one document to paint - so it says
+// so. The effect in new() writes the active theme to the root element,
+// retinting everything.
 export class Theme extends State {
+  static global = true;
+
   dark = false;
 
   toggle() {

--- a/examples/pages/composition/globals/Viewport.ts
+++ b/examples/pages/composition/globals/Viewport.ts
@@ -3,7 +3,14 @@ import State from '@expressive/react';
 // Display-agnostic logic with no render() of its own - a plain State that any
 // component can subscribe to. Mutable inputs are fields, derived values are
 // getters, and setup/teardown lives in new().
+//
+// `static global` is the opt-in that makes it reachable app-wide: it puts an
+// instance activated outside any Provider into the root context, where
+// Viewport.get() finds it. Remove the line and everything here still works -
+// the instance is just private to whoever created it.
 export class Viewport extends State {
+  static global = true;
+
   width = window.innerWidth;
 
   get compact() {

--- a/website/app/components/Hash.ts
+++ b/website/app/components/Hash.ts
@@ -4,6 +4,8 @@ import State from '@expressive/react';
 // #slug and scrolls to a section whose id matches it - so deep-links and
 // in-page anchors resolve on fresh load, past the webfont layout shift.
 export class Hash extends State {
+  static global = true;
+
   active = '';
 
   protected new() {


### PR DESCRIPTION
## Why

`main` is red. Cloudflare Pages fails on `90e9bfca` (main's tip), and the cause is fallout from #251 rather than anything in a pending branch.

#251 made root registration **opt-in**: a State joins the process-global root only when it declares `static global = true`. Two places still assumed the old implicit behavior.

## 1. Website build (breaks `main`)

`website/app/components/Hash.ts` does a module-scope `Hash.new()`, and `routes/home/Primitives.tsx` does `hash = get(Hash)`. With registration now opt-in the instance never joins root, the lookup throws, and `react-router build` dies prerendering `/`:

```
Error: Required Hash not found in context for Primitives-YSQF4C.
✗ Build failed
```

`Hash` is genuinely global — one `window` `hashchange` listener for the whole page — so it declares that.

## 2. The globals example (broken at runtime)

`examples/pages/composition/globals` threw `Could not find Viewport in context.` for the same reason: three module-scope instances resolved with `.get()`, none declaring `global`.

Rather than quietly adding the line, the page now **teaches** it. That page exists to demonstrate the globals pattern, and #251's whole argument is that implicit globals are the hazard — so the opt-in is the lesson:

- Each class declares `static global = true` with a comment naming it as the opt-in and stating what happens without it (still works, just private to its creator).
- `App.tsx` explains that two things must be true — the declaration *and* activation — and why activation alone isn't enough.
- Page copy credits the declaration instead of the act of creating an instance.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `website: bun run build` | `✗` Required Hash not found | `✓` exit 0, prerenders all pages |
| globals example renders | throws | renders; login flow works |

Also confirmed the failure is pre-existing and not from a feature branch: building with **main's own** `Primitives.tsx` reproduces the identical error.

## Not included

Docs still describe the removed implicit behavior and need a precise pass — `api/utilities.mdx` ("Any state activated by `State.new()` outside an explicit context lands here"), `guides/context.mdx` ("`State.new()` homes to root, immediately and permanently", plus the implicit-collision note), and `migrating-from-hooks.mdx`. Filed as a followup; it wants care about the exact new semantics rather than a find-and-replace.

No changeset — no published package changes.