### PR TITLE
chore: changeset for the #300 terminal-event guard

### DIFF
--- a/.changeset/terminal-event-ownership.md
+++ b/.changeset/terminal-event-ownership.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+`event(state, null)` (exported via `@expressive/mvc/observable`) now honors a terminal event only when the target owns its observer. Previously a derived object - `Object.create(subject)` or a subscriber proxy - resolved the subject's observer through the prototype chain and cleared the real subject's listeners, leaving it silently deaf while the null write landed on the throwaway object. Such calls are now inert; legitimate destruction (`State.set(null)`, owner teardown) is unaffected, as every valid terminal call already arrives holding the slot owner.


### PR DESCRIPTION
The changeset for #300 was pushed to its branch minutes after the squash-merge took the earlier head, so it never reached `main`. Cherry-picked here unchanged.

Context: review of #300 found `event` is public after all — exported by name from the published `@expressive/mvc/observable` subpath and taught in `utilities.mdx` — so the guard's behavior change (`event(derived, null)` wiped the base object's listeners; now inert) warrants a patch release note. #300's description carries the corrected rationale.

Must land before the Version Packages PR so the patch note rides the same release.