### PR TITLE
test(router): verify lazy `as` suspends into the route fallback

### DIFF
--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -1,8 +1,9 @@
 import { act, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { lazy } from 'react';
+import { describe, expect, it, vi } from 'vitest';
 import { Component, Consumer } from '@expressive/react';
 
-import { location, browserRouter, mockPromise, renderAct } from '../test.setup';
+import { location, browserRouter, mockError, mockPromise, renderAct } from '../test.setup';
 import { Route } from './route';
 import { Router } from './router';
 
@@ -1873,5 +1874,161 @@ describe('a Route passed as another Route', () => {
 
     await act(async () => { resolve(); await pending; });
     expect(view.container.textContent).toBe('ready');
+  });
+});
+
+describe('a lazy page as `as`', () => {
+  type Module = { default: () => any };
+
+  it('suspends into the route fallback, then resolves in place', async () => {
+    location('/posts/foo');
+    const module = mockPromise<Module>();
+    const Page = lazy(() => module);
+    const created = vi.fn();
+    let route!: Route;
+
+    const view = await renderAct(
+      <Route
+        to="/posts/:id"
+        fallback={<span>loading</span>}
+        as={Page}
+        is={(r) => { created(); route = r; }}
+      />
+    );
+
+    expect(view.container.textContent).toBe('loading');
+
+    await act(async () => {
+      module.resolve({ default: Post });
+      await module;
+    });
+
+    expect(view.container.textContent).toBe('id: foo');
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(route.match).toEqual({ id: 'foo' });
+  });
+
+  it('suspends within a nested scope without remounting the layout', async () => {
+    location('/admin/users/7');
+    const module = mockPromise<Module>();
+    const Users = lazy(() => module);
+    let mounted = 0;
+    let child!: Route;
+
+    const Layout = (props: { children?: React.ReactNode }) => {
+      mounted++;
+      return <main>{props.children}</main>;
+    };
+
+    const view = await renderAct(
+      <Route to="/admin/*" as={Layout}>
+        <Route
+          to="users/:id"
+          fallback={<span>loading</span>}
+          as={Users}
+          is={(r) => (child = r)}
+        />
+      </Route>
+    );
+
+    expect(view.container.querySelector('main')!.textContent).toBe('loading');
+    expect(mounted).toBe(1);
+
+    await act(async () => {
+      module.resolve({ default: Post });
+      await module;
+    });
+
+    expect(view.container.querySelector('main')!.textContent).toBe('id: 7');
+    expect(mounted).toBe(1);
+    expect(child.match).toEqual({ id: '7' });
+  });
+
+  it('resolves a lazy scope layout, then its nested children', async () => {
+    location('/admin/users');
+    const module = mockPromise<{ default: (props: any) => any }>();
+    const Layout = lazy(() => module);
+    let scope!: Route;
+
+    const view = await renderAct(
+      <Route to="/admin/*" fallback={<span>loading</span>} as={Layout} is={(r) => (scope = r)}>
+        <Route to="users" as={() => <span>users</span>} />
+        <Route to="roles" as={() => <span>roles</span>} />
+      </Route>
+    );
+
+    expect(view.container.textContent).toBe('loading');
+    expect(scope.inner).toEqual([]);
+
+    await act(async () => {
+      module.resolve({ default: (props) => <main>{props.children}</main> });
+      await module;
+    });
+
+    expect(view.container.querySelector('main')!.textContent).toBe('users');
+    expect(scope.inner.map((r) => r.path)).toEqual(['/admin/users', '/admin/roles']);
+
+    await act(async () => router.current.goto('/admin/roles'));
+
+    expect(view.container.querySelector('main')!.textContent).toBe('roles');
+  });
+
+  it('reaches the Route catch when the module rejects', async () => {
+    mockError();
+    location('/posts/foo');
+    const module = mockPromise<Module>();
+    const failure = new Error('chunk load failed');
+    let caught!: Error;
+
+    class Page extends Route {
+      fallback = (<span>loading</span>);
+
+      async catch(error: Error) {
+        caught = error;
+        this.fallback = <span>offline</span>;
+        await new Promise(() => {});
+      }
+    }
+
+    const view = await renderAct(
+      <Page to="/posts/:id" as={lazy(() => module)} />
+    );
+
+    expect(view.container.textContent).toBe('loading');
+
+    await act(async () => {
+      module.reject(failure);
+      await module.catch(() => {});
+    });
+
+    expect(caught).toBe(failure);
+    expect(view.container.textContent).toBe('offline');
+  });
+
+  it('does not mount a lazy page abandoned by navigation mid-load', async () => {
+    location('/posts/foo');
+    const module = mockPromise<Module>();
+    const page = vi.fn(() => <span>post</span>);
+
+    const view = await renderAct(
+      <>
+        <Route to="/posts/:id" fallback={<span>loading</span>} as={lazy(() => module)} />
+        <Route to="/about" as={() => <span>about</span>} />
+      </>
+    );
+
+    expect(view.container.textContent).toBe('loading');
+
+    await act(async () => router.current.goto('/about'));
+
+    expect(view.container.textContent).toBe('about');
+
+    await act(async () => {
+      module.resolve({ default: page });
+      await module;
+    });
+
+    expect(view.container.textContent).toBe('about');
+    expect(page).not.toHaveBeenCalled();
   });
 });

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -97,6 +97,18 @@ The guard may be **async** (return a `Promise`); the route's `fallback` shows wh
 
 Force-404 is path-keyed: it marks only the concrete URL that was declined, so navigating elsewhere clears it. `null` is the deliberate "definitively not here" signal - distinct from a falsy `&&` short-circuit, which allows. The 404 surface is the scope's authored `default` sibling, so a *section*-level not-found requires a parent scope with children (a flat leaf forfeits to the nearest authored default).
 
+## Code-split pages
+
+`as` takes a lazy component - `React.lazy`, or anything that suspends while its module loads. A `Route` inherits `Component`'s suspense boundary, and that is a guaranteed seam: `fallback` shows while the chunk is in flight, then the page resolves in place, with the Route instance, its `match`, and any ancestor layout intact across the load.
+
+```tsx
+const Document = lazy(() => import('./Document'));
+
+<Route to="document/:id" fallback={<Spinner />} as={Document} />
+```
+
+A lazy *layout* suspends its whole scope - child routes register only once the module resolves, so nothing below it matches while pending. Navigating away mid-load abandons the page: it never mounts. A failed chunk is an error, not a suspension - handle it with `catch` on a `Route` subclass, or it propagates to the nearest ancestor boundary.
+
 ## Reading match state inside a page
 
 A page reads the nearest `Route` from context (e.g. via `Consumer` or `get(Route)`) and uses its reactive getters:

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -99,7 +99,7 @@ Force-404 is path-keyed: it marks only the concrete URL that was declined, so na
 
 ## Code-split pages
 
-`as` takes a lazy component - `React.lazy`, or anything that suspends while its module loads. A `Route` inherits `Component`'s suspense boundary, and that is a guaranteed seam: `fallback` shows while the chunk is in flight, then the page resolves in place, with the Route instance, its `match`, and any ancestor layout intact across the load.
+`as` takes a lazy component - `React.lazy`, or anything that suspends while its module loads. A `Route` is its own suspense boundary: `fallback` shows while the chunk loads, then the page resolves in place - the Route instance, its `match`, and any ancestor layout survive.
 
 ```tsx
 const Document = lazy(() => import('./Document'));
@@ -107,7 +107,7 @@ const Document = lazy(() => import('./Document'));
 <Route to="document/:id" fallback={<Spinner />} as={Document} />
 ```
 
-A lazy *layout* suspends its whole scope - child routes register only once the module resolves, so nothing below it matches while pending. Navigating away mid-load abandons the page: it never mounts. A failed chunk is an error, not a suspension - handle it with `catch` on a `Route` subclass, or it propagates to the nearest ancestor boundary.
+A lazy *layout* suspends its whole scope - child routes register only after its module resolves. Navigating away mid-load abandons the page; it never mounts. A failed chunk is an error, not a suspension - handle it with `catch` on a `Route` subclass, or it propagates to the nearest ancestor boundary.
 
 ## Reading match state inside a page
 


### PR DESCRIPTION
Settles the H4 "lazy `as` verification" item: whether a `React.lazy` page passed as `as` suspends into the route's `fallback` and resolves in place.

**Verdict: it works, unchanged.** No router source touched, no API added. `Route` inherits `Component`'s suspense boundary, so a suspending `as` is caught by the route's own `fallback`; the Route instance lives outside that boundary (created in the wrapper's `useWatch`), so route state survives the load. `React.lazy`'s exotic component also typechecks against `as?: Exclude<JSX.ElementType, string>` today - `ExoticComponent` is callable - so no type widening is needed either.

Tests land in `packages/router/src/route.test.tsx` (new `describe('a lazy page as \`as\`')`), driving resolution deterministically with the existing `mockPromise` helper.

### Shapes covered

- **Lazy leaf** - `fallback` shows while pending, page resolves in place; the Route instance is created once (`is` fires once across the load) and `match` params are intact after.
- **Lazy page in a nested scope** - only the child suspends; the parent layout renders once and is not remounted, the child's fallback and then its content appear inside the layout's `<main>`, and the child's `match` survives.
- **Lazy scope layout** - a code-split layout suspends its whole scope: `route.inner` is empty while the chunk is in flight (children register only after the module resolves), then children register in declaration order and in-scope navigation works.
- **Rejected module** - the load failure surfaces as an error, not a suspension: it reaches `catch` on a `Route` subclass, which can swap `fallback` for error UI. Without a `catch` it propagates to the nearest ancestor boundary (existing `Component` semantics).
- **Navigation away mid-load** - the abandoned page never mounts; the new route renders and the late module resolution is inert.

### Docs

`skills/router/router.md` gains a short `## Code-split pages` section (paragraph + minimal example) stating the guarantee, the lazy-layout scope consequence, the abandon-on-navigate behavior, and that a failed chunk is an error handled by `catch`.

### Notes

- Zero-changeset: tests + skills docs only, no package behavior change.
- `bun run test` green across all four packages, router coverage still 100/100/100/100 (happy-dom via `suite(true)`).
- `bun run docs` passes after a `bun run build`.
