### PR TITLE
fix(router): packaging hygiene - drop react peer dep, sideEffects, publish metadata

### DIFF
--- a/.changeset/router-packaging-hygiene.md
+++ b/.changeset/router-packaging-hygiene.md
@@ -1,0 +1,9 @@
+---
+"@expressive/router": patch
+---
+
+Packaging hygiene: drop the `react` peer dependency and declare `sideEffects: false`.
+
+The router is host-agnostic - its runtime imports are `@expressive/mvc` entries only, so nothing here requires React itself. The hard peer range (`>=16.8.0 <20.0.0`) produced unmet-peer warnings for non-React hosts and belongs to the adapter, which already declares React as an optional peer. Installing under React is unchanged: the adapter's own peering still applies.
+
+`sideEffects: false` lets bundlers tree-shake the package like `@expressive/mvc`; no module runs anything at import time. Also aligns publish metadata with sibling packages (`publishConfig.access`) and removes a vestigial npm-based `preversion` script - releases run through changesets CI.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "expressive-mvc",
@@ -86,19 +87,16 @@
       "name": "@expressive/router",
       "version": "0.6.1",
       "dependencies": {
-        "@expressive/mvc": "^0.80.0",
+        "@expressive/mvc": "^0.82.0",
       },
       "devDependencies": {
-        "@expressive/react": "^0.81.0",
+        "@expressive/react": "^0.83.0",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "react": "^19",
         "react-dom": "^19",
         "tsdown": "^0.20.1",
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 <20.0.0",
       },
     },
     "website": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -24,6 +24,7 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -35,10 +36,12 @@
   "engines": {
     "node": ">=20"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsdown",
-    "test": "tsc --noEmit && bun test --coverage",
-    "preversion": "npm run test && npm run build"
+    "test": "tsc --noEmit && bun test --coverage"
   },
   "dependencies": {
     "@expressive/mvc": "^0.82.0"
@@ -51,8 +54,5 @@
     "react": "^19",
     "react-dom": "^19",
     "tsdown": "^0.20.1"
-  },
-  "peerDependencies": {
-    "react": ">=16.8.0 <20.0.0"
   }
 }

--- a/packages/router/src/link.tsx
+++ b/packages/router/src/link.tsx
@@ -66,7 +66,7 @@ export class Link extends Component {
   };
 
   /**
-   * If a subclass authores own render, it will override default anchor wrapping.
+   * A subclass that authors its own render overrides the default anchor wrapping.
    */
   render({ children, to, replace, ...rest } = {} as Link.Props): Component.Node {
     if (children !== this.props.children) return children;


### PR DESCRIPTION
Low-hanging packaging fixes for `@expressive/router`, surfaced while auditing the package for real-app readiness.

## Changes

- **Drop the `react` peer dependency.** The router is host-agnostic: its runtime imports are `@expressive/mvc` entries only (`.`, `/jsx-runtime`, `/observable`); `@expressive/react` appears only in tests. The hard peer range (`>=16.8.0 <20.0.0`) produced unmet-peer warnings for non-React hosts and contradicted the package's own claim. React peering belongs to the adapter, which already declares it (as optional). Install experience under React is unchanged.
- **`sideEffects: false`** - matches `@expressive/mvc`; no router module runs anything at import time (registration happens at activation), so bundlers can tree-shake or drop it freely.
- **`publishConfig.access: public`** - router was the only published package missing it.
- **Remove vestigial `preversion` script** - npm-based and unused; releases run through changesets CI. No sibling has one.
- **`bun.lock` sync** - the peer removal, plus pre-existing drift (workspace ranges stale since the last version bump, bun's new `configVersion` marker).
- One comment typo in `link.tsx`.

Changeset included (patch): the peer-dep and `sideEffects` changes are consumer-observable.

## Verification

`bun run test` in `packages/router`: 218 pass / 1 pre-existing skip, 100% line coverage. `bun run build` clean.