### PR TITLE
fix(react): declare sideEffects for the chunks that patch Component

### DIFF
--- a/.changeset/lucky-donuts-attack.md
+++ b/.changeset/lucky-donuts-attack.md
@@ -1,0 +1,15 @@
+---
+"@expressive/react": patch
+---
+
+Fix `{instance}` placement being tree-shaken out of production bundles.
+
+`Component.prototype.$$typeof` - the descriptor that lets a Component instance
+render as `{instance}` - is installed by a shared chunk that the published
+`sideEffects` manifest could not name, so bundlers dropped it. Any consumer
+build that shook away `has` and `map` lost placement entirely and threw
+"Objects are not valid as a React child" at render, in production builds only.
+
+Shared chunks now emit under a `chunk-` prefix and the manifest covers them by
+pattern, so no future chunk can fall outside it. `dist/has.js` and `dist/map.js`
+stay tree-shakeable; the export map and published entry paths are unchanged.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,14 +27,10 @@
   ],
   "type": "module",
   "sideEffects": [
+    "./src/*.ts",
     "./dist/index.js",
     "./dist/adapter.js",
-    "./src/jsx-runtime.ts",
-    "./src/state.get.ts",
-    "./src/state.use.ts",
-    "./src/component.ts",
-    "./src/map.ts",
-    "./src/has.ts"
+    "./dist/chunk-*.js"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   format: ['esm'],
   outputOptions: {
-    exports: 'named'
+    exports: 'named',
+    chunkFileNames: 'chunk-[name]-[hash].js'
   }
 });


### PR DESCRIPTION
Fixes defect 3 in #294 ("Explicitly not on this branch"). The filing scoped this as a latent hazard plus a packaging smell. It is neither — it is a live break in shipped code, and the filing's recommended fix would have made things worse.

## Correction 1: this breaks `{instance}` placement today

The filing verified runtime as correct. That test must have imported `has` or `map`, which incidentally rescued the chunk.

`element-*.js` — carrying the `Component.prototype.$$typeof` patch that makes `{instance}` placement work — is reachable from `index.js` **only** through value imports in `has.js` and `map.js`. Those are unlisted in `sideEffects`, so any consumer not using collections drops the chunk and placement silently stops working.

Reproduced with packed tarballs in a real `node_modules` (aliases bypass `package.json` and hide this), tree-shaking on, under **both esbuild 0.28.1 and vite/rollup**:

```
main:  <div></div>                        <- instance vanishes
fixed: <div><span>[placed]</span></div>
```

Production builds only — the failure mode most likely to survive a green test suite.

## Correction 2: the `./src/*.ts` entries are not dead

The filing recommended dropping them as inert (`files: ["dist"]`, so `src/` is unpublished). But **rolldown reads the same `sideEffects` field when building the package itself.** Removing them and rebuilding:

- `.use =` disappears from `dist` entirely
- `dist/index.js` drops 3171 → 2648 bytes

`State.use`, `State.get` and the JSX host registration simply vanish. The naive glob fix ships a catastrophically broken package.

## Approach

**Rejected the plain `./dist/*.js` glob** — it forces `has.js`/`map.js` and their collection machinery into every bundle for ~1.9 kB gzip. Their patches target `has.List/Pool.prototype` and `map.Managed.prototype`, classes reachable only through the exports those same modules provide, so they are legitimately shakeable. Verified empirically that esbuild and rollup both retain a module's top-level side-effect statements when its export is used, even unlisted — so leaving them out is safe, not a lie.

**Rejected named entries** for element/component/context — reshuffles chunking, splits the `declare module` augmentations across `.d.ts` files not in the export map, and still leaves a hashed chunk.

**Chosen: stable chunk-name convention + pattern.** `chunkFileNames: 'chunk-[name]-[hash].js'` and a `./dist/chunk-*.js` entry. Every shared chunk, present and future, is covered by construction — no enumeration to rot. Widening the src side to a glob also fixed the build side, so `index.js` now emits an explicit `import "./chunk-element-*.js"` and element retention no longer depends on `has`/`map` at all.

## Measured

esbuild, minified, gzip -9, `react` external, real node_modules:

| case | main (broken) | this PR | plain glob (rejected) |
| --- | --- | --- | --- |
| state-only | 7739 | **7935** (+196) | 9626 (+1887) |
| typical-app | 8256 | **8453** (+197) | 10141 (+1885) |
| everything | 10548 | **10548** (+0) | 10548 |

The main column is a bundle that renders wrong, so +196 B is the price of correctness. Trade-off accepted: ~1.7 kB saved against the plain glob, in exchange for the manifest depending on the `chunk-` convention staying in `tsdown.config.ts` — one line, same package, covering all future chunks.

`ignored-bare-import` warning: gone.

These figures should be reconciled against #294's `size-limit.ts` budgets, which are measured on that branch and not present here.

## Runtime verification

`npm pack` both packages → extract into a fixture `node_modules` → esbuild bundle with tree-shaking → execute under `renderToStaticMarkup`:

- `{instance}` placement + `<Component />` — **PASS** (renders empty at main)
- `has()` collection as a JSX child — **PASS** (guards the deliberate shaking)
- `State.use()` in a function component — **PASS** (guards the `./src/*.ts` entries)

Placement case repeated through a vite/rollup library build: PASS after, broken before.

## Verification

`bun run test` green across all four packages, 100% coverage held. `bun run build` clean. `npm publish --dry-run`: 18 files, export map paths unchanged — only internal chunk filenames gained the prefix, and those are not reachable through `exports`.

**Not verified:** webpack (semantics are close but not identical); client-side hydration (server render only); a bundled-and-run `@expressive/router` consumer.

## No CI guard here

A dist-reading vitest test cannot work — `pr.yml` runs `bun run test` **before** `bun run build`, so `dist` does not exist yet. Filed as a followup instead, with the packaged-consumer smoke as the guard that would actually have caught this.

## Followups filed

- `@expressive/react` dist emits an extensionless `./adapter` import, unloadable by Node ESM (pre-existing, untouched here).
- No in-repo consumer exercises the published dist — examples and website both alias to `src`, which is why this rotted unnoticed.
- `@expressive/mvc`'s `sideEffects: false` rests on an unwritten, untested invariant.
