### PR TITLE
fix(mvc): store the instance when a State is assigned from a subscriber

### DIFF
--- a/.changeset/spotty-pandas-hug.md
+++ b/.changeset/spotty-pandas-hug.md
@@ -1,0 +1,11 @@
+---
+"@expressive/mvc": patch
+---
+
+Store the underlying instance when a State is assigned from a subscriber.
+
+Reading a child State through a subscriber proxy - a render body, an effect, or any handler which closed over one - yields a tracking proxy for that child, not the child itself. Assigning it back to a managed field stored the proxy. Since the proxy is a fresh object each read, adoption treated it as an unparented State and claimed ownership of it, and clearing the field then fired the terminal event against the proxy. That event resolves the child's real observer through the prototype chain, so every listener on the live child was dropped while the child itself stayed active and unaware.
+
+The visible symptom was a computed getter that stopped recomputing. Its subscription is established once and never re-established, so it never recovered - it returned a frozen value while plain fields, whose subscriptions are rebuilt on each render, kept tracking. Under React this surfaced on the third `{instance}` placement of a child field toggled from an event handler.
+
+Managed fields now hold the instance, so identity, update de-duplication and adoption all reference the same object.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -233,6 +233,46 @@ it('will not update when assigning same child instance', () => {
   expect(cb).not.toBeCalled();
 });
 
+it('will store a child read through a subscriber as itself', async () => {
+  class Child extends State {
+    value = 1;
+
+    get double() {
+      return this.value * 2;
+    }
+  }
+
+  class Parent extends State {
+    a = new Child();
+    active?: Child = this.a;
+  }
+
+  const parent = Parent.new();
+  const child = parent.a;
+
+  let proxy!: Parent;
+
+  parent.get((self) => {
+    proxy = self;
+    return null;
+  });
+
+  expect(child.double).toBe(2);
+
+  proxy.active = undefined;
+  proxy.active = proxy.a;
+
+  expect(Object.is(parent.is.active, child)).toBe(true);
+
+  proxy.active = undefined;
+  child.value = 3;
+
+  await expect(child).toHaveUpdated();
+
+  expect(child.get(null)).toBe(false);
+  expect(child.double).toBe(6);
+});
+
 it('will destroy parent after child property cleared', () => {
   class Child extends State {}
   class Parent extends State {

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -747,7 +747,7 @@ function apply(
 
   function set(value: unknown, silent?: boolean) {
     if (!update(state, key, value, silent)) return;
-    if (adopt) adopt(value);
+    if (adopt) adopt(STORE.get(state)![key]);
   }
 
   define(state, key, {
@@ -931,6 +931,8 @@ function update<T>(
   }
 
   const store = STORE.get(state)!;
+
+  if (value instanceof State) value = value.is as T;
 
   if (key in store && value === store[key]) return false;
 

--- a/packages/react/src/element.test.tsx
+++ b/packages/react/src/element.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import { expect, it, describe, vi } from 'vitest';
 import React, { Suspense } from 'react';
 
@@ -527,6 +527,160 @@ describe('instance element', () => {
     element.unmount();
 
     expect(instance.get(null)).toBe(false);
+  });
+});
+
+describe('repeated placement of a child field', () => {
+  class Panel extends Component {
+    text = '';
+
+    get count() {
+      return this.text.trim() ? this.text.trim().split(/\s+/).length : 0;
+    }
+
+    render() {
+      const { text, count } = this;
+
+      return (
+        <i>
+          <b data-testid="len">{text.length}</b>
+          <u data-testid="count">{count}</u>
+          <textarea
+            data-testid="input"
+            value={text}
+            onChange={(e) => (this.text = e.target.value)}
+          />
+        </i>
+      );
+    }
+  }
+
+  /**
+   * Type into the panel, read what it rendered, then detach and reattach it -
+   * five times. Writes land in an event handler, where the owner's `this` is a
+   * render proxy.
+   */
+  async function cycle() {
+    const seen: string[] = [];
+
+    for (let i = 1; i <= 5; i++) {
+      const text = Array.from({ length: i }, (_, n) => `w${n}`).join(' ');
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId('input'), { target: { value: text } });
+      });
+
+      seen.push(
+        `${screen.getByTestId('len').textContent}/${
+          screen.getByTestId('count').textContent
+        }`
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('off'));
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('on'));
+      });
+    }
+
+    return seen;
+  }
+
+  const expected = ['2/1', '5/2', '8/3', '11/4', '14/5'];
+
+  it('will recompute for a plain-constructed instance', async () => {
+    class Host extends Component {
+      panel = new Panel();
+      active?: Panel = this.panel;
+
+      render() {
+        return (
+          <>
+            <button onClick={() => (this.active = this.panel)}>on</button>
+            <button onClick={() => (this.active = undefined)}>off</button>
+            <span>{this.active}</span>
+          </>
+        );
+      }
+    }
+
+    render(<>{Host.new()}</>);
+
+    expect(await cycle()).toEqual(expected);
+  });
+
+  it('will recompute for an activated instance', async () => {
+    class Host extends Component {
+      panel = Panel.new();
+      active?: Panel = this.panel;
+
+      render() {
+        return (
+          <>
+            <button onClick={() => (this.active = this.panel)}>on</button>
+            <button onClick={() => (this.active = undefined)}>off</button>
+            <span>{this.active}</span>
+          </>
+        );
+      }
+    }
+
+    render(<>{Host.new()}</>);
+
+    expect(await cycle()).toEqual(expected);
+  });
+
+  it('will recompute for an owned element', async () => {
+    class Host extends Component {
+      shown = true;
+
+      render() {
+        return (
+          <>
+            <button onClick={() => (this.shown = true)}>on</button>
+            <button onClick={() => (this.shown = false)}>off</button>
+            <span>{this.shown ? <Panel /> : null}</span>
+          </>
+        );
+      }
+    }
+
+    render(<>{Host.new()}</>);
+
+    expect(await cycle()).toEqual(expected);
+  });
+
+  it('will keep a child assigned through a render proxy', async () => {
+    class Host extends Component {
+      panel = new Panel();
+      active?: Panel = this.panel;
+
+      render() {
+        return (
+          <>
+            <button onClick={() => (this.active = this.panel)}>on</button>
+            <button onClick={() => (this.active = undefined)}>off</button>
+            <span>{this.active}</span>
+          </>
+        );
+      }
+    }
+
+    const host = Host.new();
+
+    render(<>{host}</>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('off'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('on'));
+    });
+
+    expect(Object.is(host.is.active, host.panel)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes the computed-getter freeze called out as defect 1 in #294 ("Explicitly not on this branch").

## The filed lead was wrong

The board item suspected a `STALE`/spent-proxy race in `compute()` (`state.ts:654-718`). It isn't — that class is already guarded at `observable.ts:277-281`, and instrumentation showed compute's re-arm path behaving correctly right up to the freeze.

## Actual root cause

1. `render()` runs with `this` bound to a subscriber proxy. An event handler closes over it.
2. `this.active = this.a` reads the child through `touch()`, which returns `observe(child)` — a **proxy of the Panel**, a fresh object on every read. The write stored that proxy.
3. `PARENT` is keyed by object identity and had never seen it, so adoption claimed it as unparented and installed the *owner* cleanup.
4. The next detach ran that cleanup. `event(proxy, null)` writes `[Observer] = null` as an **own** property on the throwaway proxy, but `observer(proxy)` resolves the **real Panel's** observer through the prototype chain — so `emit(o, null)` ran a terminal pass on the live Panel and `listeners.clear()` wiped every listener on it, while the Panel stayed alive and unaware.

This explains both oddities in the filing that the `compute()` theory never accounted for:

- **Why the third placement** — the wipe lands on the second detach.
- **Why only computed getters** — `compute()` connects exactly once (`if (!proxy)`) and never reconnects. Plain fields are wiped too, but re-register a fresh `watch` each render and heal on the next placement. Compute is the only victim that can't recover.

Not related to the watch-leak family (#126, discarded-attempt leaks): those are listeners that linger, this is every listener being destroyed.

## The fix

Two lines in `packages/mvc/src/state.ts` — normalize at the store boundary, and let `adopt` read back the normalized value. `is` is an own non-writable self-reference on the real instance, so this is idempotent for a State and resolves through the prototype for a proxy.

Core is the right layer despite the "don't fix React concerns in mvc" guardrail: the proxy escape, the `PARENT` mis-claim and the terminal event are all `packages/mvc`, and the headless test reproduces with no React at all.

Fixes two latent consequences for free: stored identity (`host.is.active === panel`) and update de-duplication (each proxy read was a distinct object, so re-assigning the same child dispatched a spurious update).

No new public surface.

## Tests

- `packages/mvc/src/state.test.ts` — headless identity + frozen-computed case.
- `packages/react/src/element.test.tsx` — 5-round cycle (type → read → detach → reattach) through `fireEvent`, so writes land at event-handler time:
  - **A** bare `new Panel()` — pre-fix `['2/1','5/2','8/2','11/2','14/2']`, matching the filed matrix exactly
  - **B** `Panel.new()` — identical pre-fix failure
  - **C** `<Panel />` ownership — passes pre-fix and post-fix, the control
  - plus stored identity through the React path

All four verified red by reverting `state.ts` to base and re-running.

## Verification

`bun run test` green across all four packages (mvc 634, react 264, router 235, preact 135), 100% statements/branches/functions/lines held, no threshold touched. `bun run build` clean.

**Not verified:** no browser or Pages-preview pass — vitest + happy-dom only.

## Followups filed

- `event(x, null)` on a subscriber proxy silently clears the real subject's listeners — the amplifier that turned a storage bug into permanent breakage. This PR closes the only path found into it; the class stays open.
- Vitest error serialization crashes on State subscriber proxies, masking the real assertion.
