### PR TITLE
fix(mvc): scope activation effects to the state being activated

### DIFF
--- a/.changeset/hungry-hoops-tickle.md
+++ b/.changeset/hungry-hoops-tickle.md
@@ -1,0 +1,14 @@
+---
+"@expressive/mvc": patch
+---
+
+Scope effects created during activation to the state that creates them.
+
+A State activated inside another state's effect registered its own activation-time
+effects into the enclosing effect scope. The enclosing effect's next run tore them
+down permanently, leaving the inner state inert - it would render once and then stop
+responding to updates. Activation now captures its own scope, so those effects belong
+to the state being activated and survive unrelated reruns.
+
+As part of the same scoping, an effect a state registers on a *different* state during
+activation is now released when that state is destroyed, rather than outliving it.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -2643,6 +2643,70 @@ describe('activation', () => {
     expect(() => event(test)).not.toThrow();
     expect(test.value).toBe(1);
   });
+
+  it('will not release effects when an enclosing effect reruns', async () => {
+    const didUpdate = vi.fn();
+
+    class Child extends State {
+      value = 0;
+
+      new() {
+        this.get((self) => void didUpdate(self.value));
+      }
+    }
+
+    class Parent extends State {
+      tick = 0;
+    }
+
+    const parent = Parent.new();
+
+    let child!: Child;
+
+    parent.get((self) => {
+      void self.tick;
+      if (!child) child = Child.new();
+    });
+
+    child.value = 1;
+    await expect(child).toHaveUpdated();
+    expect(didUpdate).toBeCalledWith(1);
+
+    parent.tick = 1;
+    await expect(parent).toHaveUpdated();
+
+    child.value = 2;
+    await expect(child).toHaveUpdated();
+    expect(didUpdate).toBeCalledWith(2);
+  });
+
+  it('will release effects on a foreign state when destroyed', async () => {
+    const didUpdate = vi.fn();
+
+    class Foreign extends State {
+      value = 0;
+    }
+
+    const foreign = Foreign.new();
+
+    class Test extends State {
+      new() {
+        foreign.get((self) => void didUpdate(self.value));
+      }
+    }
+
+    const test = Test.new();
+
+    foreign.value = 1;
+    await expect(foreign).toHaveUpdated();
+    expect(didUpdate).toBeCalledTimes(2);
+
+    test.set(null);
+
+    foreign.value = 2;
+    await expect(foreign).toHaveUpdated();
+    expect(didUpdate).toBeCalledTimes(2);
+  });
 });
 
 describe('is method (static)', () => {

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -1,5 +1,6 @@
 import { Context } from './context';
 import {
+  capture,
   event,
   listener,
   Observer,
@@ -541,19 +542,23 @@ function init(state: State, ...args: State.Args) {
 
     const queue = [...before, observe, ...args, ...after, register];
 
-    for (let i = 0; i < queue.length; i++) {
-      const arg = queue[i];
-      const out = typeof arg == 'function' ? arg.call(state, state) : arg;
+    capture((release) => {
+      listener(state, () => release(null), null);
 
-      if (out instanceof Promise)
-        out.catch((err) => {
-          console.error(`Async error in constructor for ${state}:`);
-          console.error(err);
-        });
-      else if (Array.isArray(out)) queue.splice(i + 1, 0, ...out);
-      else if (typeof out == 'function') listener(state, out, null);
-      else if (typeof out == 'object') assign(state, out, true);
-    }
+      for (let i = 0; i < queue.length; i++) {
+        const arg = queue[i];
+        const out = typeof arg == 'function' ? arg.call(state, state) : arg;
+
+        if (out instanceof Promise)
+          out.catch((err) => {
+            console.error(`Async error in constructor for ${state}:`);
+            console.error(err);
+          });
+        else if (Array.isArray(out)) queue.splice(i + 1, 0, ...out);
+        else if (typeof out == 'function') listener(state, out, null);
+        else if (typeof out == 'object') assign(state, out, true);
+      }
+    });
 
     return null;
   });


### PR DESCRIPTION
## The bug

A State activated synchronously inside another state's effect registers its own
activation-time effects into the **enclosing** effect scope. `watch`'s registered
cleanup ignores its `update` argument, so the enclosing effect's next pass tears
those effects down permanently. Symptom: the inner state initializes, responds once,
then goes inert.

Reachable in plain `packages/mvc` — no adapter, no custom host. Constructing a State
inside another State's effect is ordinary usage:

```ts
class Child extends State {
  value = 0;
  new(){ this.get(self => didUpdate(self.value)) }
}

parent.get(self => {
  void self.tick;
  if (!child) child = Child.new();
});

child.value = 1;   // observed
parent.tick = 1;   // enclosing effect reruns
child.value = 2;   // never observed — Child's own effect is gone
```

`@expressive/react` does not hit this today because it mounts children inside React's
render rather than inside a parent's `watch`, but nothing in core prevents user code
from reaching it.

## The fix

Wrap the activation queue in `capture`, so effects created while a state activates
belong to that state and are released on its own teardown:

```ts
capture((release) => {
  listener(state, () => release(null), null);
  // ...activation queue
});
```

## Alternative considered and rejected

The symmetric-looking fix is to make `watch`'s `EffectContext` cleanup honour its
`update` argument the way `observe` already does at
[observable.ts:93](../blob/main/packages/mvc/src/observable.ts#L93):

```ts
EffectContext.add((update) => { if (update !== true) cleanup() });
```

That fixes this case but breaks the normal one — an effect *recreated* on each pass of
the enclosing effect is then never torn down, so it double-fires. Probe output went
from `[0,1,1,2]` to `[0,1,1,2,2]`. The scope boundary has to be drawn at activation,
not at teardown.

## Secondary behavior change

Scoping activation this way also means an effect a state registers on a **different**
state during activation is released when that state is destroyed, instead of outliving
it. Previously `new(){ other.get(fn) }` kept running after `this.set(null)`. This is
covered by the second test and called out in the changeset.

## Tests

Two regression tests in `packages/mvc/src/state.test.ts` under `describe('activation')`.
Both fail on `main`:

```
FAIL  activation > will not release effects when an enclosing effect reruns
      expected "vi.fn()" to be called with arguments: [ 2 ]
FAIL  activation > will release effects on a foreign state when destroyed
      expected "vi.fn()" to be called 2 times, but got 3 times
```

`bun run test` passes clean across all four packages — typecheck, 1265 tests, and the
100% coverage gates.

## Provenance

Found while spiking a three.js adapter; re-verified against `main` in a clean checkout.
The wider batch of findings from that spike is filed on **MVC Followups** (12 items),
including two — the `def` token registry leak and the `Component` construction dedupe —
that are real but carry design decisions, so they are deliberately not in this PR.