### PR TITLE
fix(mvc): run effect cleanup when an effect terminates its own subject

### DIFF
--- a/.changeset/brave-lamps-wave.md
+++ b/.changeset/brave-lamps-wave.md
@@ -1,0 +1,9 @@
+---
+"@expressive/mvc": patch
+---
+
+Run effect cleanup when an effect terminates its own subject.
+
+An effect which called `set(null)` on its own subject synchronously - during its first run or any re-run - left the cleanup it returned dangling. The terminal event completed inside `set(null)`, before the effect had returned, so its cleanup registered after listeners were already cleared and never fired. Resources held there, such as timers or sockets, would leak.
+
+Cleanup returned by a run which terminated its subject now fires immediately with `null`, matching the normal destruction path.

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -357,6 +357,60 @@ describe('effect', () => {
       expect(test.get(null)).toBe(true);
     });
 
+    it('will run cleanup when effect terminates own subject', async () => {
+      class Test extends State {
+        done = false;
+      }
+
+      const test = Test.new();
+      const didCleanup = vi.fn();
+
+      test.get(($) => {
+        if ($.done) $.set(null);
+        return didCleanup;
+      });
+
+      test.done = true;
+      await expect(test).toHaveUpdated();
+
+      expect(test.get(null)).toBe(true);
+      expect(didCleanup).toBeCalledWith(null);
+    });
+
+    it('will run cleanup when first run terminates subject', () => {
+      class Test extends State {
+        done = true;
+      }
+
+      const test = Test.new();
+      const didCleanup = vi.fn();
+
+      test.get(($) => {
+        if ($.done) $.set(null);
+        return didCleanup;
+      });
+
+      expect(test.get(null)).toBe(true);
+      expect(didCleanup).toBeCalledWith(null);
+    });
+
+    it('will run cleanup when uncaptured effect terminates subject', () => {
+      class Test extends State {
+        value = 1;
+      }
+
+      const test = Test.new();
+      const didCleanup = vi.fn();
+
+      watch(test, ($) => {
+        $.set(null);
+        return didCleanup;
+      }, false);
+
+      expect(test.get(null)).toBe(true);
+      expect(didCleanup).toBeCalledWith(null);
+    });
+
     it('will not terminate subject via derived object', async () => {
       class Test extends State {
         value = 1;

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -276,6 +276,12 @@ function watch<T extends object>(
       const proxy = observe(target, onUpdate, argument === true);
       const output = callback.call(proxy, proxy, events);
 
+      if (observer(target) === null) {
+        if (typeof output == 'function') output(null);
+        if (release) release(null);
+        return;
+      }
+
       if (previous && argument === false) {
         const { watching } = (proxy as Observed)[Observing]!;
         if (!watching.size)


### PR DESCRIPTION
Fixes the dangling-cleanup defect found while verifying #300 (board item: "Effect cleanup returned after synchronous self-termination never runs").

## The bug

An effect that calls `set(null)` on its own subject synchronously — during its first run or any re-run — leaves the cleanup it returns dangling forever. The terminal emit completes inside `set(null)`, before the effect has returned, so `unset` is still empty when the watch-level terminal handler checks it; the cleanup then registers into a watch whose observer is dead and whose listeners are cleared. A timer or socket held by that cleanup leaks. The first-run shape has a second wrinkle: `listener()` fires the ready callback before inserting the terminal handler into the listener map, so the handler is not even registered yet.

## The fix

Detect termination in `run()` itself, immediately after the callback returns: if the subject died during the run, fire the just-produced cleanup with `null` and release captured child effects, instead of storing dead state. This matches the normal terminal path exactly — cleanup receives `null`, nested effects release through `release(null)`. The suspense branch is unaffected (a thrown Promise means no cleanup was produced, and the post-resume `invoke` already bails on a terminated observer).

## Deliberately not included

An earlier draft also cleared `unset` after the watch-level terminal handler fires it, so the handle returned by `get(effect)` would be inert after termination. That broke all of `packages/router`'s nav tests with `TypeError: unset is not a function`: stale child-state listeners created through nested proxies outlive the subject's terminal event and still call `unset(true)` — `unset` surviving termination is load-bearing zombie-tolerance. The wart (post-terminal spurious cleanup invocations) is real but needs child-listener release on terminal to fix properly; filed on the board instead.

## Tests

Three in `packages/mvc/src/observable.test.ts`, all verified red against base:

- `will run cleanup when effect terminates own subject` — re-run shape, cleanup fires with `null`
- `will run cleanup when first run terminates subject` — synchronous first-run shape
- `will run cleanup when uncaptured effect terminates subject` — `watch(target, cb, false)`, covering the no-capture arm

## Verification

Full suite green across all four packages, 100% statements/branches/functions/lines held, build clean. vitest + happy-dom only; no browser pass.