### PR TITLE
fix(website): example refresh, focused-group nav, animated collapse

### DIFF
--- a/website/app/components/CodeLabel.tsx
+++ b/website/app/components/CodeLabel.tsx
@@ -1,5 +1,5 @@
 const CHIP =
-  'mr-[3px] rounded-sm border border-fd-border bg-fd-muted px-1 py-px font-mono text-[0.85em] font-normal';
+  'relative -top-px mr-[3px] rounded-sm border border-fd-border bg-fd-muted px-1 py-px font-mono text-[0.85em] font-normal';
 
 export default function CodeLabel({
   label,

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -1,12 +1,12 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { ChevronRight, PanelLeftClose } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import { NavLink, Outlet } from 'react-router';
+import { NavLink, Outlet, useLocation } from 'react-router';
 
 import CodeLabel from '@/components/CodeLabel';
 
 import { layoutOptions } from '../home';
-import { GROUPS } from './loader';
+import { exampleSlug, GROUPS } from './loader';
 
 export interface ExamplesOutletContext {
   navigationOpen: boolean;
@@ -113,7 +113,17 @@ export default function ExamplesLayout() {
 }
 
 function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const active = useActiveGroup();
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(() =>
+    active ? { [active]: true } : {}
+  );
+
+  useEffect(() => {
+    if (active)
+      setExpanded((state) =>
+        state[active] ? state : { ...state, [active]: true }
+      );
+  }, [active]);
 
   return (
     <aside
@@ -129,39 +139,53 @@ function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
           <PanelLeftClose className="size-4" />
         </button>
       </div>
-      <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto">
-        {GROUPS.map((group) => (
-          <div className="flex flex-col gap-1" key={group.slug}>
-            <GroupLabel
-              label={group.label}
-              expanded={!collapsed[group.slug]}
-              onToggle={() =>
-                setCollapsed((state) => ({
-                  ...state,
-                  [group.slug]: !state[group.slug],
-                }))
-              }
-            />
-            {!collapsed[group.slug] && (
-              <div className="ml-2.5 flex flex-col gap-0.5 border-l border-fd-border">
-                {(group.children ?? []).map((e) => (
-                  <ExampleLink
-                    key={e.slug}
-                    path={e.path}
-                    label={e.label}
-                    onNavigate={() => {
-                      if (window.matchMedia('(max-width: 1279px)').matches)
-                        onClose();
-                    }}
-                  />
-                ))}
+      <nav className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto pb-[50vh]">
+        {GROUPS.map((group) => {
+          const isOpen = !!expanded[group.slug];
+
+          return (
+            <div className="flex flex-col" key={group.slug}>
+              <GroupLabel
+                label={group.label}
+                expanded={isOpen}
+                onToggle={() =>
+                  setExpanded((state) => ({
+                    ...state,
+                    [group.slug]: !state[group.slug],
+                  }))
+                }
+              />
+              <div
+                inert={!isOpen}
+                className={`${isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none`}>
+                <div className="ml-2.5 flex min-h-0 flex-col gap-0.5 overflow-hidden border-l border-fd-border">
+                  {(group.children ?? []).map((e) => (
+                    <ExampleLink
+                      key={e.slug}
+                      path={e.path}
+                      label={e.label}
+                      onNavigate={() => {
+                        if (window.matchMedia('(max-width: 1279px)').matches)
+                          onClose();
+                      }}
+                    />
+                  ))}
+                </div>
               </div>
-            )}
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </nav>
     </aside>
   );
+}
+
+function useActiveGroup() {
+  const slug = exampleSlug(useLocation().pathname);
+
+  return GROUPS.find((group) =>
+    (group.children ?? []).some((child) => child.path === slug)
+  )?.slug;
 }
 
 function ExampleLink({

--- a/website/app/routes/examples/layout.tsx
+++ b/website/app/routes/examples/layout.tsx
@@ -160,15 +160,7 @@ function Navigation({ open, onClose }: { open: boolean; onClose: () => void }) {
                 className={`${isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'} grid transition-[grid-template-rows,opacity] duration-200 ease-out motion-reduce:transition-none`}>
                 <div className="ml-2.5 flex min-h-0 flex-col gap-0.5 overflow-hidden border-l border-fd-border">
                   {(group.children ?? []).map((e) => (
-                    <ExampleLink
-                      key={e.slug}
-                      path={e.path}
-                      label={e.label}
-                      onNavigate={() => {
-                        if (window.matchMedia('(max-width: 1279px)').matches)
-                          onClose();
-                      }}
-                    />
+                    <ExampleLink key={e.slug} path={e.path} label={e.label} />
                   ))}
                 </div>
               </div>
@@ -188,19 +180,10 @@ function useActiveGroup() {
   )?.slug;
 }
 
-function ExampleLink({
-  path,
-  label,
-  onNavigate,
-}: {
-  path: string;
-  label: string;
-  onNavigate: () => void;
-}) {
+function ExampleLink({ path, label }: { path: string; label: string }) {
   return (
     <NavLink
       to={`/examples/${path}`}
-      onClick={onNavigate}
       className="group -ml-px rounded-r-sm border-l-2 border-l-transparent py-1.5 px-3 text-sm no-underline text-fd-muted-foreground select-none whitespace-nowrap hover:border-l-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground aria-[current=page]:border-l-(--accent) aria-[current=page]:bg-[color-mix(in_srgb,var(--accent)_14%,transparent)] aria-[current=page]:text-(--accent)">
       <CodeLabel
         label={label}

--- a/website/app/routes/examples/loader.ts
+++ b/website/app/routes/examples/loader.ts
@@ -67,6 +67,11 @@ for (const [path, code] of Object.entries(FILES)) {
 // Default redirect target: first example in tree order that has files.
 export const REDIRECT = leaves(GROUPS).map((n) => n.path).find((p) => examples[p]);
 
+// Static hosting 308s /examples/<slug> to a trailing slash; normalize so the
+// slug still resolves instead of falling through to the default redirect.
+export const exampleSlug = (path = '') =>
+  path.replace(/^\/examples\//, '').replace(/\/+$/, '');
+
 for (const folder of Object.values(examples)) {
   const cssImports = Object.keys(folder)
     .filter((p) => p.endsWith('.css'))

--- a/website/app/routes/examples/view.tsx
+++ b/website/app/routes/examples/view.tsx
@@ -4,12 +4,19 @@ import { Navigate, useOutletContext, useParams } from 'react-router';
 import CodeLabel from '@/components/CodeLabel';
 
 import type { ExamplesOutletContext } from './layout';
-import { examples, EXAMPLE_LABELS, getFiles, REDIRECT } from './loader';
+import {
+  exampleSlug,
+  examples,
+  EXAMPLE_LABELS,
+  getFiles,
+  REDIRECT,
+} from './loader';
 
 const Sandbox = lazy(() => import('@/components/Sandbox'));
 
 export function meta({ params }: { params: { '*'?: string } }) {
-  const label = params['*'] && EXAMPLE_LABELS[params['*']]?.replace(/`/g, '');
+  const slug = exampleSlug(params['*']);
+  const label = slug && EXAMPLE_LABELS[slug]?.replace(/`/g, '');
 
   if (!label)
     return [
@@ -60,7 +67,7 @@ function SourceListing({ name }: { name: string }) {
 }
 
 export default function CodeSample() {
-  const name = useParams()['*'];
+  const name = exampleSlug(useParams()['*']);
   const { navigationOpen, openNavigation } =
     useOutletContext<ExamplesOutletContext>();
   const [ready, setReady] = useState(false);


### PR DESCRIPTION
Four fixes to the examples playground nav, all verified in a real browser (headless Chrome over CDP) rather than by build alone.

## Refresh landed on counter instead of the addressed example

Reproduced against production: `https://expressive.dev/examples/instructions/ref` returns a **308 to `/examples/instructions/ref/`**. Prerender emits a directory per example, so static hosting canonicalizes to a trailing slash. The splat param then carried that slash, missed the `examples` map, and `view.tsx` fell through to `<Navigate to={REDIRECT}>` - i.e. every refresh (and every shared link) landed on counter.

`exampleSlug()` in `loader.ts` normalizes the slash off; the view and its `meta()` both go through it. The URL keeps its canonical trailing slash - no redirect ping-pong - and `NavLink` still marks the active link.

## Only the focused group opens on load

Group state was a `collapsed` map defaulting to `{}`, so every group started expanded. It is now an `expanded` map seeded from the group holding the current example, so the sidebar opens showing exactly where you are. Navigating to a group that is collapsed (direct URL, shared link) expands it; groups the reader opened by hand stay open.

## Open/close animates

Panels stay mounted and animate `grid-template-rows: 0fr -> 1fr` plus opacity over 200ms instead of unmounting, with a `motion-reduce` opt-out. Collapsed panels are `inert`, so hidden links stay out of the tab order.

## Nav no longer hugs the fold

The scrolling `<nav>` carries `pb-[50vh]`, so the last examples in the list scroll up to a comfortable reading position.

## Sidebar no longer dismisses itself on selection

On narrow layouts the overlay nav closed on every link click, so working through a section meant reopening it each time. Link clicks now leave it open; the backdrop and Escape still close it. Measured at 820px wide: opening the nav then selecting `instructions/set` navigates with `aria-hidden="false"` and `inert: false` intact, and a backdrop click still closes.

## Code labels align with adjacent text

The backtick-derived chips render `display: inline`, where a bottom margin has no layout effect, so a 1px relative offset lifts them instead. Measured: chip top 165px -> 164px, unchanged width and box. Applies everywhere `CodeLabel` renders - sidebar links, sandbox tab title, no-JS listing heading - so the alignment is consistent.

## Verification

Measured in-page on the dev server, on the rebased tree (includes the new `Component` group from #269):

- `/examples/component/lifecycle/` (trailing slash) -> title `Lifecycle Example`, `aria-current` on Lifecycle, group state `Component=true` with all others `false`.
- `/examples` -> redirects to `essentials/counter` with Essentials the only open group.
- Expanding a collapsed group samples heights `91 -> 138 -> 162 -> 168px` across the transition, so it eases rather than snaps.
- Collapsed panel: `grid-template-rows: 0px`, `inert: true`, height 0.
- `nav` computed `padding-bottom` = 50vh.
- At 820px wide: nav opens via the sandbox trigger, survives selecting another example, and still closes from the backdrop.
- Code chip top shifts 165px -> 164px.

No changeset - website-only, and `website` is private.

Not touched: the examples dev shell (`examples/app/Shell.tsx`) has a separate nav with no collapsible groups and no bottom padding. Say the word if that should match.
