### PR TITLE
fix(react): accept assignment to subcomponent fields

### DIFF
--- a/.changeset/plain-pumas-listen.md
+++ b/.changeset/plain-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+'@expressive/react': patch
+---
+
+Accept assignment to subcomponent fields, so a Component override such as `Sidebar = Sidebar` no longer throws `TypeError: Cannot set property ... which has only a getter` when built with `useDefineForClassFields: false` (the default for any `target` below ES2022).

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -1222,6 +1222,41 @@ describe('subcomponents', () => {
     }
   });
 
+  it('will work with function assigned after activation', async () => {
+    class Dashboard extends Component {
+      content = 'value';
+
+      Sidebar(): React.ReactNode {
+        return null;
+      }
+
+      render() {
+        return <this.Sidebar />;
+      }
+    }
+
+    let instance!: Dashboard;
+
+    render(
+      <Dashboard
+        is={(x) => {
+          instance = x;
+          x.Sidebar = function (this: Dashboard) {
+            return <span>Sidebar {this.content}</span>;
+          };
+        }}
+      />
+    );
+
+    expect(screen).toHaveText('Sidebar value');
+
+    await act(async () => {
+      instance.content = 'updated';
+    });
+
+    expect(screen).toHaveText('Sidebar updated');
+  });
+
   it('will allow override via setter', async () => {
     class Dashboard extends Component {
       value = 'Original';

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -1175,6 +1175,53 @@ describe('subcomponents', () => {
     expect(screen).toHaveText('Sidebar updated');
   });
 
+  it('will work with function assigned in constructor', async () => {
+    class Dashboard extends Component {
+      Sidebar(): React.ReactNode {
+        return null;
+      }
+
+      render() {
+        return <this.Sidebar />;
+      }
+    }
+
+    function Sidebar(this: Defined) {
+      return <span>Sidebar {this.content}</span>;
+    }
+
+    class Defined extends Dashboard {
+      content = 'value';
+      Sidebar = Sidebar;
+    }
+
+    class Assigned extends Dashboard {
+      content = 'value';
+
+      constructor(props: {}) {
+        super(props);
+        this.Sidebar = Sidebar as any;
+      }
+    }
+
+    for (const Type of [Defined, Assigned]) {
+      let instance!: Defined;
+
+      const { unmount } = render(
+        <Type is={(x) => (instance = x as Defined)} />
+      );
+
+      expect(screen).toHaveText('Sidebar value');
+
+      await act(async () => {
+        instance.content = 'updated';
+      });
+
+      expect(screen).toHaveText('Sidebar updated');
+      unmount();
+    }
+  });
+
   it('will allow override via setter', async () => {
     class Dashboard extends Component {
       value = 'Original';

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -189,6 +189,14 @@ function subcomponents(target: object, configurable?: boolean) {
         });
 
         return Component;
+      },
+      set(this: Component, value: unknown) {
+        Object.defineProperty(this, key, {
+          value,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        });
       }
     });
   }

--- a/packages/react/src/component.ts
+++ b/packages/react/src/component.ts
@@ -197,6 +197,8 @@ function subcomponents(target: object, configurable?: boolean) {
           enumerable: true,
           configurable: true
         });
+
+        subcomponents(this, true);
       }
     });
   }


### PR DESCRIPTION
Followups audit item **H2**.

## Defect

`subcomponents()` (`packages/react/src/component.ts`) rewrites each capitalized method into a getter-only prototype accessor. A consumer overriding one with a field —

```ts
class MyDashboard extends Dashboard {
  Sidebar = Sidebar;
}
```

— is fine only under **define** semantics. With `useDefineForClassFields: false` (the default for any tsconfig `target` below ES2022, e.g. `es2020`) the field compiles to a plain assignment in the constructor, which hits the getter-only accessor and throws at construction:

```
TypeError: Cannot set property Sidebar of #<Component> which has only a getter
```

The message names neither the cause nor the fix. An assignment-tolerant setter does exist on the *instance-level* define inside the getter, but it is only reachable after a first `get`, so construction-time assignment still fails. Every tsconfig in this repo sets `useDefineForClassFields: true`, which is why it never bites in-repo.

## Fix

Give the outer prototype accessor a `set` that performs the own-property define define-semantics would have produced (`value`, `writable`, `enumerable`, `configurable` all matching a class field). Assignment and define now converge on the same instance shape, and the existing `before` hook promotes it to a subcomponent either way.

## Test

`component.test.tsx` — "will work with function assigned in constructor". The suite itself compiles with define semantics, so the downgraded emit is simulated: `tsc --target es2020` on a field override emits exactly `super(...arguments); this.Sidebar = Sidebar;`, and the test declares that constructor body verbatim. It then renders both shapes — a declared field (define) and the constructor assignment (assignment) — through the same loop, asserting identical initial render and identical reactive update. Fails on `main` with the `TypeError` above.

## Preact

No mirror needed: `@expressive/preact` consumes `@expressive/react/adapter`, so `component.ts` is shared source. Preact's suite passes unchanged.

## Stance

`useDefineForClassFields: false` is **supported** — the fix is 8 lines and the failure mode is a cryptic construction-time throw in ordinary consumer code.

Suggested (kept out of this PR): no docs line is required to prevent confusion now that assignment works. If a note is wanted later, the right home is a sentence in `skills/react/component.md` on subcomponent overrides working under either class-field mode, not a tsconfig requirement — this PR removes the reason to state one.

## Verification

`bun run test` green across all four packages, 100% on all coverage metrics. Runtime exercised via the real React render path (happy-dom + `@testing-library/react`), not just type-check.


## Late assignment (added in review)

The prototype setter originally defined a bare own property. That covers the
constructor case, but an assignment *after* activation lands past the `before`
hook and is never promoted - the function then renders as a raw React component
with no `useWatch` binding and no `this`:

```
TypeError: Cannot read properties of undefined (reading 'content')
```

A body that does not touch `this` is worse - it renders, and is silently
non-reactive.

That made the bare-value setter a **regression**, not merely an incomplete fix.
On `main` the assignment is silently dropped and the prototype subcomponent keeps
working; with the bare-value setter the override took effect as an unbound
component and broke a subcomponent that had rendered fine before. Verified by
running the new test against `main`'s `component.ts`: it fails with the override
ignored (`Expected to find text "Sidebar value" but found none`) rather than with
a `TypeError`.

The setter now routes through the same `subcomponents(this, true)` sweep the
`before` hook uses. It is idempotent (an already-promoted key has no `value` on
its descriptor, so the sweep skips it) and `this.is` is still read lazily inside
the getter, so constructor-time assignment stays safe. Define, constructor
assignment and late assignment now converge on one instance shape.

New test: "will work with function assigned after activation" - assigns via the
`is` callback, asserts bound `this` on first render and reactivity on update.
Fails with the promotion removed (the `TypeError` above).

