### PR TITLE
fix(mvc): refuse terminal events on objects that do not own their observer

### DIFF
--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -340,6 +340,23 @@ describe('effect', () => {
       expect(effect).not.toBeCalled();
     });
 
+    it('will terminate subject via set(null) within an effect', async () => {
+      class Test extends State {
+        done = false;
+      }
+
+      const test = Test.new();
+
+      test.get(($) => {
+        if ($.done) $.set(null);
+      });
+
+      test.done = true;
+      await expect(test).toHaveUpdated();
+
+      expect(test.get(null)).toBe(true);
+    });
+
     it('will not terminate subject via derived object', async () => {
       class Test extends State {
         value = 1;

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -340,6 +340,26 @@ describe('effect', () => {
       expect(effect).not.toBeCalled();
     });
 
+    it('will not terminate subject via derived object', async () => {
+      class Test extends State {
+        value = 1;
+      }
+
+      const test = Test.new();
+      const effect = vi.fn(($: Test) => void $.value);
+
+      watch(test, effect);
+
+      event(Object.create(test), null);
+
+      expect(observer(test)!.listeners.size).toBeGreaterThan(0);
+
+      test.value = 2;
+
+      await expect(test).toHaveUpdated();
+      expect(effect).toBeCalledTimes(2);
+    });
+
     it('will throw for get(effect) on destroyed instance', () => {
       class Test extends State {
         foo = 1;

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -169,6 +169,8 @@ function event(state: object, key?: Observer.Event | null, silent?: boolean) {
   if (!o) return;
 
   if (key === null) {
+    if (!Object.getOwnPropertyDescriptor(state, Observer)) return;
+
     (state as Observable)[Observer] = null;
     return emit(o, key);
   }


### PR DESCRIPTION
Hardens the amplifier behind #295: `event(x, null)` on a subscriber proxy silently cleared the real subject's listeners. Filed as a followup on the board when #295 closed the only known path in; this closes the class.

## The hole

A subscriber proxy is `Object.create(subject)`, so on a terminal call `observer(state)` resolves the `Observer` slot through the prototype chain and hands back the real subject's observer. `emit(o, null)` then runs `listeners.clear()` against an object that never asked to die, while the null write lands as an own property on the throwaway proxy — the subject stays live, silently deaf.

## The guard

One line in `event()`: a terminal event is honored only if the target owns its `Observer` slot (`Object.getOwnPropertyDescriptor(state, Observer)`). An inherited slot means the caller holds a derivation, not the subject — refuse, touch nothing.

**Refuse silently rather than throw**: terminal events fire from teardown (`state.ts` owner cleanup, `context.ts` owned-state teardown), where an unexpected throw would break unmounts in consuming apps. Legitimate destruction is unaffected — `State.set(null)` normalizes with `this.is` before dispatching, so every valid terminal call already arrives holding the slot owner. A proxy reaching `event(x, null)` can only be a bypassed-normalization bug, and now it's inert.

## Changeset: patch

~~`event` is internal — not re-exported from the package entry or `Runtime`.~~ **Corrected in review:** `event` is public — exported by name from the published `@expressive/mvc/observable` subpath, and taught in `utilities.mdx`'s custom-observable walkthrough. This PR changes that function's observable behavior (`event(derived, null)` wiped the base object's listeners; now inert), so per convention it carries a patch changeset. Internal call sites are unaffected either way — `State.set(null)` normalizes through `this.is` and both teardown sites pass real stored instances.

## Tests

- `packages/mvc/src/observable.test.ts` — `will not terminate subject via derived object`: listeners survive a terminal event through `Object.create(subject)`, and the effect still re-fires on the next update. Verified red against base (listeners wiped, effect frozen) and green with the guard.
- `will terminate subject via set(null) within an effect`: the legitimate self-termination path — an effect deciding its own subject is done — still terminates through the guard, because `set(null)` normalizes with `this.is` before dispatch. Codifies that the guard is unreachable from public surface.
- Full suite green across all four packages, 100% statements/branches/functions/lines held — both arms of the guard are exercised.
- vitest + happy-dom only; no browser pass, none warranted for a core dispatch guard.

