### PR TITLE
fix(mvc): clean up two cryptic error paths (prototype-property activation crash, destroyed-state message)

### DIFF
--- a/.changeset/error-path-clarity.md
+++ b/.changeset/error-path-clarity.md
@@ -1,0 +1,17 @@
+---
+"@expressive/mvc": patch
+---
+
+Fix two error paths that reported internals instead of the mistake.
+
+An enumerable property declared on a State subclass's prototype crashed
+activation with `undefined is not an object (evaluating 'property.value')`.
+`for-in` enumerates such a key but `getOwnPropertyDescriptor` returns nothing for
+it, and the `def` and `observe` sweeps assumed a descriptor. Keys with no own
+descriptor are now skipped - prototype members are unmanaged by design, the same
+as methods.
+
+Using a destroyed state threw `Object is not observable (terminated).`, naming an
+internal slot rather than the error. It now names the state and what cannot be
+done with it: `Foo-a1b2c3 was destroyed - a destroyed state cannot be rendered,
+watched or updated.`

--- a/.changeset/error-path-clarity.md
+++ b/.changeset/error-path-clarity.md
@@ -13,5 +13,5 @@ as methods.
 
 Using a destroyed state threw `Object is not observable (terminated).`, naming an
 internal slot rather than the error. It now names the state and what cannot be
-done with it: `Foo-a1b2c3 was destroyed - a destroyed state cannot be rendered,
-watched or updated.`
+done with it: `Foo-a1b2c3 was destroyed - cannot be rendered, watched or
+updated.`

--- a/packages/mvc/src/field/def.test.ts
+++ b/packages/mvc/src/field/def.test.ts
@@ -17,6 +17,24 @@ describe('instruction', () => {
     expect(didApply).toBeCalledWith('property');
   });
 
+  it('will skip enumerable properties inherited from prototype', () => {
+    class Test extends State {
+      property = def(() => ({ value: 'hello' }));
+    }
+
+    Object.defineProperty(Test.prototype, 'legacy', {
+      value: 'world',
+      enumerable: true,
+      writable: true,
+      configurable: true
+    });
+
+    const test = Test.new();
+
+    expect(test.property).toBe('hello');
+    expect((test as any).legacy).toBe('world');
+  });
+
   describe('symbol', () => {
     it('will use unique symbol as placeholder', async () => {
       class Test extends State {

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -30,10 +30,7 @@ State.on((self) => {
   const store = STORE.get(self)!;
 
   for (const key in self) {
-    const property = Object.getOwnPropertyDescriptor(self, key);
-
-    if (!property) continue;
-
+    const property: PropertyDescriptor = Object.getOwnPropertyDescriptor(self, key) || {};
     const instruction = APPLY.get(property.value);
 
     if (!instruction) continue;

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -30,7 +30,10 @@ State.on((self) => {
   const store = STORE.get(self)!;
 
   for (const key in self) {
-    const property = Object.getOwnPropertyDescriptor(self, key)!;
+    const property = Object.getOwnPropertyDescriptor(self, key);
+
+    if (!property) continue;
+
     const instruction = APPLY.get(property.value);
 
     if (!instruction) continue;

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -442,7 +442,7 @@ describe('effect', () => {
       test.set(null);
 
       expect(() => test.get(effect)).toThrow(
-        /Test-[\w-]+ was destroyed - a destroyed state cannot be rendered, watched or updated\./
+        /Test-[\w-]+ was destroyed - cannot be rendered, watched or updated\./
       );
       expect(effect).not.toBeCalled();
     });
@@ -676,7 +676,7 @@ describe('observable', () => {
       event(test, null);
 
       expect(() => listener(test, () => {})).toThrow(
-        '[object Object] was destroyed - a destroyed state cannot be rendered, watched or updated.'
+        '[object Object] was destroyed - cannot be rendered, watched or updated.'
       );
     });
 
@@ -690,7 +690,7 @@ describe('observable', () => {
       test.set(null);
 
       expect(() => listener(test, () => {})).toThrow(
-        `${test} was destroyed - a destroyed state cannot be rendered, watched or updated.`
+        `${test} was destroyed - cannot be rendered, watched or updated.`
       );
     });
   });

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -336,7 +336,7 @@ describe('effect', () => {
       event(test);
       event(test, null);
 
-      expect(() => watch(test, effect)).toThrow('terminated');
+      expect(() => watch(test, effect)).toThrow('was destroyed');
       expect(effect).not.toBeCalled();
     });
 
@@ -441,7 +441,9 @@ describe('effect', () => {
 
       test.set(null);
 
-      expect(() => test.get(effect)).toThrow('terminated');
+      expect(() => test.get(effect)).toThrow(
+        /Test-[\w-]+ was destroyed - a destroyed state cannot be rendered, watched or updated\./
+      );
       expect(effect).not.toBeCalled();
     });
 
@@ -673,7 +675,23 @@ describe('observable', () => {
       listener(test, () => {});
       event(test, null);
 
-      expect(() => listener(test, () => {})).toThrow(/terminated/);
+      expect(() => listener(test, () => {})).toThrow(
+        '[object Object] was destroyed - a destroyed state cannot be rendered, watched or updated.'
+      );
+    });
+
+    it('will name the state which was destroyed', () => {
+      class Test extends State {
+        foo = 1;
+      }
+
+      const test = Test.new();
+
+      test.set(null);
+
+      expect(() => listener(test, () => {})).toThrow(
+        `${test} was destroyed - a destroyed state cannot be rendered, watched or updated.`
+      );
     });
   });
 });

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -66,7 +66,7 @@ function observer(state: object, create?: boolean) {
   if (!o && create) {
     if (o === null)
       throw new Error(
-        `${state} was destroyed - a destroyed state cannot be rendered, watched or updated.`
+        `${state} was destroyed - cannot be rendered, watched or updated.`
       );
 
     const value: Observer = {

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -65,7 +65,9 @@ function observer(state: object, create?: boolean) {
 
   if (!o && create) {
     if (o === null)
-      throw new Error('Object is not observable (terminated).');
+      throw new Error(
+        `${state} was destroyed - a destroyed state cannot be rendered, watched or updated.`
+      );
 
     const value: Observer = {
       listeners: new Map(),

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -2146,7 +2146,7 @@ describe('set method', () => {
 
       test.set(null);
 
-      expect(() => test.set({ foo: 1 })).toThrow(/terminated/);
+      expect(() => test.set({ foo: 1 })).toThrow(/was destroyed/);
     });
 
     it('will still read values after destroyed', () => {
@@ -2988,6 +2988,40 @@ describe('non-configurable members (bootstrap)', () => {
 
     expect(typeof desc.get).toBe('function');
     expect(desc.value).toBeUndefined();
+  });
+});
+
+describe('enumerable prototype members', () => {
+  class Test extends State {
+    foo = 1;
+  }
+
+  Object.defineProperty(Test.prototype, 'legacy', {
+    value: 'world',
+    enumerable: true,
+    writable: true,
+    configurable: true
+  });
+
+  it('will activate without managing the property', async () => {
+    const test = Test.new();
+
+    expect((test as any).legacy).toBe('world');
+    expect(test.get()).toEqual({ foo: 1 });
+
+    (test as any).legacy = 'moon';
+
+    await expect(test).not.toHaveUpdated();
+    expect((test as any).legacy).toBe('moon');
+  });
+
+  it('will assign to the property without dispatch', async () => {
+    const test = Test.new();
+
+    test.set({ legacy: 'moon' } as any);
+
+    await expect(test).not.toHaveUpdated();
+    expect((test as any).legacy).toBe('moon');
   });
 });
 

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -516,9 +516,7 @@ function init(state: State, ...args: State.Args) {
 
   function observe() {
     for (const key in state) {
-      const desc = Object.getOwnPropertyDescriptor(state, key);
-
-      if (!desc) continue;
+      const desc: PropertyDescriptor = Object.getOwnPropertyDescriptor(state, key) || {};
 
       if ('value' in desc && desc.configurable) apply(state, key, desc, true);
     }
@@ -906,8 +904,8 @@ function assign(state: State, data: State.Assign<State>, silent?: boolean) {
     if (bind) bind.call(state, data[key]);
     else if (getters?.has(key)) continue;
     else if (key in state && key !== 'is') {
-      const desc = Object.getOwnPropertyDescriptor(state, key);
-      const set = desc && (desc.set as (value: any, silent?: boolean) => void);
+      const desc: PropertyDescriptor = Object.getOwnPropertyDescriptor(state, key) || {};
+      const set = desc.set as (value: any, silent?: boolean) => void;
 
       if (set) {
         set.call(state, data[key], silent);

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -516,7 +516,10 @@ function init(state: State, ...args: State.Args) {
 
   function observe() {
     for (const key in state) {
-      const desc = Object.getOwnPropertyDescriptor(state, key)!;
+      const desc = Object.getOwnPropertyDescriptor(state, key);
+
+      if (!desc) continue;
+
       if ('value' in desc && desc.configurable) apply(state, key, desc, true);
     }
   }
@@ -903,7 +906,7 @@ function assign(state: State, data: State.Assign<State>, silent?: boolean) {
     if (bind) bind.call(state, data[key]);
     else if (getters?.has(key)) continue;
     else if (key in state && key !== 'is') {
-      const desc = Object.getOwnPropertyDescriptor(state, key)!;
+      const desc = Object.getOwnPropertyDescriptor(state, key);
       const set = desc && (desc.set as (value: any, silent?: boolean) => void);
 
       if (set) {


### PR DESCRIPTION
Two error-path defects from the 08-03 followups audit (H1 first half, and the destroyed-instance message in T1). Both were re-probed against `main` @ `88606452` before the fix and after.

## 1 — Enumerable prototype property crashed activation

```ts
class Foo extends State { bar = 1 }
Object.defineProperty(Foo.prototype, 'proto', { value: 42, enumerable: true });

Foo.new(); // TypeError: undefined is not an object (evaluating 'property.value')
```

`for-in` enumerates inherited enumerable keys, but `Object.getOwnPropertyDescriptor(self, key)` returns `undefined` for them. Three sweeps asserted a descriptor was always there:

- `field/def.ts:33` — crashed first (`property.value`).
- `state.ts:519` — crashed next once `def` was fixed (`'value' in desc`).
- `state.ts:906` (`assign`) — the `!` was a lie but the following `&&` already guarded it.

All three now default a missing descriptor to `{}` (`... || {}`) rather than taking an early-exit guard. This is a very low-probability case and does not deserve its own control flow: an empty descriptor already falls through every condition each sweep applies — `APPLY.get(undefined)` misses, `'value' in desc` is false, `desc.set` is undefined — so the outcome is identical and `assign` sheds its `desc &&` for free.

### The semantic call: silent skip, not a diagnostic

Skipped silently. Reasons:

- **The same sweep already skips silently.** `observe()`'s condition is `'value' in desc && desc.configurable` — an own accessor, or a sealed own property, is already declined without a word. `assign` likewise skips reactive getters with a bare `continue`. A key that is not an own property is the same category of "not something this sweep manages", and it would be inconsistent for the *weaker* case to be the loud one.
- **Prototype members are unmanaged by design, not by accident.** Every method on a State lives on the prototype and is deliberately outside the field sweep; the only thing unusual here is the `enumerable` flag. A value on the prototype is out of scope, not misuse.
- **A diagnostic would fire on working code.** `Object.assign(Class.prototype, mixin)` produces enumerable prototype properties, and decorator and older transpiler output can too. Those instances work fine — the property reads and writes as a plain property, it simply is not reactive. Warning or throwing would break or spam patterns that have no defect in them.
- Throwing in particular would make an inherited enumerable property a hard error at activation, a behavior change well beyond fixing a crash.

Where the property genuinely was *meant* to be a managed field, the observable symptom is now that it is not reactive — the same symptom as any other unmanaged declaration. New tests pin that the value stays readable and writable and that writing it dispatches nothing.

## 2 — Destroyed state reported an internal slot

`observable.ts:68` threw `Object is not observable (terminated).` for any use of a destroyed subject — including rendering `{instance}` in React, and a React-owned instance touched after teardown. Nothing in it points at the destroyed state.

Now: `Widget-NETKO4 was destroyed - cannot be rendered, watched or updated.`

`String(state)` resolves to the instance id for a State and stays safe post-teardown; a plain custom observable degrades to `[object Object]`, which is pinned by a test. Message text only — no change to dispatch, teardown, or the terminal pass, which is left to the in-flight terminal-hygiene work.

## Probe

Before (`main` @ `88606452`):

```
PROBE1  THREW: TypeError: undefined is not an object (evaluating 'property.value')
PROBE1b THREW: TypeError: undefined is not an object (evaluating 'property.value')
PROBE2-render >>> Object is not observable (terminated).
```

After:

```
PROBE1  ok: 1 42
PROBE1b ok: 7
PROBE2-render >>> Widget-NETKO4 was destroyed - cannot be rendered, watched or updated.
```

## Tests

Adjacent to source, each verified to fail with its fix reverted (restoring the `!` assertions fails 4 tests across the two files):

- `field/def.test.ts` — activation with an enumerable prototype property (fails `Cannot read properties of undefined (reading 'value')` without the `def.ts` change).
- `state.test.ts` — `describe('enumerable prototype members')`: activation leaves the property unmanaged but readable/writable with no dispatch; `set()` assigns without dispatch.
- `observable.test.ts` — new message asserted for a plain object and for a named State; the three existing `/terminated/` matchers (plus one in `state.test.ts`) retargeted at the new text.

`bun run test` green across all four packages, 100% statements/branches/functions/lines retained in each.
