### PR TITLE
fix(react): hold State.get dispatch until the attempt commits

### DIFF
--- a/.changeset/olive-pandas-refresh.md
+++ b/.changeset/olive-pandas-refresh.md
@@ -1,0 +1,5 @@
+---
+'@expressive/react': patch
+---
+
+`State.get()` no longer dispatches a React update before its render attempt has committed. A subscriber whose fiber was discarded pre-commit - a sibling mutating shared state during render, under a Suspense boundary that never resolves - called `setState` on a fiber React had not mounted, producing the dev warning *"Can't perform a React state update on a component that hasn't mounted yet."* A change arriving before commit is now held and flushed once the fiber commits, so no update is lost.

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -1,8 +1,9 @@
 import React, { Suspense } from 'react';
-import { Component, get, State, Provider, set } from '.';
-import { mock, spyOn, expect, it, describe, afterEach, afterAll } from 'bun:test';
+import { Component, Context, get, State, Provider, set } from '.';
+import { mock, spyOn, expect, it, describe, beforeEach, afterEach, afterAll } from 'bun:test';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { mockPromise, flushMicrotasks } from '../test.setup';
+import { Runtime } from './runtime';
 
 function renderWith<T>(Type: State.Type | State, hook: () => T) {
   return renderHook(hook, {
@@ -1176,5 +1177,101 @@ describe('State.get - nested dependency', () => {
 
     expect(hook.result.current).toBe(5);
     expect(didRender).toBeCalledTimes(2);
+  });
+});
+
+// Runtime is stubbed with a hand-driven lifecycle (as in runtime.test.ts) so a
+// change can land strictly before vs. after commit - the ordering React itself
+// won't reproduce on demand.
+describe('State.get - pre-commit dispatch', () => {
+  class Test extends State {
+    value = 0;
+  }
+
+  function harness(test: Test) {
+    const refs: { current: any }[] = [];
+    const inited: boolean[] = [];
+    const effects: (() => (() => void) | void)[] = [];
+    const context = new Context({ test });
+    const update = mock();
+    let index = 0;
+
+    Runtime.useContext = (() => context) as typeof Runtime.useContext;
+
+    Runtime.useRef = ((value: any) => {
+      const ref = refs[index] || (refs[index] = { current: value });
+      index++;
+      return ref;
+    }) as typeof Runtime.useRef;
+
+    Runtime.useState = ((value: any) => {
+      const slot = index++;
+      if (!inited[slot]) {
+        inited[slot] = true;
+        if (typeof value === 'function') value();
+      }
+      return [0, update];
+    }) as typeof Runtime.useState;
+
+    Runtime.useEffect = ((fn: any) => void effects.push(fn)) as typeof Runtime.useEffect;
+
+    return {
+      update,
+      render: () => {
+        index = 0;
+        effects.length = 0;
+        void Test.get().value;
+      },
+      commit: () => effects.forEach((fn) => fn())
+    };
+  }
+
+  let saved: Partial<typeof Runtime>;
+
+  beforeEach(() => void (saved = { ...Runtime }));
+  afterEach(() => void Object.assign(Runtime, saved));
+
+  it('will not dispatch before the attempt commits', async () => {
+    const test = Test.new();
+    const { update, render } = harness(test);
+
+    render();
+    test.value = 1;
+
+    await expect(test).toHaveUpdated();
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('will flush a deferred dispatch once committed', async () => {
+    const test = Test.new();
+    const { update, render, commit } = harness(test);
+
+    render();
+    test.value = 1;
+    test.value = 2;
+
+    await expect(test).toHaveUpdated();
+
+    expect(update).not.toHaveBeenCalled();
+
+    commit();
+
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('will dispatch immediately after commit', async () => {
+    const test = Test.new();
+    const { update, render, commit } = harness(test);
+
+    render();
+    commit();
+    update.mockClear();
+
+    test.value = 1;
+
+    await expect(test).toHaveUpdated();
+
+    expect(update).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/state.get.ts
+++ b/packages/react/src/state.get.ts
@@ -87,6 +87,11 @@ State.get = function get<T extends State>(
       next((x) => x + 1);
     }
 
+    function observed() {
+      if (mounted) update();
+      else pending = true;
+    }
+
     function refresh<T>(action?: Promise<T> | (() => Promise<T>)): any {
       if (typeof action == 'function') action = action();
       update();
@@ -123,7 +128,7 @@ State.get = function get<T extends State>(
             value = current;
           }
 
-          if (!first) update();
+          if (!first) observed();
           first = false;
         },
         argument === true
@@ -174,6 +179,7 @@ State.get = function get<T extends State>(
       pending = false;
       useHook(() => () => {
         mounted = true;
+        if (pending) update();
         return release;
       });
       return value === undefined ? null : value;


### PR DESCRIPTION
Closes #125.

## What was wrong

`State.get()` subscribes during render but dispatches through a raw `useState` setter (`next`, `state.get.ts:77`) with no commit gate. Its `mounted` flag is only set in the commit stage, yet the watch callback called `update()` unconditionally. So a change arriving between subscribe and commit ran `setState` on a fiber React had never mounted:

> Can't perform a React state update on a component that hasn't mounted yet.

#108 (`1e08e3bc`) fixed exactly this shape for `useHook` — deferring pre-commit refreshes behind a `pending` flag — but `State.get` keeps its own setter and was never covered by that change. #125 was filed nine days after `1e08e3bc` landed, which is why it read as already-fixed on inspection; the warning is still reachable, just through the other path.

Reproduced against `main`: a sibling mutating shared state during render, under a `Suspense` boundary that stays suspended, so the subscribed attempt is discarded. Confirmed the exact React 19 dev string is emitted.

## The fix

Eight lines, reusing the machinery already present:

- a pre-commit change sets the existing `pending` flag instead of dispatching;
- the commit stage flushes it.

Deferred, not dropped — a subscriber that does commit still gets its update. Post-commit dispatch is unchanged.

`@expressive/preact` consumes `@expressive/react/adapter`, so it inherits the fix; no duplicate implementation.

## Tests

React won't reproduce the render/commit interleaving on demand — a warning-sniffing test passes or fails on scheduling luck (rendering inside `act` suppresses it entirely; `flushMicrotasks` lets the fallback commit first). So the tests stub `Runtime` with a hand-driven lifecycle, the pattern `runtime.test.ts` already uses for the `useHook` equivalent, and drive render/commit explicitly.

Three cases, each load-bearing — verified by reverting one half of the fix at a time:

| Test | Fails without |
| --- | --- |
| will not dispatch before the attempt commits | the gate |
| will flush a deferred dispatch once committed | the commit-stage flush |
| will dispatch immediately after commit | (guards against over-deferring) |

## Verification

mvc 617 · router 218 · react 257 · preact 142 — 0 fail, `tsc --noEmit` clean in every package, 100% line **and** function coverage held in `@expressive/react`, all four builds clean.

## Not in scope

#126 (a discarded subcomponent attempt never releases its `watch` on the owner) is the adjacent leak and stays open — this change makes the discarded attempt silent, not unsubscribed.