### PR TITLE
fix(mvc): throw on duplicate same-type global

### DIFF
--- a/.changeset/duplicate-global-throws.md
+++ b/.changeset/duplicate-global-throws.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": minor
+---
+
+A second global instance of the same type now throws on activation instead of silently evicting both from root. A duplicate `static global` singleton is nearly always a bug (double `.new()`, leaked test instance), and mutual eviction deferred the failure to a distant "Could not find X in context". Destroy the existing instance first (`set(null)`), or register additional instances explicitly via context. Sibling-subtype collisions at a shared ancestor keep the per-ancestor eviction semantics.

--- a/packages/mvc/src/context.test.ts
+++ b/packages/mvc/src/context.test.ts
@@ -1351,7 +1351,7 @@ describe('root global', () => {
     instance.set(null);
   });
 
-  it('will evict prior and reject new on implicit collision', () => {
+  it('will throw on duplicate global of same type', () => {
     class Multi extends State {
       static global = true;
     }
@@ -1360,12 +1360,42 @@ describe('root global', () => {
 
     expect(root.get(Multi)).toBe(first);
 
-    const second = Multi.new();
+    expect(() => Multi.new()).toThrow(
+      /already exists in root/
+    );
 
-    // Both are released - collision is an implicit opt-out from global
-    expect(root.get(Multi, false)).toBeUndefined();
+    expect(root.get(Multi)).toBe(first);
 
     first.set(null);
+  });
+
+  it('will throw on duplicate global from a resolver', () => {
+    class Multi extends State {
+      static global: State.Global = () => true;
+    }
+
+    const first = Multi.new();
+
+    expect(() => Multi.new()).toThrow(
+      /already exists in root/
+    );
+
+    first.set(null);
+  });
+
+  it('will register a new global after previous is destroyed', () => {
+    class Multi extends State {
+      static global = true;
+    }
+
+    const first = Multi.new();
+
+    first.set(null);
+
+    const second = Multi.new();
+
+    expect(root.get(Multi)).toBe(second);
+
     second.set(null);
   });
 

--- a/packages/mvc/src/context.ts
+++ b/packages/mvc/src/context.ts
@@ -232,8 +232,17 @@ class Context {
       const entries = provide.get(T);
       if (entries)
         for (const entry of entries)
-          if (!entry[1] && entry[0] !== I)
+          if (!entry[1] && entry[0] !== I) {
+            const type = I.constructor as State.Extends;
+            const g = type.global;
+
+            if (entry[0].constructor === type && (typeof g == 'function' ? g(I) : g))
+              throw new Error(
+                `Cannot register ${I} as a global - ${entry[0]} already exists in root. Destroy the existing instance first, or provide additional ones via explicit context.`
+              );
+
             return entries.delete(entry);
+          }
     }
 
     for (

--- a/packages/router/src/router.test.tsx
+++ b/packages/router/src/router.test.tsx
@@ -112,6 +112,7 @@ describe('Router (headless)', () => {
     encoded.goto('/x?q=a%20b');
     await encoded.set();
     expect(encoded.entries).toEqual(['/', '/x?q=a+b']);
+    encoded.set(null);
 
     const repeated = Router.new();
     repeated.goto('/x?a=1&a=2');
@@ -323,8 +324,8 @@ describe('BrowserRouter', () => {
       const server = BrowserRouter.new();
 
       expect(server.path).toBe('/');
-      // did not register a global - else it would collide with and evict the
-      // client instance, leaving the lookup ambiguous
+      // did not register a global - else it would throw on collision with the
+      // live client instance
       expect(Context.root.get(BrowserRouter)).toBe(router.current);
 
       server.set(null);

--- a/skills/state/context.md
+++ b/skills/state/context.md
@@ -88,19 +88,19 @@ Global status is irrelevant to a context-claimed State: an instance provided by 
 
 ### Global Collision
 
-Two global instances of the same type in root mutually evict at the contested ancestor:
+A second global instance of the same type throws on activation - a global is a singleton, and a duplicate is treated as a bug at its source:
 
 ```ts
 const a = Sub.new(); // Sub declares `static global`
-const b = Sub.new();
-Context.root.get(Sub, false); // undefined - both evicted
+Sub.new();           // throws - Sub already exists in root
+Context.root.get(Sub); // a - first instance unaffected
 ```
 
-Read this as "a collision is opt-out from global" - if you create two, neither is the global instance. A third `Sub.new()` would re-claim global status (the empty contested set is reclaimable).
+Destroy the existing instance first (`a.set(null)`) and a fresh `Sub.new()` registers cleanly. To hold multiple instances deliberately, register them explicitly instead (see [Explicit Bypass](#explicit-bypass)).
 
-### Subtype Preservation
+### Subtype Eviction
 
-Eviction is per-ancestor. Sibling subtypes only collide at their shared supertype - subtype lookups remain unambiguous:
+Sibling subtypes are different types - they don't throw, they collide only at their shared supertype, where both evict. Subtype lookups remain unambiguous:
 
 ```ts
 // Base is a widened global; each subtype re-declares (required on extend)
@@ -117,7 +117,7 @@ Context.root.get(SubB);        // b - unambiguous at SubB
 
 ### Explicit Bypass
 
-Explicit registration (`new Context(state)`, `ctx.add(state, true)`, JSX `Provider`) bypasses global eviction. Global and explicit entries coexist; explicit wins priority on lookup.
+Explicit registration (`new Context(state)`, `ctx.add(state, true)`, JSX `Provider`) bypasses collision handling entirely - no throw, no eviction. Global and explicit entries coexist; explicit wins priority on lookup.
 
 ```ts
 const a = Sub.new();          // global, in root
@@ -157,7 +157,7 @@ ctx.get(Parent).foo = undefined;
 ctx.get(Foo); // Bar instance - heals
 ```
 
-This differs from root's permanent eviction because scoped contexts model "candidates available here," whereas root models "the global instance."
+This differs from root - where a same-type duplicate throws and ancestor contests evict permanently - because scoped contexts model "candidates available here," whereas root models "the global instance."
 
 ## API Surface
 


### PR DESCRIPTION
## Problem

`static global = true` had no dedupe guard: creating a second live instance of the same global type silently evicted **both** from root ("collision is opt-out from global"). A duplicate global singleton is nearly always a bug - a double `.new()`, a leaked test instance - and mutual eviction deferred the failure to a distant `Could not find X in context` throw (or worse, code holding a direct reference kept working while consumers could no longer resolve it).

## Change

`Context.add` now throws on an implicit root add when a live implicit entry of the **exact same class** exists and the class resolves `static global` truthy:

```
Cannot register Sub-XXXX as a global - Sub-YYYY already exists in root.
Destroy the existing instance first, or provide additional ones via explicit context.
```

Scoping decisions:

- **Exact-type duplicates only.** Sibling subtypes (SubA/SubB both global) are legitimate ambiguity, not a bug - they keep the per-ancestor eviction semantics at their shared supertype.
- **Gated on `static global`.** `map()`/`has()` adoption implicitly adds members into a root-homed owner's context; non-global states on that path keep the old eviction behavior rather than throwing.
- **Resolver globals** (`State.Global` functions, e.g. router's `clientOnly`) are evaluated the same way `register()` does, so they throw too when they would have registered.
- Explicit registration (`ctx.add(state, true)`, `Provider`) bypasses collision handling as before; destroying the existing instance frees the slot for a fresh `.new()`.

The new guard immediately caught a real leak: a router test created two live `Router` globals in one test, previously masked by silent eviction.

## Included

- Tests: duplicate throws (boolean + resolver globals), first instance unaffected, re-registration after destroy; subtype-eviction tests unchanged.
- `skills/state/context.md` Global Collision section rewritten to the new contract.
- Changeset (minor, `@expressive/mvc`).

All packages green at 100% coverage.