### PR TITLE
docs(examples): render each example's README inside the example

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-mvc",

--- a/examples/common/Notes.css
+++ b/examples/common/Notes.css
@@ -1,65 +1,85 @@
 .notes {
+  interpolate-size: allow-keywords;
   width: 100%;
-  margin: 0 0 var(--s6);
+  margin: var(--s2) 0 var(--s6);
   color: var(--fg-soft);
+  font-size: var(--t-sm);
   text-align: left;
 }
 
 .notes > summary {
   display: flex;
-  align-items: baseline;
-  gap: var(--s2);
-  margin-bottom: var(--s4);
-  color: var(--fg);
-  font-size: var(--t-2xl);
-  font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: -0.02em;
+  align-items: center;
+  gap: var(--s3);
+  color: var(--muted);
+  font-size: var(--t-xs);
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
   list-style: none;
   cursor: pointer;
+  transition: color 0.15s;
 }
 
 .notes > summary::-webkit-details-marker {
   display: none;
 }
 
-.notes > summary::before {
+.notes > summary::before,
+.notes > summary::after {
   content: '';
-  flex: none;
-  width: 0.4em;
-  height: 0.4em;
-  border-right: 2px solid var(--muted);
-  border-bottom: 2px solid var(--muted);
-  transform: rotate(45deg) translate(-0.1em, -0.1em);
-  transition: transform 0.15s;
+  flex: 1;
+  border-top: 1px solid var(--border);
+  transition: border-color 0.15s;
 }
 
-.notes:not([open]) > summary::before {
-  transform: rotate(-45deg) translate(0.05em, 0.05em);
+.notes > summary:hover {
+  color: var(--fg-soft);
 }
 
-.notes > summary:hover::before {
-  border-color: var(--accent);
+.notes > summary:hover::before,
+.notes > summary:hover::after {
+  border-color: var(--border-2);
+}
+
+.notes::details-content {
+  block-size: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition:
+    block-size 0.3s ease,
+    opacity 0.2s ease,
+    content-visibility 0.3s allow-discrete;
+}
+
+.notes[open]::details-content {
+  block-size: auto;
+  opacity: 1;
+}
+
+.notes-body {
+  padding: var(--s5);
+  border: 1px solid var(--border);
+  border-top: none;
+}
+
+.notes-body > :first-child {
+  margin-top: 0;
 }
 
 .notes-body > :last-child {
   margin-bottom: 0;
 }
 
-.notes-body h2 {
-  margin: var(--s5) 0 var(--s2);
-  color: var(--fg);
-  font-size: var(--t-lg);
-  font-weight: 600;
-}
-
-.notes-body h2:first-child {
-  margin-top: 0;
-}
-
 .notes-body p {
   margin: 0 0 var(--s3);
   max-width: none;
+  line-height: 1.6;
+}
+
+.notes-body em {
+  color: var(--fg);
+  font-style: italic;
 }
 
 .notes-body strong {
@@ -72,6 +92,7 @@
   border-radius: var(--r-sm);
   background: var(--code-bg);
   color: var(--fg-soft);
+  font-size: 0.92em;
 }
 
 .notes-body ul {
@@ -85,6 +106,7 @@
   padding: 0 0 0 var(--s4);
   margin-bottom: var(--s1);
   border-radius: 0;
+  line-height: 1.6;
   cursor: auto;
 }
 
@@ -96,7 +118,7 @@
   content: '';
   position: absolute;
   left: var(--s1);
-  top: 0.65em;
+  top: 0.7em;
   width: 3px;
   height: 3px;
   border-radius: 50%;

--- a/examples/common/Notes.css
+++ b/examples/common/Notes.css
@@ -1,0 +1,104 @@
+.notes {
+  width: 100%;
+  margin: 0 0 var(--s6);
+  color: var(--fg-soft);
+  text-align: left;
+}
+
+.notes > summary {
+  display: flex;
+  align-items: baseline;
+  gap: var(--s2);
+  margin-bottom: var(--s4);
+  color: var(--fg);
+  font-size: var(--t-2xl);
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  list-style: none;
+  cursor: pointer;
+}
+
+.notes > summary::-webkit-details-marker {
+  display: none;
+}
+
+.notes > summary::before {
+  content: '';
+  flex: none;
+  width: 0.4em;
+  height: 0.4em;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg) translate(-0.1em, -0.1em);
+  transition: transform 0.15s;
+}
+
+.notes:not([open]) > summary::before {
+  transform: rotate(-45deg) translate(0.05em, 0.05em);
+}
+
+.notes > summary:hover::before {
+  border-color: var(--accent);
+}
+
+.notes-body > :last-child {
+  margin-bottom: 0;
+}
+
+.notes-body h2 {
+  margin: var(--s5) 0 var(--s2);
+  color: var(--fg);
+  font-size: var(--t-lg);
+  font-weight: 600;
+}
+
+.notes-body h2:first-child {
+  margin-top: 0;
+}
+
+.notes-body p {
+  margin: 0 0 var(--s3);
+  max-width: none;
+}
+
+.notes-body strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.notes-body code {
+  padding: 0.1em 0.35em;
+  border-radius: var(--r-sm);
+  background: var(--code-bg);
+  color: var(--fg-soft);
+}
+
+.notes-body ul {
+  display: block;
+  margin: 0 0 var(--s3);
+  padding: 0;
+}
+
+.notes-body li {
+  position: relative;
+  padding: 0 0 0 var(--s4);
+  margin-bottom: var(--s1);
+  border-radius: 0;
+  cursor: auto;
+}
+
+.notes-body li:hover {
+  background: none;
+}
+
+.notes-body li::before {
+  content: '';
+  position: absolute;
+  left: var(--s1);
+  top: 0.65em;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--muted);
+}

--- a/examples/common/Notes.tsx
+++ b/examples/common/Notes.tsx
@@ -1,0 +1,48 @@
+import './Notes.css';
+
+import type { ReactNode } from 'react';
+
+const INLINE = /(\*\*.+?\*\*|`.+?`|\[.+?\]\(.+?\))/g;
+const LINK = /^\[(.+?)\]\((.+?)\)$/;
+
+const inline = (text: string): ReactNode[] =>
+  text.split(INLINE).map((part, i) => {
+    if (part.startsWith('**')) return <strong key={i}>{part.slice(2, -2)}</strong>;
+    if (part.startsWith('`')) return <code key={i}>{part.slice(1, -1)}</code>;
+
+    const link = LINK.exec(part);
+
+    return link ? <a key={i} href={link[2]}>{link[1]}</a> : part;
+  });
+
+const block = (text: string, i: number) => {
+  if (text.startsWith('## '))
+    return <h2 key={i}>{inline(text.slice(3))}</h2>;
+
+  if (text.startsWith('- '))
+    return (
+      <ul key={i}>
+        {text.split(/\n(?=- )/).map((item, j) => (
+          <li key={j}>{inline(item.slice(2).replace(/\n\s+/g, ' '))}</li>
+        ))}
+      </ul>
+    );
+
+  return <p key={i}>{inline(text.replace(/\n/g, ' '))}</p>;
+};
+
+export default ({ children }: { children: string }) => {
+  const source = children.trim();
+  const heading = /^#\s+(.*)\n+/.exec(source);
+
+  return (
+    <details className="notes" open>
+      <summary>{heading ? heading[1] : 'About this example'}</summary>
+      <div className="notes-body">
+        {(heading ? source.slice(heading[0].length) : source)
+          .split(/\n{2,}/)
+          .map(block)}
+      </div>
+    </details>
+  );
+};

--- a/examples/common/Notes.tsx
+++ b/examples/common/Notes.tsx
@@ -7,7 +7,9 @@ const LINK = /^\[(.+?)\]\((.+?)\)$/;
 
 const inline = (text: string): ReactNode[] =>
   text.split(INLINE).map((part, i) => {
-    if (part.startsWith('**')) return <strong key={i}>{part.slice(2, -2)}</strong>;
+    if (part.startsWith('**'))
+      return <strong key={i}>{inline(part.slice(2, -2))}</strong>;
+
     if (part.startsWith('`')) return <code key={i}>{part.slice(1, -1)}</code>;
 
     const link = LINK.exec(part);

--- a/examples/common/Notes.tsx
+++ b/examples/common/Notes.tsx
@@ -2,7 +2,7 @@ import './Notes.css';
 
 import type { ReactNode } from 'react';
 
-const INLINE = /(\*\*.+?\*\*|`.+?`|\[.+?\]\(.+?\))/g;
+const INLINE = /(\*\*.+?\*\*|\*[^*]+\*|`.+?`|\[.+?\]\(.+?\))/g;
 const LINK = /^\[(.+?)\]\((.+?)\)$/;
 
 const inline = (text: string): ReactNode[] =>
@@ -10,6 +10,7 @@ const inline = (text: string): ReactNode[] =>
     if (part.startsWith('**'))
       return <strong key={i}>{inline(part.slice(2, -2))}</strong>;
 
+    if (part.startsWith('*')) return <em key={i}>{inline(part.slice(1, -1))}</em>;
     if (part.startsWith('`')) return <code key={i}>{part.slice(1, -1)}</code>;
 
     const link = LINK.exec(part);
@@ -18,9 +19,6 @@ const inline = (text: string): ReactNode[] =>
   });
 
 const block = (text: string, i: number) => {
-  if (text.startsWith('## '))
-    return <h2 key={i}>{inline(text.slice(3))}</h2>;
-
   if (text.startsWith('- '))
     return (
       <ul key={i}>

--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -1,7 +1,9 @@
 import { lazy, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { home, loadFrame, tree } from './pages';
+import Notes from './common/Notes';
+import { notesFor } from './notes';
+import { frameFile, home, loadFrame, tree } from './pages';
 
 const root = createRoot(document.getElementById('root')!);
 
@@ -17,11 +19,15 @@ if (window.self === window.top) {
   // Theme is pushed in directly by the shell (see Outlet).
   document.body.classList.add('example');
 
+  const file = frameFile();
+  const notes = notesFor(file);
+
   // Await the module so render commits promptly.
-  const { default: Example } = await loadFrame()();
+  const { default: Example } = await loadFrame(file)();
 
   root.render(
     <Suspense>
+      {notes && <Notes>{notes}</Notes>}
       <Example />
     </Suspense>
   );

--- a/examples/notes.ts
+++ b/examples/notes.ts
@@ -1,0 +1,13 @@
+// Kept out of pages.ts on purpose: the website imports that module, and its
+// fumadocs-mdx plugin claims every `*.md` id (query and all), so a raw glob
+// for README.md there compiles to an MDX component instead of a string. The
+// website reads the same files through its own `virtual:example-notes`.
+const notes = import.meta.glob('./pages/**/README.md', {
+  query: '?raw',
+  import: 'default',
+  eager: true
+}) as Record<string, string>;
+
+/** An example's README.md, keyed by its App.tsx module id. */
+export const notesFor = (file: string): string | undefined =>
+  notes[file.replace(/App\.tsx$/, 'README.md')];

--- a/examples/pages.ts
+++ b/examples/pages.ts
@@ -81,7 +81,9 @@ export const home = leaves(tree)[0]?.path;
 
 export const frameSrc = (file: string) => `module#${encodeURIComponent(file)}`;
 
-export const loadFrame = () => apps[decodeURIComponent(location.hash.slice(1))];
+export const frameFile = () => decodeURIComponent(location.hash.slice(1));
+
+export const loadFrame = (file: string) => apps[file];
 
 const sortKey = (name: string) =>
   (name === 'App.tsx' ? '0' : name === 'App.css' ? '1' : '2') + name;

--- a/examples/pages/component/boundary/App.tsx
+++ b/examples/pages/component/boundary/App.tsx
@@ -5,14 +5,6 @@ import { Component } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Error Boundary</h1>
-    <p>
-      Override <code>catch()</code> and a Component becomes the boundary for
-      everything it renders - per-feature error handling without nesting{' '}
-      <code>&lt;ErrorBoundary&gt;</code> wrappers. Boundary below has no{' '}
-      <code>render()</code> at all; it exists to sit in the tree and catch.
-    </p>
-
     <Boundary>
       <div className="card">
         <h2>Handled in place</h2>
@@ -24,12 +16,6 @@ export default () => (
         <Escalating message="The widget gave up." />
       </div>
     </Boundary>
-
-    <small>
-      The first card keeps its error, so only it swaps to a fallback while the
-      rest stays put. The second declines - its <code>catch()</code> rejects, so
-      the boundary above takes the whole group.
-    </small>
   </div>
 );
 
@@ -85,8 +71,6 @@ class Recoverable extends Fragile {
     );
   }
 
-  // Returning a pending promise holds the fallback up; resolving immediately
-  // would re-render, throw again, and loop.
   catch() {
     this.fallback = <this.Fallback />;
 

--- a/examples/pages/component/boundary/README.md
+++ b/examples/pages/component/boundary/README.md
@@ -1,0 +1,32 @@
+# Error Boundary
+
+Override `catch()` and a Component becomes the boundary for everything it
+renders - per-feature error handling without nesting `<ErrorBoundary>`
+wrappers.
+
+## What to try
+
+Break the first card: it swaps to a fallback in place while the rest of the
+page stays put, and **Retry** puts it back. Break the second and the whole
+group goes, because that one declines to handle its own error.
+
+## What it teaches
+
+**Catching is a method, not a wrapper.** Any Component that defines `catch()`
+covers its subtree. `Boundary` here has no `render()` at all - it exists only
+to sit in the tree and catch.
+
+**Handle in place or escalate.** `Recoverable` keeps its error and shows its
+own fallback. `Escalating` rethrows, so the error travels up to the nearest
+ancestor that will take it. The decision is one method on the class that
+failed.
+
+**Returning a promise holds the fallback.** `catch()` returns a promise that
+stays pending until the user acts. Resolving immediately would re-render,
+throw again, and loop.
+
+## Where to look next
+
+- **suspense** is the same seam for pending values instead of errors.
+- **headless** is the pattern of a Component that renders nothing and exists
+  to own a scope.

--- a/examples/pages/component/boundary/README.md
+++ b/examples/pages/component/boundary/README.md
@@ -2,31 +2,10 @@
 
 Override `catch()` and a Component becomes the boundary for everything it
 renders - per-feature error handling without nesting `<ErrorBoundary>`
-wrappers.
+wrappers. `Boundary` here has no `render()` at all; it exists to sit in the
+tree and catch.
 
-## What to try
-
-Break the first card: it swaps to a fallback in place while the rest of the
-page stays put, and **Retry** puts it back. Break the second and the whole
-group goes, because that one declines to handle its own error.
-
-## What it teaches
-
-**Catching is a method, not a wrapper.** Any Component that defines `catch()`
-covers its subtree. `Boundary` here has no `render()` at all - it exists only
-to sit in the tree and catch.
-
-**Handle in place or escalate.** `Recoverable` keeps its error and shows its
-own fallback. `Escalating` rethrows, so the error travels up to the nearest
-ancestor that will take it. The decision is one method on the class that
-failed.
-
-**Returning a promise holds the fallback.** `catch()` returns a promise that
-stays pending until the user acts. Resolving immediately would re-render,
-throw again, and loop.
-
-## Where to look next
-
-- **suspense** is the same seam for pending values instead of errors.
-- **headless** is the pattern of a Component that renders nothing and exists
-  to own a scope.
+The class that failed decides what happens. The first card keeps its error and
+swaps in a fallback while the rest of the page stays put; the second rethrows,
+so the whole group goes. Returning a pending promise holds the fallback up -
+resolving immediately would re-render, throw again, and loop.

--- a/examples/pages/component/dial/App.tsx
+++ b/examples/pages/component/dial/App.tsx
@@ -5,17 +5,7 @@ import { Scale } from './Scale';
 
 export default () => (
   <div className="container">
-    <h1>Custom Control</h1>
-    <p>
-      Drag the arc, or focus it and use the arrow keys. The number lives on the
-      form above it, so the arc, the slider and the input are three views of one
-      field - and none of them knows the others exist.
-    </p>
     <Manuscript />
-    <small>
-      Arc finds the Scale above it and declares <code>children</code> on{' '}
-      <code>render</code>, so the caller decides what sits in the well.
-    </small>
   </div>
 );
 

--- a/examples/pages/component/dial/README.md
+++ b/examples/pages/component/dial/README.md
@@ -1,0 +1,30 @@
+# Custom Control
+
+The arc, the slider and the number input are three views of one field, and
+none of them knows the others exist.
+
+## What to try
+
+Drag the arc, or focus it and use the arrow keys. Then move the slider or type
+a number - everything stays in step because there is only ever one value.
+
+## What it teaches
+
+**The value lives above its controls.** `Manuscript` extends `Scale` and holds
+the number. Each control reads `Scale.get()` to find whichever scale encloses
+it, so adding a fourth view means writing a fourth reader and nothing else.
+
+**Coordination without wiring.** No control is passed a value or a change
+handler. They call `scale.to(n)` and re-render because they read `value`.
+
+**A subclass supplies the configuration.** `value` and `max` are just fields
+overridden on the subclass, so a new dial is a new class rather than a new set
+of props.
+
+**`children` declared on `render` is a required slot,** which is how `Arc` lets
+the caller decide what sits in the well.
+
+## Where to look next
+
+- **subcomponents** covers overriding rendering seams on a base class.
+- **headless** is the same context trick with nothing rendered at all.

--- a/examples/pages/component/dial/README.md
+++ b/examples/pages/component/dial/README.md
@@ -1,30 +1,10 @@
 # Custom Control
 
-The arc, the slider and the number input are three views of one field, and
-none of them knows the others exist.
+The arc, the slider and the number input are three views of one field, and none
+of them knows the others exist. `Manuscript` extends `Scale` and holds the
+value; each control finds whichever scale encloses it, so a fourth view means a
+fourth reader and nothing else.
 
-## What to try
-
-Drag the arc, or focus it and use the arrow keys. Then move the slider or type
-a number - everything stays in step because there is only ever one value.
-
-## What it teaches
-
-**The value lives above its controls.** `Manuscript` extends `Scale` and holds
-the number. Each control reads `Scale.get()` to find whichever scale encloses
-it, so adding a fourth view means writing a fourth reader and nothing else.
-
-**Coordination without wiring.** No control is passed a value or a change
-handler. They call `scale.to(n)` and re-render because they read `value`.
-
-**A subclass supplies the configuration.** `value` and `max` are just fields
-overridden on the subclass, so a new dial is a new class rather than a new set
-of props.
-
-**`children` declared on `render` is a required slot,** which is how `Arc` lets
-the caller decide what sits in the well.
-
-## Where to look next
-
-- **subcomponents** covers overriding rendering seams on a base class.
-- **headless** is the same context trick with nothing rendered at all.
+No control is passed a value or a change handler - they call `scale.to(n)` and
+re-render because they read `value`. Configuration is fields overridden on the
+subclass, so a new dial is a new class rather than a new set of props.

--- a/examples/pages/component/headless/App.tsx
+++ b/examples/pages/component/headless/App.tsx
@@ -5,15 +5,7 @@ import { Component } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Headless</h1>
-    <p>
-      A Component without <code>render()</code> draws nothing. Children pass
-      through its context provider, which makes placement in the tree the entire
-      feature: it owns a lifecycle and hosts the suspense and error boundaries
-      for everything below it.
-    </p>
     <Scopes />
-    <small>Same Readout, same class, two scopes - each finds the Ticker above it.</small>
   </div>
 );
 

--- a/examples/pages/component/headless/README.md
+++ b/examples/pages/component/headless/README.md
@@ -1,27 +1,10 @@
 # Headless
 
-A Component without `render()` draws nothing. Children pass through its
-context provider, which makes placement in the tree the entire feature.
+A Component without `render()` draws nothing. Children pass through its context
+provider, which makes placement in the tree the entire feature: `Ticker` has
+fields, a `mount()` and a lifecycle, but nothing to draw.
 
-## What to try
-
-Two tickers run side by side at different rates. Same `Readout` class in both
-- each one finds the `Ticker` directly above it.
-
-## What it teaches
-
-**No render, still a component.** `Ticker` has fields, a `mount()` and a
-lifecycle, but nothing to draw. It owns behavior and scope rather than markup.
-
-**Placement is the API.** Wrapping something in a `Ticker` puts it in that
-ticker's scope. `Readout` asks for `Ticker.get()` and receives whichever one
-encloses it - no props, no ids, no selector.
-
-**It hosts the boundaries too.** A headless Component still carries the
-suspense and error boundaries for everything below it, so it is a useful place
-to put them even when it renders nothing.
-
-## Where to look next
-
-- **boundary** puts error handling on that same seam.
-- **lifecycle** shows what `mount()` guarantees and when it runs.
+Wrapping something in a `Ticker` puts it in that ticker's scope, so the same
+`Readout` class finds a different one on each side - no props, no ids, no
+selector. A headless Component still hosts the suspense and error boundaries
+for everything below it.

--- a/examples/pages/component/headless/README.md
+++ b/examples/pages/component/headless/README.md
@@ -1,0 +1,27 @@
+# Headless
+
+A Component without `render()` draws nothing. Children pass through its
+context provider, which makes placement in the tree the entire feature.
+
+## What to try
+
+Two tickers run side by side at different rates. Same `Readout` class in both
+- each one finds the `Ticker` directly above it.
+
+## What it teaches
+
+**No render, still a component.** `Ticker` has fields, a `mount()` and a
+lifecycle, but nothing to draw. It owns behavior and scope rather than markup.
+
+**Placement is the API.** Wrapping something in a `Ticker` puts it in that
+ticker's scope. `Readout` asks for `Ticker.get()` and receives whichever one
+encloses it - no props, no ids, no selector.
+
+**It hosts the boundaries too.** A headless Component still carries the
+suspense and error boundaries for everything below it, so it is a useful place
+to put them even when it renders nothing.
+
+## Where to look next
+
+- **boundary** puts error handling on that same seam.
+- **lifecycle** shows what `mount()` guarantees and when it runs.

--- a/examples/pages/component/instances/App.tsx
+++ b/examples/pages/component/instances/App.tsx
@@ -5,18 +5,7 @@ import { Component } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Instances</h1>
-    <p>
-      An activated instance is an element. Hold one as a field and that field
-      becomes the switch - assign a different instance and the view swaps, while
-      whatever left the tree keeps its state. Each panel here is
-      bare-constructed, which makes it nested state the workspace owns.
-    </p>
     <Workspace />
-    <small>
-      Type in one, switch, come back - the text is still there. The field decides
-      what renders, never what exists.
-    </small>
   </div>
 );
 

--- a/examples/pages/component/instances/README.md
+++ b/examples/pages/component/instances/README.md
@@ -1,0 +1,28 @@
+# Instances
+
+An activated instance is an element. Hold one as a field and that field
+becomes the switch.
+
+## What to try
+
+Type into one panel, switch to the other, then come back - the text is still
+there. Close them both and reopen; still there.
+
+## What it teaches
+
+**Assigning swaps the view.** `active` holds a `Panel`, so rendering `{active}`
+renders that panel. Assigning a different instance changes what is on screen
+without constructing anything.
+
+**Leaving the tree is not dying.** The panel that scrolls out of view keeps its
+state, because the field decides what *renders* - never what *exists*. Both
+panels are alive the whole time.
+
+**Bare construction means nested state.** `new Panel({ name: 'Draft' })` at the
+field makes the panel something the workspace owns, rather than something the
+tree creates and discards.
+
+## Where to look next
+
+- **props** covers what those constructor and JSX arguments actually do.
+- **has** owns a whole collection of instances instead of two named fields.

--- a/examples/pages/component/instances/README.md
+++ b/examples/pages/component/instances/README.md
@@ -1,28 +1,10 @@
 # Instances
 
-An activated instance is an element. Hold one as a field and that field
-becomes the switch.
+An activated instance is an element, so holding one as a field makes that field
+the switch. Assign a different instance and the view swaps; rendering
+`{active}` is all the wiring there is.
 
-## What to try
-
-Type into one panel, switch to the other, then come back - the text is still
-there. Close them both and reopen; still there.
-
-## What it teaches
-
-**Assigning swaps the view.** `active` holds a `Panel`, so rendering `{active}`
-renders that panel. Assigning a different instance changes what is on screen
-without constructing anything.
-
-**Leaving the tree is not dying.** The panel that scrolls out of view keeps its
-state, because the field decides what *renders* - never what *exists*. Both
-panels are alive the whole time.
-
-**Bare construction means nested state.** `new Panel({ name: 'Draft' })` at the
-field makes the panel something the workspace owns, rather than something the
-tree creates and discards.
-
-## Where to look next
-
-- **props** covers what those constructor and JSX arguments actually do.
-- **has** owns a whole collection of instances instead of two named fields.
+Leaving the tree is not dying. Type in one panel, switch away and come back -
+the text is still there, because the field decides what *renders*, never what
+*exists*. Both panels are bare-constructed, which makes them nested state the
+workspace owns.

--- a/examples/pages/component/lifecycle/App.tsx
+++ b/examples/pages/component/lifecycle/App.tsx
@@ -5,19 +5,7 @@ import { Component, get, has, ref } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Lifecycle</h1>
-    <p>
-      Three seams, three phases. <code>new()</code> runs at construction,
-      synchronously and during server render too, so it belongs to setup the
-      instance carries with it. <code>mount()</code> runs at commit and only on
-      the client - where timers, listeners and anything reaching for{' '}
-      <code>window</code> go. <code>ref()</code> fires when its element attaches.
-    </p>
     <Demo />
-    <small>
-      Toggle the probe to watch each seam fire, then unwind in reverse. The
-      transcript lives on the demo, which outlives the probe writing to it.
-    </small>
   </div>
 );
 

--- a/examples/pages/component/lifecycle/README.md
+++ b/examples/pages/component/lifecycle/README.md
@@ -1,0 +1,28 @@
+# Lifecycle
+
+Three seams, three phases.
+
+## What to try
+
+Toggle the probe and watch each seam fire in order, then unwind in reverse.
+Resize the window to see the `mount()` listener still working.
+
+## What it teaches
+
+**`new()` runs at construction** - synchronously, and during server render too.
+It belongs to setup the instance carries with it, and what it returns is the
+teardown for when the instance is destroyed.
+
+**`mount()` runs at commit, client only.** Timers, listeners and anything
+reaching for `window` go here. Its return value is the unmount cleanup.
+
+**`ref()` fires when its element attaches** and its cleanup when the element
+detaches - which is not the same moment as unmount.
+
+**The transcript outlives the probe.** `entries` lives on `Demo`, so the probe
+can log its own destruction to something that is still there afterwards.
+
+## Where to look next
+
+- **headless** owns a lifecycle with no markup at all.
+- **ref** covers the element seam on its own.

--- a/examples/pages/component/lifecycle/README.md
+++ b/examples/pages/component/lifecycle/README.md
@@ -1,28 +1,15 @@
 # Lifecycle
 
-Three seams, three phases.
+Three seams, three phases. Toggle the probe to watch each fire, then unwind in
+reverse.
 
-## What to try
+- **`new()`** runs at construction - synchronously, and during server render
+  too. It belongs to setup the instance carries with it, and returns the
+  teardown for when it is destroyed.
+- **`mount()`** runs at commit, client only. Timers, listeners and anything
+  reaching for `window` go here; its return value is the unmount cleanup.
+- **`ref()`** fires when its element attaches, and its cleanup when the element
+  detaches - which is not the same moment as unmount.
 
-Toggle the probe and watch each seam fire in order, then unwind in reverse.
-Resize the window to see the `mount()` listener still working.
-
-## What it teaches
-
-**`new()` runs at construction** - synchronously, and during server render too.
-It belongs to setup the instance carries with it, and what it returns is the
-teardown for when the instance is destroyed.
-
-**`mount()` runs at commit, client only.** Timers, listeners and anything
-reaching for `window` go here. Its return value is the unmount cleanup.
-
-**`ref()` fires when its element attaches** and its cleanup when the element
-detaches - which is not the same moment as unmount.
-
-**The transcript outlives the probe.** `entries` lives on `Demo`, so the probe
-can log its own destruction to something that is still there afterwards.
-
-## Where to look next
-
-- **headless** owns a lifecycle with no markup at all.
-- **ref** covers the element seam on its own.
+The transcript lives on `Demo`, so the probe can log its own destruction to
+something that outlives it.

--- a/examples/pages/component/props/App.tsx
+++ b/examples/pages/component/props/App.tsx
@@ -5,19 +5,7 @@ import { Component } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Props</h1>
-    <p>
-      Every state field is an optional JSX prop, reapplied on each render - so
-      whoever passes one owns it. <code>unit</code> is declared on{' '}
-      <code>render</code> instead, which keeps it out of state and, being
-      non-optional there, makes it a required attribute.
-    </p>
     <Dashboard />
-    <small>
-      CPU takes its value from above, so its own buttons only hold until the next
-      render up there reapplies the preset. Disk keeps its own, seeded once by{' '}
-      <code>is</code> at construction.
-    </small>
   </div>
 );
 

--- a/examples/pages/component/props/README.md
+++ b/examples/pages/component/props/README.md
@@ -1,30 +1,10 @@
 # Props
 
 Every state field is an optional JSX prop, reapplied on each render - so
-whoever passes one owns it.
+whoever passes one owns it. **CPU** takes its value from above, and its own
+buttons only hold until the next render up there reapplies the preset.
 
-## What to try
-
-Pick a preset and watch **CPU** follow it. Nudge CPU with its own buttons: the
-change holds only until the next render above reapplies the preset. **Disk**
-keeps whatever you set, because nothing upstream is passing its value.
-
-## What it teaches
-
-**Fields are props, and props win.** A field passed from JSX is reapplied every
-render, so the parent is the owner of that value. A field nobody passes stays
-the component's own.
-
-**`is` seeds without owning.** `is={(disk) => (disk.value = 128)}` runs once at
-construction, so Disk starts at 128 and then keeps its own value - the
-difference between initializing and controlling.
-
-**`render` parameters are required props.** `unit` is declared on `render`
-rather than as a field. That keeps it out of state entirely, and because it is
-non-optional there, it becomes a required attribute.
-
-## Where to look next
-
-- **instances** holds constructed components as fields instead of passing
-  props to them.
-- **set** validates or reacts to a field however it was assigned.
+`is` seeds without owning: **Disk** starts at 128 and then keeps whatever you
+set, which is the difference between initializing and controlling. `unit` is
+declared on `render` instead of as a field, keeping it out of state and - being
+non-optional there - making it a required attribute.

--- a/examples/pages/component/props/README.md
+++ b/examples/pages/component/props/README.md
@@ -1,0 +1,30 @@
+# Props
+
+Every state field is an optional JSX prop, reapplied on each render - so
+whoever passes one owns it.
+
+## What to try
+
+Pick a preset and watch **CPU** follow it. Nudge CPU with its own buttons: the
+change holds only until the next render above reapplies the preset. **Disk**
+keeps whatever you set, because nothing upstream is passing its value.
+
+## What it teaches
+
+**Fields are props, and props win.** A field passed from JSX is reapplied every
+render, so the parent is the owner of that value. A field nobody passes stays
+the component's own.
+
+**`is` seeds without owning.** `is={(disk) => (disk.value = 128)}` runs once at
+construction, so Disk starts at 128 and then keeps its own value - the
+difference between initializing and controlling.
+
+**`render` parameters are required props.** `unit` is declared on `render`
+rather than as a field. That keeps it out of state entirely, and because it is
+non-optional there, it becomes a required attribute.
+
+## Where to look next
+
+- **instances** holds constructed components as fields instead of passing
+  props to them.
+- **set** validates or reacts to a field however it was assigned.

--- a/examples/pages/component/subcomponents/App.tsx
+++ b/examples/pages/component/subcomponents/App.tsx
@@ -6,13 +6,6 @@ import { Picker } from './Picker';
 
 export default () => (
   <div className="container">
-    <h1>Subcomponents</h1>
-    <p>
-      Picker owns the data and the selection logic; its PascalCase methods are
-      seams a subclass overrides to change only how things look. Fruit replaces{' '}
-      <code>Item</code> alone and inherits the rest. Color replaces{' '}
-      <code>Summary</code> too, adding a readout Fruit has no use for.
-    </p>
     <Split>
       <FruitPicker />
       <PalettePicker />

--- a/examples/pages/component/subcomponents/README.md
+++ b/examples/pages/component/subcomponents/README.md
@@ -1,27 +1,9 @@
 # Subcomponents
 
-PascalCase methods are seams. A subclass overrides one to change how something
-looks, and inherits everything else.
+PascalCase methods are seams. `Item` and `Summary` are methods rendered as
+`<this.Item />`; they read `this`, so they need no props to reach what they
+display, and a subclass overrides one to change how something looks.
 
-## What to try
-
-Two pickers, one base class. They share the data handling and the selection
-logic; only the parts each one overrode differ.
-
-## What it teaches
-
-**A method that returns markup is a component.** `Item` and `Summary` are
-methods on `Picker`, rendered as `<this.Item />`. They read `this`, so they
-need no props to reach the state they display.
-
-**Overriding replaces one seam.** `FruitPicker` replaces `Item` alone.
-`PalettePicker` replaces `Item` and `Summary`, adding a readout the fruit
-picker has no use for.
-
-**Inheritance carries behavior, not just shape.** The selection logic is
+`FruitPicker` replaces `Item` alone. `PalettePicker` replaces `Summary` too,
+adding a readout the fruit picker has no use for. The selection logic is
 written once on the base and neither subclass restates it.
-
-## Where to look next
-
-- **dial** extends a base class the same way to build a custom control.
-- **instances** composes with fields instead of with inheritance.

--- a/examples/pages/component/subcomponents/README.md
+++ b/examples/pages/component/subcomponents/README.md
@@ -1,0 +1,27 @@
+# Subcomponents
+
+PascalCase methods are seams. A subclass overrides one to change how something
+looks, and inherits everything else.
+
+## What to try
+
+Two pickers, one base class. They share the data handling and the selection
+logic; only the parts each one overrode differ.
+
+## What it teaches
+
+**A method that returns markup is a component.** `Item` and `Summary` are
+methods on `Picker`, rendered as `<this.Item />`. They read `this`, so they
+need no props to reach the state they display.
+
+**Overriding replaces one seam.** `FruitPicker` replaces `Item` alone.
+`PalettePicker` replaces `Item` and `Summary`, adding a readout the fruit
+picker has no use for.
+
+**Inheritance carries behavior, not just shape.** The selection logic is
+written once on the base and neither subclass restates it.
+
+## Where to look next
+
+- **dial** extends a base class the same way to build a custom control.
+- **instances** composes with fields instead of with inheritance.

--- a/examples/pages/component/suspense/App.tsx
+++ b/examples/pages/component/suspense/App.tsx
@@ -5,20 +5,7 @@ import { Component, get, set } from '@expressive/react';
 
 export default () => (
   <div className="container">
-    <h1>Suspense</h1>
-    <p>
-      An async <code>set</code> factory resolves straight into its field, and
-      reading it while pending suspends the render. Every Component carries a
-      boundary for that, so <code>fallback</code> is the whole of the wiring -
-      there is no <code>&lt;Suspense&gt;</code> anywhere in this file.
-    </p>
     <Demo />
-    <small>
-      The second card declines its own boundary with{' '}
-      <code>{'fallback={false}'}</code>, so Panel covers it. That works only
-      because Panel owns the pending value: a boundary rebuilds the subtree it
-      retries, so state owned below would be rebuilt and requested again forever.
-    </small>
   </div>
 );
 
@@ -42,8 +29,6 @@ class Demo extends Component {
           </Panel>
         </div>
 
-        {/* An async factory resolves once, so a fresh request means a fresh
-            instance - which is what keying the owner asks for. */}
         <Button primary onClick={() => this.round++}>
           Ask again
         </Button>

--- a/examples/pages/component/suspense/README.md
+++ b/examples/pages/component/suspense/README.md
@@ -1,32 +1,11 @@
 # Suspense
 
 An async `set` factory resolves straight into its field, and reading it while
-pending suspends the render.
+pending suspends the render. Every Component carries a boundary for that, so
+declaring `fallback` is the whole of the wiring - there is no `<Suspense>`
+anywhere in this example.
 
-## What to try
-
-Both cards start pending and fill in as their requests land. **Ask again**
-restarts them.
-
-## What it teaches
-
-**`fallback` is the whole of the wiring.** Every Component carries a suspense
-boundary, so a field declaring what to show while pending is all it takes -
-there is no `<Suspense>` anywhere in this example.
-
-**Reading is what suspends.** `Greeter` renders `{this.greeting}`; because the
-value has not resolved, the render suspends and its own fallback shows. No
-loading flag, no `isPending`.
-
-**A child can decline its boundary.** `fallback={false}` sends the suspension
-up to `Panel` instead. That works here only because `Panel` owns the pending
-value - a boundary rebuilds the subtree it retries, so state owned *below* the
-boundary would be rebuilt and requested again forever.
-
-**An async factory resolves once.** A fresh request means a fresh instance,
-which is why asking again keys the owner.
-
-## Where to look next
-
-- **boundary** is the same seam for errors rather than pending values.
-- **set** covers the non-async forms of the instruction.
+A child can decline its own boundary with `fallback={false}`, sending the
+suspension up to `Panel`. That works here only because `Panel` owns the pending
+value: a boundary rebuilds the subtree it retries, so state owned *below* it
+would be rebuilt and requested again forever.

--- a/examples/pages/component/suspense/README.md
+++ b/examples/pages/component/suspense/README.md
@@ -1,0 +1,32 @@
+# Suspense
+
+An async `set` factory resolves straight into its field, and reading it while
+pending suspends the render.
+
+## What to try
+
+Both cards start pending and fill in as their requests land. **Ask again**
+restarts them.
+
+## What it teaches
+
+**`fallback` is the whole of the wiring.** Every Component carries a suspense
+boundary, so a field declaring what to show while pending is all it takes -
+there is no `<Suspense>` anywhere in this example.
+
+**Reading is what suspends.** `Greeter` renders `{this.greeting}`; because the
+value has not resolved, the render suspends and its own fallback shows. No
+loading flag, no `isPending`.
+
+**A child can decline its boundary.** `fallback={false}` sends the suspension
+up to `Panel` instead. That works here only because `Panel` owns the pending
+value - a boundary rebuilds the subtree it retries, so state owned *below* the
+boundary would be rebuilt and requested again forever.
+
+**An async factory resolves once.** A fresh request means a fresh instance,
+which is why asking again keys the owner.
+
+## Where to look next
+
+- **boundary** is the same seam for errors rather than pending values.
+- **set** covers the non-async forms of the instruction.

--- a/examples/pages/essentials/counter/App.tsx
+++ b/examples/pages/essentials/counter/App.tsx
@@ -3,18 +3,9 @@ import './App.css';
 import Button from '@common/Button';
 import { Component } from '@expressive/react';
 
-// Yes, it's a class with render(). No, it's nothing like the class
-// components you were told to avoid: no setState, no lifecycle methods,
-// no useState/useCallback/useMemo, no dependency arrays.
-//
-// Fields are reactive - assign one and the view updates. Methods are
-// auto-bound, so you can pull them off `this` and they still work.
-// One class is the state AND the view.
 class Counter extends Component {
   current = 1;
 
-  // Declared methods, not arrows - binding is intrinsic, not lexical.
-  // That's why destructuring them in render() below is safe.
   increment() {
     this.current++;
   }
@@ -32,10 +23,8 @@ class Counter extends Component {
 
     return (
       <div className="container">
-        <h1>Counter Example</h1>
         <div className="counter">
           <Button onClick={decrement}>{'−'}</Button>
-          {/* Click the number to reset. */}
           <pre onClick={reset}>{current}</pre>
           <Button onClick={increment}>{'+'}</Button>
         </div>
@@ -44,5 +33,4 @@ class Counter extends Component {
   }
 }
 
-// It's the element and the state in one - no hook, no provider.
 export default () => <Counter />;

--- a/examples/pages/essentials/counter/README.md
+++ b/examples/pages/essentials/counter/README.md
@@ -1,35 +1,9 @@
 # Counter
 
-The smallest complete Expressive MVC component: one class that is both the
-state and the view.
+The smallest complete component: one class that is both the state and the
+view. `current` is a reactive field, so `this.current++` *is* the update - the
+view re-renders because `render()` read it, and nothing declares a dependency.
 
-## What to try
-
-Use `+` and `−` to change the count, and **click the number itself** to reset
-it to 1. All three go through methods on the class - there is no handler
-plumbing in the markup.
-
-## What it teaches
-
-**A class with `render()`, not a class component.** No `setState`, no
-lifecycle methods, no `useState` / `useCallback` / `useMemo`, no dependency
-arrays. The only thing it shares with the class components you were told to
-avoid is the keyword.
-
-**Fields are the state.** `current = 1` is a reactive field. Assigning it -
-`this.current++` - is the update; the view re-renders because `render()` read
-it. Nothing declares a dependency.
-
-**Methods are auto-bound.** `increment`, `decrement` and `reset` are declared
-methods, not arrow properties. Binding is intrinsic to the class rather than
-lexical to the constructor, which is why `render()` can destructure them off
-`this` and pass them straight to `onClick`.
-
-**The class is the element.** `<Counter />` needs no hook, no provider and no
-wrapper - `Component` is a React component whose instance is its own state.
-
-## Where to look next
-
-- **Computed** derives a value from fields instead of storing it.
-- **Context** shares one instance across a subtree, once one component is no
-  longer enough.
+Methods are declared, not arrow properties. Binding is intrinsic to the class,
+which is why `render()` can destructure `increment` off `this` and hand it
+straight to `onClick`. Click the number itself to reset.

--- a/examples/pages/essentials/counter/README.md
+++ b/examples/pages/essentials/counter/README.md
@@ -1,0 +1,35 @@
+# Counter
+
+The smallest complete Expressive MVC component: one class that is both the
+state and the view.
+
+## What to try
+
+Use `+` and `−` to change the count, and **click the number itself** to reset
+it to 1. All three go through methods on the class - there is no handler
+plumbing in the markup.
+
+## What it teaches
+
+**A class with `render()`, not a class component.** No `setState`, no
+lifecycle methods, no `useState` / `useCallback` / `useMemo`, no dependency
+arrays. The only thing it shares with the class components you were told to
+avoid is the keyword.
+
+**Fields are the state.** `current = 1` is a reactive field. Assigning it -
+`this.current++` - is the update; the view re-renders because `render()` read
+it. Nothing declares a dependency.
+
+**Methods are auto-bound.** `increment`, `decrement` and `reset` are declared
+methods, not arrow properties. Binding is intrinsic to the class rather than
+lexical to the constructor, which is why `render()` can destructure them off
+`this` and pass them straight to `onClick`.
+
+**The class is the element.** `<Counter />` needs no hook, no provider and no
+wrapper - `Component` is a React component whose instance is its own state.
+
+## Where to look next
+
+- **Computed** derives a value from fields instead of storing it.
+- **Context** shares one instance across a subtree, once one component is no
+  longer enough.

--- a/examples/pages/instructions/def/App.tsx
+++ b/examples/pages/instructions/def/App.tsx
@@ -2,11 +2,6 @@ import './App.css';
 
 import { Component, def } from '@expressive/react';
 
-// `def` is the low-level primitive every other instruction is built on. Its
-// factory runs at init and returns a property descriptor; a `set` that
-// returns a value rewrites each assignment. Two tiny reusable instructions:
-
-// Keeps a number within range.
 function clamped(value: number, min: number, max: number) {
   return def<number>(() => ({
     value,
@@ -14,7 +9,6 @@ function clamped(value: number, min: number, max: number) {
   }));
 }
 
-// Coerces every assignment into a URL-safe slug.
 function slug(value = '') {
   return def<string>(() => ({
     value,
@@ -31,14 +25,6 @@ class Profile extends Component {
 
     return (
       <div className="container">
-        <h1>Custom Instruction</h1>
-
-        <p>
-          Both fields are governed by instructions we defined with{' '}
-          <code>def</code> - the same primitive <code>set</code> and{' '}
-          <code>get</code> are built on.
-        </p>
-
         <label>
           Volume <small>(clamped to 0–10)</small>
           <div className="stepper">

--- a/examples/pages/instructions/def/README.md
+++ b/examples/pages/instructions/def/README.md
@@ -1,0 +1,31 @@
+# Custom Instruction
+
+`def` is the low-level primitive every other instruction is built on. Both
+fields here are governed by instructions defined right in this file - the same
+way `set` and `get` are defined inside the library.
+
+## What to try
+
+Push **Volume** past either end with the ±3 buttons; it stops at 0 and 10.
+Type a name with spaces or capitals into **Handle** and watch each keystroke
+come back as a slug.
+
+## What it teaches
+
+**A factory that returns a descriptor.** `def` takes a function that runs when
+the instance initializes and returns a property descriptor. Whatever it
+returns becomes the behavior of that field.
+
+**`set` in the descriptor rewrites the assignment.** Returning a value from
+`set` stores that value instead of the one assigned - which is all `clamped`
+and `slug` do. The consumer writes `this.volume += 3` and the instruction
+decides what actually lands.
+
+**Instructions are ordinary functions.** `clamped(5, 0, 10)` is a call, so
+instructions take arguments, close over state, and get shared across classes
+like any other helper. There is no registration step and nothing to extend.
+
+## Where to look next
+
+- **set** is the everyday form of this, for defaults, validation and effects.
+- **get** is the same primitive aimed at derived values and context.

--- a/examples/pages/instructions/def/README.md
+++ b/examples/pages/instructions/def/README.md
@@ -1,31 +1,9 @@
 # Custom Instruction
 
-`def` is the low-level primitive every other instruction is built on. Both
-fields here are governed by instructions defined right in this file - the same
-way `set` and `get` are defined inside the library.
+`def` is the primitive every other instruction is built on. It takes a factory
+that runs at init and returns a property descriptor; a `set` in that descriptor
+rewrites each assignment, which is all `clamped` and `slug` do here.
 
-## What to try
-
-Push **Volume** past either end with the ±3 buttons; it stops at 0 and 10.
-Type a name with spaces or capitals into **Handle** and watch each keystroke
-come back as a slug.
-
-## What it teaches
-
-**A factory that returns a descriptor.** `def` takes a function that runs when
-the instance initializes and returns a property descriptor. Whatever it
-returns becomes the behavior of that field.
-
-**`set` in the descriptor rewrites the assignment.** Returning a value from
-`set` stores that value instead of the one assigned - which is all `clamped`
-and `slug` do. The consumer writes `this.volume += 3` and the instruction
-decides what actually lands.
-
-**Instructions are ordinary functions.** `clamped(5, 0, 10)` is a call, so
-instructions take arguments, close over state, and get shared across classes
-like any other helper. There is no registration step and nothing to extend.
-
-## Where to look next
-
-- **set** is the everyday form of this, for defaults, validation and effects.
-- **get** is the same primitive aimed at derived values and context.
+Instructions are ordinary functions, so they take arguments and get shared like
+any other helper - `clamped(5, 0, 10)` is just a call. Push **Volume** past
+either end, or type spaces and capitals into **Handle**.

--- a/examples/pages/instructions/get/App.tsx
+++ b/examples/pages/instructions/get/App.tsx
@@ -2,9 +2,6 @@ import './App.css';
 
 import State, { Component, get, Provider } from '@expressive/react';
 
-// The same instruction reaches both directions of the context tree.
-// Downstream: get(Candidate, true) collects every Candidate mounted below,
-// and the array tracks them as they mount and unmount - no registration.
 class Poll extends State {
   candidates = get(Candidate, true);
   choice = '';
@@ -14,8 +11,6 @@ class Poll extends State {
   }
 }
 
-// Upstream: get(Poll) hands each Candidate the poll it lives under, so a
-// click writes the shared choice and every candidate restyles.
 class Candidate extends Component {
   poll = get(Poll);
   name = '';
@@ -33,8 +28,6 @@ class Candidate extends Component {
   }
 }
 
-// A separate consumer reads the collected array - it re-renders as the
-// roster grows or shrinks, and when the shared choice changes.
 function Tally() {
   const { candidates, leader } = Poll.get();
 
@@ -60,8 +53,6 @@ export default class App extends Component {
 
     return (
       <div className="container">
-        <h1>Context Collection</h1>
-
         <Provider for={Poll}>
           <Tally />
           <ul className="ballot">

--- a/examples/pages/instructions/get/README.md
+++ b/examples/pages/instructions/get/README.md
@@ -1,28 +1,9 @@
 # Context Collection
 
-One instruction reaches both directions of the context tree: `get(Poll)` looks
-up, `get(Candidate, true)` looks down.
+One instruction reaches both directions of the tree. `get(Candidate, true)`
+gives the poll an array of every candidate mounted beneath it, tracking mounts
+and unmounts on its own - nothing registers itself.
 
-## What to try
-
-Click a name to choose it - every candidate restyles and the tally updates.
-Add a guest with the form and watch the count grow without anything
-registering it.
-
-## What it teaches
-
-**Downstream collection.** `get(Candidate, true)` gives `Poll` an array of
-every `Candidate` mounted beneath it. The array tracks mounts and unmounts on
-its own; members never register themselves and the parent never holds a list.
-
-**Upstream lookup.** `get(Poll)` hands each `Candidate` the poll it lives
-under. A click writes `poll.choice` directly, so the shared value is the only
-thing coordinating the group - no callback props threaded down.
-
-**Reads decide re-renders.** `Tally` renders when the roster changes *and*
-when the choice changes, because it read both. Nothing declares that.
-
-## Where to look next
-
-- **map** keys owned members instead of collecting mounted ones.
-- **has** owns a pool the parent spawns itself.
+`get(Poll)` is the other direction, handing each candidate the poll it lives
+under, so a click writes the shared choice with no callback threaded down.
+`Tally` re-renders on both the roster and the choice, because it read both.

--- a/examples/pages/instructions/get/README.md
+++ b/examples/pages/instructions/get/README.md
@@ -1,0 +1,28 @@
+# Context Collection
+
+One instruction reaches both directions of the context tree: `get(Poll)` looks
+up, `get(Candidate, true)` looks down.
+
+## What to try
+
+Click a name to choose it - every candidate restyles and the tally updates.
+Add a guest with the form and watch the count grow without anything
+registering it.
+
+## What it teaches
+
+**Downstream collection.** `get(Candidate, true)` gives `Poll` an array of
+every `Candidate` mounted beneath it. The array tracks mounts and unmounts on
+its own; members never register themselves and the parent never holds a list.
+
+**Upstream lookup.** `get(Poll)` hands each `Candidate` the poll it lives
+under. A click writes `poll.choice` directly, so the shared value is the only
+thing coordinating the group - no callback props threaded down.
+
+**Reads decide re-renders.** `Tally` renders when the roster changes *and*
+when the choice changes, because it read both. Nothing declares that.
+
+## Where to look next
+
+- **map** keys owned members instead of collecting mounted ones.
+- **has** owns a pool the parent spawns itself.

--- a/examples/pages/instructions/has-list/App.tsx
+++ b/examples/pages/instructions/has-list/App.tsx
@@ -2,9 +2,6 @@ import './App.css';
 
 import { Component, has } from '@expressive/react';
 
-// `has<string>()` is the list mode: an ordered collection of plain values you
-// push, addressed by index. No spawned members, no keys - just a log. Reads
-// track precisely, so `get(-1)` re-renders on a new tail, `size` on length.
 export default class Editor extends Component {
   history = has<string>();
   draft = '';
@@ -29,12 +26,6 @@ export default class Editor extends Component {
 
     return (
       <div className="container log">
-        <h1>Owned List</h1>
-        <p>
-          <code>has&lt;string&gt;()</code> stores values by position. Push to
-          append, pop to undo; <code>get(-1)</code> reads the latest entry.
-        </p>
-
         <ol className="entries">
           {[...history].map((entry, i) => (
             <li key={i}>

--- a/examples/pages/instructions/has-list/README.md
+++ b/examples/pages/instructions/has-list/README.md
@@ -1,0 +1,26 @@
+# Owned List
+
+`has<string>()` is the list mode: an ordered collection of plain values you
+push, addressed by index. No spawned members, no keys - just a log.
+
+## What to try
+
+Record a few actions, then undo. The footer tracks both the length and the
+latest entry.
+
+## What it teaches
+
+**Same instruction, no factory.** Give `has` a type instead of a class and it
+stores values rather than spawning members. Push to append, pop to undo.
+
+**Reads track precisely.** `get(-1)` re-renders on a new tail; `size`
+re-renders on a length change. A consumer that reads only one of them ignores
+the other.
+
+**Negative indices count from the end,** so `get(-1)` is the latest entry
+without arithmetic against `size`.
+
+## Where to look next
+
+- **has (pool)** spawns Component members instead of storing values.
+- **map** addresses entries by key rather than position.

--- a/examples/pages/instructions/has-list/README.md
+++ b/examples/pages/instructions/has-list/README.md
@@ -1,26 +1,9 @@
 # Owned List
 
-`has<string>()` is the list mode: an ordered collection of plain values you
-push, addressed by index. No spawned members, no keys - just a log.
+Give `has` a type instead of a class and it stores plain values by position
+rather than spawning members. Push to append, pop to undo - an ordered log with
+no keys and no identity to manage.
 
-## What to try
-
-Record a few actions, then undo. The footer tracks both the length and the
-latest entry.
-
-## What it teaches
-
-**Same instruction, no factory.** Give `has` a type instead of a class and it
-stores values rather than spawning members. Push to append, pop to undo.
-
-**Reads track precisely.** `get(-1)` re-renders on a new tail; `size`
-re-renders on a length change. A consumer that reads only one of them ignores
-the other.
-
-**Negative indices count from the end,** so `get(-1)` is the latest entry
-without arithmetic against `size`.
-
-## Where to look next
-
-- **has (pool)** spawns Component members instead of storing values.
-- **map** addresses entries by key rather than position.
+Reads track precisely: `get(-1)` re-renders on a new tail, `size` on a length
+change, and a consumer reading one ignores the other. Negative indices count
+from the end, so the latest entry needs no arithmetic.

--- a/examples/pages/instructions/has/App.tsx
+++ b/examples/pages/instructions/has/App.tsx
@@ -2,14 +2,10 @@ import './App.css';
 
 import { Component, has } from '@expressive/react';
 
-// `has(Item)` is an owned pool. `add` spawns a member and returns it;
-// members carry their own identity, so dropping the pool into the tree
-// is the whole render - no keys, no spread, no <Row>, no use().
 export default class TodoList extends Component {
   todos = has(Item);
   draft = '';
 
-  // Pools resolve at activation, so seed members from the new() hook.
   protected new() {
     this.add('Learn Expressive');
   }
@@ -34,13 +30,6 @@ export default class TodoList extends Component {
 
     return (
       <div className="container todo">
-        <h1>Owned Collections</h1>
-        <p>
-          <code>has(Item)</code> is a pool that spawns and owns its members.
-          Each todo is its own Component, so dropping the pool into the tree
-          is the whole render.
-        </p>
-
         <div className="card">
           <form
             onSubmit={(e) => {
@@ -69,9 +58,6 @@ export default class TodoList extends Component {
   }
 }
 
-// Each todo is a Component - it owns its fields, its behavior, and its
-// own markup. With #247 an instance renders directly as an element, so
-// the parent never writes a row wrapper or wires props.
 class Item extends Component {
   text = '';
   done = false;
@@ -80,7 +66,6 @@ class Item extends Component {
     this.done = !this.done;
   }
 
-  // A member that destroys itself is evicted from the pool automatically.
   remove() {
     this.set(null);
   }

--- a/examples/pages/instructions/has/README.md
+++ b/examples/pages/instructions/has/README.md
@@ -1,32 +1,9 @@
 # Owned Collections
 
-`has(Item)` is a pool that spawns and owns its members. Each todo is its own
-Component, so dropping the pool into the tree is the whole render.
+`has(Item)` is a pool that spawns and owns its members. `add` constructs an
+`Item`, seeds it and files it away; because an instance is an element,
+`<ul>{todos}</ul>` is the whole render - no keys, no `.map()`, no row wrapper.
 
-## What to try
-
-Add a task, toggle a few done, then clear them. Note what the parent never
-writes: no keys, no `.map()`, no row wrapper, no props passed down.
-
-## What it teaches
-
-**`add` spawns a member and returns it.** `this.todos.add({ text })`
-constructs an `Item`, seeds its fields and files it in the pool. The parent
-holds the pool, not an array it has to keep in sync.
-
-**Members carry their own identity.** `<ul>{todos}</ul>` renders the pool
-directly, because an instance *is* an element. Identity comes from the member
-itself, which is why there are no keys to invent.
-
-**Members own their behavior.** `toggle` and `remove` live on `Item`, next to
-the fields they change. `this.set(null)` destroys a member, and the pool
-evicts it automatically - the parent is never told.
-
-**Pools resolve at activation.** Seeding happens in the `new()` hook rather
-than at the field, because the pool is not addressable until the instance is
-live.
-
-## Where to look next
-
-- **has (list)** is the same instruction storing plain values by position.
-- **map** keys spawned members instead of pooling them anonymously.
+Members own their behavior too. `toggle` and `remove` live on `Item`, and
+`this.set(null)` destroys a member which the pool then evicts on its own. Pools
+resolve at activation, so seeding happens in `new()` rather than at the field.

--- a/examples/pages/instructions/has/README.md
+++ b/examples/pages/instructions/has/README.md
@@ -1,0 +1,32 @@
+# Owned Collections
+
+`has(Item)` is a pool that spawns and owns its members. Each todo is its own
+Component, so dropping the pool into the tree is the whole render.
+
+## What to try
+
+Add a task, toggle a few done, then clear them. Note what the parent never
+writes: no keys, no `.map()`, no row wrapper, no props passed down.
+
+## What it teaches
+
+**`add` spawns a member and returns it.** `this.todos.add({ text })`
+constructs an `Item`, seeds its fields and files it in the pool. The parent
+holds the pool, not an array it has to keep in sync.
+
+**Members carry their own identity.** `<ul>{todos}</ul>` renders the pool
+directly, because an instance *is* an element. Identity comes from the member
+itself, which is why there are no keys to invent.
+
+**Members own their behavior.** `toggle` and `remove` live on `Item`, next to
+the fields they change. `this.set(null)` destroys a member, and the pool
+evicts it automatically - the parent is never told.
+
+**Pools resolve at activation.** Seeding happens in the `new()` hook rather
+than at the field, because the pool is not addressable until the instance is
+live.
+
+## Where to look next
+
+- **has (list)** is the same instruction storing plain values by position.
+- **map** keys spawned members instead of pooling them anonymously.

--- a/examples/pages/instructions/map-insert/App.tsx
+++ b/examples/pages/instructions/map-insert/App.tsx
@@ -2,9 +2,6 @@ import './App.css';
 
 import { Component, map } from '@expressive/react';
 
-// `map<K, V>()` is the insert mode: a reactive Map of values you place by
-// key with `set(key, value)` - no factory, no spawning. Bumping one key
-// notifies only that entry; adding or removing a key notifies shape.
 export default class Inventory extends Component {
   stock = map<string, number>();
   item = '';
@@ -28,13 +25,6 @@ export default class Inventory extends Component {
 
     return (
       <div className="container inv">
-        <h1>Reactive Map</h1>
-        <p>
-          <code>map&lt;string, number&gt;()</code> keys values you insert with{' '}
-          <code>set(key, value)</code>. Re-adding a name bumps its count in
-          place.
-        </p>
-
         <ul className="stock">
           {[...stock].map(([name, qty]) => (
             <li key={name}>

--- a/examples/pages/instructions/map-insert/README.md
+++ b/examples/pages/instructions/map-insert/README.md
@@ -1,0 +1,26 @@
+# Reactive Map
+
+`map<string, number>()` is the insert mode: a reactive Map of values you place
+by key with `set(key, value)` - no factory, no spawning.
+
+## What to try
+
+Nudge a count with ± , then type a name that already exists and add it - the
+existing row bumps in place rather than duplicating.
+
+## What it teaches
+
+**Keys hold plain values.** Give `map` two types instead of a factory and it
+behaves like a `Map` that anything reading it can subscribe to.
+
+**Notification is per-key.** Changing one entry notifies readers of that
+entry. Adding or removing a key notifies readers of the collection's shape.
+A consumer reading a single count ignores every other change.
+
+**It reads like the built-in.** `get`, `set`, `size`, `values()` and iteration
+all behave as expected, so the reactivity is the only thing that is new.
+
+## Where to look next
+
+- **map (spawn)** takes a factory and owns the members it creates.
+- **has (list)** stores values by position when keys add nothing.

--- a/examples/pages/instructions/map-insert/README.md
+++ b/examples/pages/instructions/map-insert/README.md
@@ -1,26 +1,9 @@
 # Reactive Map
 
-`map<string, number>()` is the insert mode: a reactive Map of values you place
-by key with `set(key, value)` - no factory, no spawning.
+Give `map` two types instead of a factory and it becomes a reactive `Map` you
+fill yourself with `set(key, value)`. `get`, `size`, `values()` and iteration
+all behave as expected - the reactivity is the only new thing.
 
-## What to try
-
-Nudge a count with ± , then type a name that already exists and add it - the
-existing row bumps in place rather than duplicating.
-
-## What it teaches
-
-**Keys hold plain values.** Give `map` two types instead of a factory and it
-behaves like a `Map` that anything reading it can subscribe to.
-
-**Notification is per-key.** Changing one entry notifies readers of that
-entry. Adding or removing a key notifies readers of the collection's shape.
-A consumer reading a single count ignores every other change.
-
-**It reads like the built-in.** `get`, `set`, `size`, `values()` and iteration
-all behave as expected, so the reactivity is the only thing that is new.
-
-## Where to look next
-
-- **map (spawn)** takes a factory and owns the members it creates.
-- **has (list)** stores values by position when keys add nothing.
+Notification is per-key: changing one entry notifies readers of that entry,
+while adding or removing a key notifies readers of the collection's shape. Add
+a name that already exists and its row bumps in place.

--- a/examples/pages/instructions/map/App.tsx
+++ b/examples/pages/instructions/map/App.tsx
@@ -5,10 +5,6 @@ import { Component, get, map } from '@expressive/react';
 const PEOPLE = ['alice', 'bob', 'carol', 'dave'];
 const STATUS = ['online', 'away', 'busy'];
 
-// The room owns the people, keyed by id, and spawns them with a second
-// argument: set(id, name) forwards to the factory. The detail reads
-// people.get(selected), which subscribes to that one key - so it
-// re-renders when the selected person changes, not when the others do.
 export default class Room extends Component {
   people = map((id: string) => new Person({ id, name: capitalize(id) }));
   selected = '';
@@ -24,12 +20,6 @@ export default class Room extends Component {
 
     return (
       <div className="container room">
-        <h1>Presence</h1>
-        <p>
-          Click a name to select; click a status dot to cycle it. The detail
-          reads <code>people.get(selected)</code>, so it tracks only that key.
-        </p>
-
         <div className="layout">
           <ul className="people">{people}</ul>
 
@@ -51,8 +41,6 @@ export default class Room extends Component {
   }
 }
 
-// A person is a spawned, owned member keyed by id. It reads get(Room) to
-// reflect and change the selection.
 class Person extends Component {
   room = get(Room);
   id = '';

--- a/examples/pages/instructions/map/README.md
+++ b/examples/pages/instructions/map/README.md
@@ -1,0 +1,29 @@
+# Presence
+
+`map` with a factory owns its members and keys them. `set(id, name)` spawns a
+member and forwards the extra argument to the factory.
+
+## What to try
+
+Click a name to select it; click a status dot to cycle that person without
+selecting them. The detail pane on the right follows the selection.
+
+## What it teaches
+
+**Keyed, spawned members.** The room owns every `Person` and addresses them by
+id. Rendering `{people}` drops the whole collection in - members are elements,
+so there is nothing to map over.
+
+**A read of one key subscribes to one key.** The detail pane reads
+`people.get(selected)`, so it re-renders when the selection changes or when
+*that* person changes - not when the other three do.
+
+**Members reach back up.** `Person` reads `get(Room)` to know whether it is
+selected and to change the selection on click. State flows through the shared
+instance rather than through props and callbacks.
+
+## Where to look next
+
+- **map (insert)** is the same instruction without a factory, keying plain
+  values you place yourself.
+- **has** owns members without keys, when position or identity is enough.

--- a/examples/pages/instructions/map/README.md
+++ b/examples/pages/instructions/map/README.md
@@ -1,29 +1,10 @@
 # Presence
 
-`map` with a factory owns its members and keys them. `set(id, name)` spawns a
-member and forwards the extra argument to the factory.
+`map` with a factory owns its members and keys them; `set(id, name)` spawns one
+and forwards the extra argument along. Rendering `{people}` drops the whole
+collection in, since members are elements.
 
-## What to try
-
-Click a name to select it; click a status dot to cycle that person without
-selecting them. The detail pane on the right follows the selection.
-
-## What it teaches
-
-**Keyed, spawned members.** The room owns every `Person` and addresses them by
-id. Rendering `{people}` drops the whole collection in - members are elements,
-so there is nothing to map over.
-
-**A read of one key subscribes to one key.** The detail pane reads
-`people.get(selected)`, so it re-renders when the selection changes or when
-*that* person changes - not when the other three do.
-
-**Members reach back up.** `Person` reads `get(Room)` to know whether it is
-selected and to change the selection on click. State flows through the shared
-instance rather than through props and callbacks.
-
-## Where to look next
-
-- **map (insert)** is the same instruction without a factory, keying plain
-  values you place yourself.
-- **has** owns members without keys, when position or identity is enough.
+The detail pane reads `people.get(selected)`, which subscribes to that one key
+- so it re-renders when the selection changes or when *that* person does, not
+when the other three do. Each `Person` reads `get(Room)` to change the
+selection without a prop.

--- a/examples/pages/instructions/ref-multiple/App.tsx
+++ b/examples/pages/instructions/ref-multiple/App.tsx
@@ -8,10 +8,6 @@ const FIELDS = [
   { key: 'email', label: 'Email' }
 ] as const;
 
-// `ref(this)` is the plural form: one call hands back an imperative handle
-// for *every* field, keyed by name. Each `refs.first` is a callable ref -
-// `refs.first('Ada')` writes the field - so one proxy drives the whole form
-// and a loop can clear every field, with no useRef per input.
 class Profile extends State {
   first = '';
   last = '';
@@ -32,12 +28,6 @@ function Form() {
 
   return (
     <div className="container form">
-      <h1>Ref Proxy</h1>
-      <p>
-        <code>ref(this)</code> exposes one callable ref per field. Every input
-        writes through that proxy, and Clear loops it over all three.
-      </p>
-
       <div className="fields">
         {FIELDS.map(({ key, label }) => (
           <label key={key}>

--- a/examples/pages/instructions/ref-multiple/README.md
+++ b/examples/pages/instructions/ref-multiple/README.md
@@ -1,0 +1,27 @@
+# Ref Proxy
+
+`ref(this)` is the plural form: one call hands back an imperative handle for
+*every* field, keyed by name.
+
+## What to try
+
+Fill in a field or two - the counter tracks how many are filled - then hit
+**Clear all** and watch one loop empty the whole form.
+
+## What it teaches
+
+**One proxy, every field.** `refs.first` is a callable ref for `first`,
+`refs.email` for `email`, and so on. Adding a field to the class adds a handle
+without touching the ref.
+
+**Calling the handle writes the field.** `refs.first('Ada')` assigns, which is
+why each input can change through the proxy and why `clear()` is a loop rather
+than three assignments.
+
+**No `useRef` per input.** The class already knows its own fields, so the
+handles come from the shape of the state instead of from the render body.
+
+## Where to look next
+
+- **ref (single)** holds one value - typically a DOM node.
+- **def** is how a plural instruction like this one is built.

--- a/examples/pages/instructions/ref-multiple/README.md
+++ b/examples/pages/instructions/ref-multiple/README.md
@@ -1,27 +1,9 @@
 # Ref Proxy
 
-`ref(this)` is the plural form: one call hands back an imperative handle for
-*every* field, keyed by name.
+`ref(this)` is the plural form: one call hands back a callable handle for every
+field, keyed by name. Adding a field to the class adds a handle without
+touching the ref.
 
-## What to try
-
-Fill in a field or two - the counter tracks how many are filled - then hit
-**Clear all** and watch one loop empty the whole form.
-
-## What it teaches
-
-**One proxy, every field.** `refs.first` is a callable ref for `first`,
-`refs.email` for `email`, and so on. Adding a field to the class adds a handle
-without touching the ref.
-
-**Calling the handle writes the field.** `refs.first('Ada')` assigns, which is
-why each input can change through the proxy and why `clear()` is a loop rather
-than three assignments.
-
-**No `useRef` per input.** The class already knows its own fields, so the
-handles come from the shape of the state instead of from the render body.
-
-## Where to look next
-
-- **ref (single)** holds one value - typically a DOM node.
-- **def** is how a plural instruction like this one is built.
+Calling a handle writes its field, so each input changes through the proxy and
+**Clear all** is a loop rather than three assignments. The handles come from
+the shape of the state, not from `useRef` calls in the render body.

--- a/examples/pages/instructions/ref/App.tsx
+++ b/examples/pages/instructions/ref/App.tsx
@@ -3,10 +3,6 @@ import './App.css';
 import { Component, ref } from '@expressive/react';
 import type { PointerEvent } from 'react';
 
-// `ref` is the useRef replacement: a slot for a value outside the render
-// data - here the DOM node being dragged. Its callable form captures the
-// node; `.current` reaches it to measure geometry. Position is plain x/y
-// state, so the box just follows the numbers.
 class Draggable extends Component {
   box = ref<HTMLDivElement>();
 
@@ -16,8 +12,7 @@ class Draggable extends Component {
 
   offset = { x: 0, y: 0 };
 
-  // Pointer events unify mouse and touch; capturing the pointer keeps the
-  // drag tracking even when it outruns the box.
+  // Capturing the pointer keeps the drag tracking when it outruns the box.
   grab(e: PointerEvent) {
     const rect = this.box.current!.getBoundingClientRect();
 
@@ -45,12 +40,6 @@ class Draggable extends Component {
 
     return (
       <div className="container drag">
-        <h1>Refs</h1>
-        <p>
-          Drag the box. Its position is plain <code>x</code>/<code>y</code>{' '}
-          state; <code>ref</code> holds the node so the handler can measure it.
-        </p>
-
         <div className="surface">
           <div
             ref={this.box}

--- a/examples/pages/instructions/ref/README.md
+++ b/examples/pages/instructions/ref/README.md
@@ -1,28 +1,10 @@
 # Refs
 
-`ref` is the `useRef` replacement: a slot for a value that lives outside the
-render data - here, the DOM node being dragged.
+`ref` is the `useRef` replacement - a slot for a value outside the render data,
+here the node being dragged. Its callable form captures the element and
+`.current` reaches it, replacing the usual `useRef` and `useEffect` pair.
 
-## What to try
-
-Drag the box around the surface. It clamps at the edges, and dragging fast
-enough to outrun the pointer still tracks.
-
-## What it teaches
-
-**The callable form captures the node.** Passing `this.box` to `ref=` stores
-the element; `this.box.current` reaches it later. One field replaces the
-`useRef` + `useEffect` pair.
-
-**Position is ordinary state.** `x` and `y` are plain reactive fields, so the
-box simply follows the numbers. The ref is only there for the one thing state
-cannot answer: the node's measured geometry.
-
-**Handlers are methods.** `grab`, `move` and `drop` are declared methods
-passed straight to the element - no arrow wrappers, no `useCallback`, and no
-stale closure over the drag offset.
-
-## Where to look next
-
-- **ref (proxy)** hands back one callable ref per field in a single call.
-- **set** manages a field's value rather than a slot beside it.
+Position is ordinary state, so the box just follows `x` and `y`; the ref exists
+only for the one thing state cannot answer, which is measured geometry.
+Handlers are declared methods passed straight to the element - no
+`useCallback`, no stale closure over the drag offset.

--- a/examples/pages/instructions/ref/README.md
+++ b/examples/pages/instructions/ref/README.md
@@ -1,0 +1,28 @@
+# Refs
+
+`ref` is the `useRef` replacement: a slot for a value that lives outside the
+render data - here, the DOM node being dragged.
+
+## What to try
+
+Drag the box around the surface. It clamps at the edges, and dragging fast
+enough to outrun the pointer still tracks.
+
+## What it teaches
+
+**The callable form captures the node.** Passing `this.box` to `ref=` stores
+the element; `this.box.current` reaches it later. One field replaces the
+`useRef` + `useEffect` pair.
+
+**Position is ordinary state.** `x` and `y` are plain reactive fields, so the
+box simply follows the numbers. The ref is only there for the one thing state
+cannot answer: the node's measured geometry.
+
+**Handlers are methods.** `grab`, `move` and `drop` are declared methods
+passed straight to the element - no arrow wrappers, no `useCallback`, and no
+stale closure over the drag offset.
+
+## Where to look next
+
+- **ref (proxy)** hands back one callable ref per field in a single call.
+- **set** manages a field's value rather than a slot beside it.

--- a/examples/pages/instructions/set/App.tsx
+++ b/examples/pages/instructions/set/App.tsx
@@ -2,17 +2,12 @@ import './App.css';
 
 import { Component, set } from '@expressive/react';
 
-// `set` manages a slot beyond a plain field: a default value, a validator,
-// or a change-effect - each just a callback, no useEffect, no deps array.
 class Account extends Component {
-  // A default, plus a callback that vets every assignment. `throw false`
-  // rejects the update - the field never exceeds 12 characters.
   name = set('guest', (next) => {
+    // `throw false` rejects the assignment; the field keeps its old value.
     if (next.length > 12) throw false;
   });
 
-  // The callback may return a cleanup, run before the next change - so a
-  // debounce falls out for free: each keystroke cancels the previous timer.
   query = set('', (next) => {
     this.result = 'typing…';
 
@@ -30,8 +25,6 @@ class Account extends Component {
 
     return (
       <div className="container">
-        <h1>Managed Slots</h1>
-
         <label>
           Display name <small>(max 12 chars — extra input is rejected)</small>
           <input value={name} onChange={(e) => (this.name = e.target.value)} />

--- a/examples/pages/instructions/set/README.md
+++ b/examples/pages/instructions/set/README.md
@@ -1,0 +1,32 @@
+# Managed Slots
+
+`set` manages a slot beyond a plain field: a default value, a validator, or a
+change-effect - each just a callback, no `useEffect`, no dependency array.
+
+## What to try
+
+Type more than twelve characters into **Display name** - the extra input is
+rejected outright and the field never holds it. Then type into **Search** and
+pause: the result only settles 500ms after you stop.
+
+## What it teaches
+
+**A callback can vet an assignment.** `name` pairs a default with a function
+that runs before every write. Throwing `false` rejects the update, so the
+invalid value is never stored - validation lives with the field rather than in
+the handler that changes it.
+
+**A callback can return a cleanup.** The cleanup runs before the next change,
+so `query` debounces for free: each keystroke cancels the timer the previous
+one started. That is the whole debounce - no effect, no deps, no ref to hold
+the timer.
+
+**Both are the same callback.** There is one signature for validating,
+reacting, and cleaning up, because all three are "something to do when this
+field changes."
+
+## Where to look next
+
+- **def** is the primitive `set` itself is built on, when you want to define
+  your own instruction.
+- **get** derives one field from others, or reaches into context.

--- a/examples/pages/instructions/set/README.md
+++ b/examples/pages/instructions/set/README.md
@@ -1,32 +1,9 @@
 # Managed Slots
 
-`set` manages a slot beyond a plain field: a default value, a validator, or a
-change-effect - each just a callback, no `useEffect`, no dependency array.
+`set` manages a slot beyond a plain field - a default, a validator, or a
+change-effect - each just a callback. **Display name** rejects anything over
+twelve characters by throwing `false`, so the invalid value is never stored.
 
-## What to try
-
-Type more than twelve characters into **Display name** - the extra input is
-rejected outright and the field never holds it. Then type into **Search** and
-pause: the result only settles 500ms after you stop.
-
-## What it teaches
-
-**A callback can vet an assignment.** `name` pairs a default with a function
-that runs before every write. Throwing `false` rejects the update, so the
-invalid value is never stored - validation lives with the field rather than in
-the handler that changes it.
-
-**A callback can return a cleanup.** The cleanup runs before the next change,
-so `query` debounces for free: each keystroke cancels the timer the previous
-one started. That is the whole debounce - no effect, no deps, no ref to hold
-the timer.
-
-**Both are the same callback.** There is one signature for validating,
-reacting, and cleaning up, because all three are "something to do when this
-field changes."
-
-## Where to look next
-
-- **def** is the primitive `set` itself is built on, when you want to define
-  your own instruction.
-- **get** derives one field from others, or reaches into context.
+The same callback may return a cleanup, run before the next change, so
+**Search** debounces for free: each keystroke cancels the timer the previous
+one started. No `useEffect`, no dependency array, no ref holding the timer.

--- a/examples/pages/router/overview/App.tsx
+++ b/examples/pages/router/overview/App.tsx
@@ -3,13 +3,10 @@ import './App.css';
 import { Component, get } from '@expressive/react';
 import { Link, Route, Router } from '@expressive/router';
 
-// Routes ARE Components. The layout renders the nav once; the matched
-// child arrives as `props.children`.
 class Layout extends Component {
   render() {
     return (
       <div className="container">
-        <h1>Router</h1>
         <nav className="nav">
           <Link to="/">Home</Link>
           <Link to="/about">About</Link>
@@ -33,7 +30,6 @@ class About extends Component {
   }
 }
 
-// A page reads its own Route from context for params, match, navigation.
 class User extends Component {
   route = get(Route);
 

--- a/examples/pages/router/overview/README.md
+++ b/examples/pages/router/overview/README.md
@@ -1,27 +1,11 @@
 # Router
 
-Routes are Components. A route matches a path and the Component it names
-renders - there is no separate page abstraction.
+Routes are Components - a route matches a path and the Component it names
+renders, with no separate page abstraction. `Layout` draws the nav once and
+receives the matched child as `props.children`, so nesting routes nests
+components.
 
-## What to try
-
-Follow the links. Navigation is in-memory here, so nothing leaves the sandbox,
-and the **User** link shows a param arriving from the path.
-
-## What it teaches
-
-**A layout is a Component that renders its children.** `Layout` draws the nav
-once and puts the matched child in `props.children`. Nesting routes nests
-components; nothing else declares the hierarchy.
-
-**A page reads its own route.** `get(Route)` gives a Component the route it was
-matched by, which is where params, match state and navigation come from - so
-`User` reads `this.route.match?.name` without being handed a prop.
-
-**Routes are ordinary classes.** They have fields, methods and lifecycle like
-any other Component, so data loading and guards live on the route itself.
-
-## Where to look next
-
-- **get** covers context lookup generally, of which `get(Route)` is one case.
-- **lifecycle** is where a route would fetch on mount.
+A page reads its own route with `get(Route)`, which is where params, match
+state and navigation come from - `User` reads `this.route.match?.name` without
+being handed a prop. Routes are ordinary classes, so loading and guards live on
+the route itself.

--- a/examples/pages/router/overview/README.md
+++ b/examples/pages/router/overview/README.md
@@ -1,0 +1,27 @@
+# Router
+
+Routes are Components. A route matches a path and the Component it names
+renders - there is no separate page abstraction.
+
+## What to try
+
+Follow the links. Navigation is in-memory here, so nothing leaves the sandbox,
+and the **User** link shows a param arriving from the path.
+
+## What it teaches
+
+**A layout is a Component that renders its children.** `Layout` draws the nav
+once and puts the matched child in `props.children`. Nesting routes nests
+components; nothing else declares the hierarchy.
+
+**A page reads its own route.** `get(Route)` gives a Component the route it was
+matched by, which is where params, match state and navigation come from - so
+`User` reads `this.route.match?.name` without being handed a prop.
+
+**Routes are ordinary classes.** They have fields, methods and lifecycle like
+any other Component, so data loading and guards live on the route itself.
+
+## Where to look next
+
+- **get** covers context lookup generally, of which `get(Route)` is one case.
+- **lifecycle** is where a route would fetch on mount.

--- a/website/app/routes/examples/loader.ts
+++ b/website/app/routes/examples/loader.ts
@@ -1,6 +1,7 @@
 // Shared stylesheet lives at the examples root - pull it in directly.
 import styles from '@examples/global.css?raw';
 import { tree, type Directory } from '@examples/pages';
+import notes from 'virtual:example-notes';
 
 const leaves = (dirs: Directory[]): Directory[] =>
   dirs.flatMap((d) => (d.children ? leaves(d.children) : d));
@@ -11,22 +12,37 @@ export const EXAMPLE_LABELS = Object.fromEntries(
 );
 
 // `*/**/*` requires at least one folder under examples/ - skips top-level
-// SPA scaffolding (package.json, vite.config.ts, main.tsx, etc.).
-const FILES = import.meta.glob('@examples/*/**/*', {
+// SPA scaffolding (package.json, vite.config.ts, main.tsx, etc.). Extensions
+// are explicit so README.md stays out: fumadocs-mdx would claim it here and
+// hand back a compiled component (see `virtual:example-notes`).
+const FILES = import.meta.glob('@examples/*/**/*.{ts,tsx,css}', {
   query: '?raw',
   import: 'default',
   eager: true
 }) as Record<string, string>;
 
-const ENTRY = `\
+const entry = (readme: boolean) => `\
 import './global.css';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-
+${readme ? "import Readme from './README';\n" : ''}
 // Matches the dev harness: centers/constrains example content via global.css.
 document.body.classList.add('example');
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  ${readme ? '<>\n    <Readme />\n    <App />\n  </>' : '<App />'}
+);
+`;
+
+// Backslash, backtick and `${` would otherwise break out of the literal.
+const readme = (source: string) => `\
+import Notes from './common/Notes';
+
+export default () => (
+  <Notes>{\`
+${source.trim().replace(/[\\`]|\$(?=\{)/g, '\\$&')}
+\`}</Notes>
+);
 `;
 
 
@@ -72,13 +88,17 @@ export const REDIRECT = leaves(GROUPS).map((n) => n.path).find((p) => examples[p
 export const exampleSlug = (path = '') =>
   path.replace(/^\/examples\//, '').replace(/\/+$/, '');
 
-for (const folder of Object.values(examples)) {
+for (const [slug, folder] of Object.entries(examples)) {
   const cssImports = Object.keys(folder)
     .filter((p) => p.endsWith('.css'))
     .map((p) => `import '.${p}';\n`)
     .join('');
 
-  folder['/index.tsx'] = cssImports + ENTRY;
+  const source = notes[slug];
+
+  if (source) folder['/README.tsx'] = readme(source);
+
+  folder['/index.tsx'] = cssImports + entry(!!source);
 }
 
 // Matches `import ... '...'` and re-exports (`export ... from '...'`).
@@ -126,8 +146,11 @@ export function getFiles(name: string) {
 
   for (const [path, code] of sorted) {
     if (path === '/index.css') continue;
-    // /index.tsx is generated boilerplate from the sandbox plugin.
-    files[path] = path === '/index.tsx' ? { hidden: true, code } : code;
+    // Both are generated: the entry point, and the example's README as JSX.
+    files[path] =
+      path === '/index.tsx' || path === '/README.tsx'
+        ? { hidden: true, code }
+        : code;
   }
 
   // Shared chrome ships hidden: no editor tab, but present on eject so the

--- a/website/app/virtual.d.ts
+++ b/website/app/virtual.d.ts
@@ -1,0 +1,5 @@
+declare module 'virtual:example-notes' {
+  /** Example slug (e.g. `essentials/counter`) to its README.md source. */
+  const notes: Record<string, string>;
+  export default notes;
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -41,9 +41,49 @@ export default defineConfig({
     tailwindcss(),
     reactRouter(),
     tsconfigPaths(),
+    exampleNotes(),
     serveSkills()
   ]
 });
+
+const NOTES = 'virtual:example-notes';
+
+/**
+ * Example READMEs as a slug -> markdown map. Read off disk rather than
+ * import.meta.glob'd because fumadocs-mdx claims every `*.md` id (including
+ * `?raw`) and would hand back a compiled MDX component instead of source.
+ */
+function exampleNotes(): Plugin {
+  const resolved = `\0${NOTES}`;
+  const root = resolve(__dirname, '../examples/pages');
+
+  return {
+    name: 'example-notes',
+    resolveId(id) {
+      if (id === NOTES) return resolved;
+    },
+    async load(id) {
+      if (id !== resolved) return;
+
+      const notes: Record<string, string> = {};
+
+      for await (const entry of glob('**/README.md', { cwd: root })) {
+        notes[dirname(entry)] = await readFile(join(root, entry), 'utf8');
+        this.addWatchFile(join(root, entry));
+      }
+
+      return `export default ${JSON.stringify(notes)}`;
+    },
+    configureServer(server) {
+      server.watcher.on('all', (_event, file) => {
+        if (!file.endsWith('README.md')) return;
+
+        const mod = server.moduleGraph.getModuleById(resolved);
+        if (mod) server.reloadModule(mod);
+      });
+    }
+  };
+}
 
 function serveSkills(): Plugin {
   // Site-owned llm content overlays the skills copy under the same /llm root.


### PR DESCRIPTION
An example's commentary moves out of its source and into a `README.md` beside
it, rendered **inside the example frame** by a shared `@common/Notes`
component rather than by chrome around it.

Examples were carrying their lesson two or three times over: a comment block
above the class, a heading and lead paragraph inside `render()`, and often a
closing `<small>` captioning the demo. That is prose competing with the code it
is meant to explain, and it made the spreadsheet-class examples unreadable
until you read the comments — which is the thing nobody does.

## Why inside the frame

An earlier prototype (`feat/example-readme`, abandoned) rendered notes as a
panel in the chrome. That needed two independent pipelines for one piece of
content, a panel header, a draggable split and two stylesheets — and the copy
still vanished the moment anyone ejected to CodeSandbox.

Rendering inside the example gets it for free: one surface by construction
instead of two implementations kept in sync, no split to build, and the notes
survive an eject because they are part of the sandbox.

## Can the README be imported?

No — and worth recording, because it shaped the design. Sandpack 2 hits
`https://<version>-sandpack.codesandbox.io/`, whose React preset ends
`mapTransformers` with:

```ts
if (/\.css$/.test(module.filepath)) { ... }
throw new Error(`No transformer for ${module.filepath}`);
```

Only `js/jsx/ts/tsx/mjs/cjs` and `.css` are handled. Importing markdown does
not degrade — it kills the preview. (An unimported `README.md` sitting in the
file tree is inert and would ship fine; it just can't be wired up, which makes
shipping it redundant once the copy lives in a generated file.)

So the markdown stays a repo-side source, and the sandbox gets a generated
`/README.tsx` carrying the copy as a template literal inside `<Notes>` —
hidden, alongside the generated `/index.tsx`.

## Approach

- **`examples/common/Notes.tsx`** — a `<details open>` plus a ~40-line
  markdown-subset renderer (h2, paragraphs, lists, bold, inline code, links).
  Native disclosure, so collapsing needs no state and no dependency; a runtime
  markdown library would otherwise land in every ejected `package.json`.
  Living in `common/` means the existing transitive-closure logic in
  `loader.ts` already ships it and its CSS into the sandbox, hidden.
- **Dev app** — `main.tsx`'s iframe branch wraps the lazily-loaded `App`,
  reading the markdown through a raw glob in `examples/notes.ts`.
- **Website** — the generated entry gains `import Readme from './README'` and
  renders `<><Readme /><App /></>` when the example has one.
- **`virtual:example-notes`** — fumadocs-mdx claims every `*.md` id, `?raw`
  included, and would hand back a compiled MDX component. The plugin reads the
  files off disk instead. The sandbox `FILES` glob is now extension-explicit so
  a README can never wander into it.

## Extraction

18 write-ups: `essentials/counter`, all nine `instructions`, all eight
`component`, and `router/overview`. Each `App.tsx` loses its `<h1>`, lead
paragraph and caption; what survives in code is four callouts stating
something the code genuinely cannot — pointer capture in `ref`, `throw false`
in `set`, the hoisting note in `dial`, and the clamping comments in `dial/Arc`.

## Verification

Beyond `tsc`: `vite build` on examples and a full `bun run build` on the
website both pass, and the output was inspected — the READMEs are in the
examples bundle, the virtual module resolved, and both generators appear in
`loader-*.js`.

A throwaway happy-dom pass over all 18 READMEs caught a real bug: **inline code
nested inside bold** rendered its backticks literally, which this copy uses
constantly. Fixed by recursing the inline parser through `<strong>`; the sweep
then asserted no leftover `**`, backticks, `](http` or `##` in any rendered
body. The harness was deleted — `examples/` has no test infrastructure and
adding some is out of scope here.

No changeset: `@expressive/examples` is private and the website is not
published.

## Worth a look in review

- Prose renders inside `body.example #root`, a centered **32rem** column —
  narrower than the abandoned panel's measure. Reads fine, but it is a real
  change in line length; widening is one rule in `Notes.css`.
- Examples now open with a left-aligned notes title where a centered `<h1>`
  used to be. Intended, but it is the first thing you notice.
