### PR TITLE
fix(react): make the published dist importable by native Node ESM

### DIFF
--- a/.changeset/react-dist-esm-resolution.md
+++ b/.changeset/react-dist-esm-resolution.md
@@ -1,0 +1,13 @@
+---
+"@expressive/react": patch
+---
+
+Fix an unloadable published dist: `import '@expressive/react'` threw
+`ERR_MODULE_NOT_FOUND` under native Node ESM.
+
+The build declared `./adapter` external, so `dist/index.js` shipped an
+extensionless `from "./adapter"`. Bundlers tolerate that; Node's ESM resolver
+does not, which broke plain-node and native-ESM SSR consumers - the package
+could only be imported through a bundler. The adapter is already its own entry,
+so dropping the external emits `./adapter.js` with no change to chunking or
+public surface.

--- a/.github/scripts/dist-check.ts
+++ b/.github/scripts/dist-check.ts
@@ -1,0 +1,88 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+/**
+ * Static invariants on the built dist, both learned from shipped breakage:
+ *
+ * 1. Every relative specifier resolves to a file that was actually emitted.
+ *    Node's ESM resolver does not add extensions, so an extensionless emit
+ *    (`from "./adapter"`) makes the package unloadable outside a bundler.
+ *
+ * 2. Every side-effect-only import (`import "./chunk-x.js"`) lands on a path
+ *    covered by the package's `sideEffects`. Those imports exist solely to pull
+ *    in prototype patches; a bundler told the target is pure drops them, and
+ *    the chunk filenames are content-hashed, so the glob and the emitted names
+ *    have to be kept in agreement.
+ */
+const PACKAGES = ['mvc', 'react', 'router'];
+
+const IMPORTS = /(?:^|;)\s*(?:import|export)[^'"]*?from\s*['"]([^'"]+)['"]/gm;
+const SIDE_EFFECT = /(?:^|;)\s*import\s*['"]([^'"]+)['"]/gm;
+
+/** Match one `sideEffects` entry against a dist-relative path, `*` per segment. */
+function covered(patterns: string[] | false | undefined, path: string) {
+  if (!Array.isArray(patterns)) return false;
+
+  return patterns.some((pattern) => {
+    const source = pattern.replace(/^\.\//, '').replace(/[.+^${}()|[\]\\]/g, '\\$&');
+
+    return new RegExp(`^${source.replace(/\*/g, '[^/]*')}$`).test(path);
+  });
+}
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory()
+      ? walk(join(dir, entry.name))
+      : entry.name.endsWith('.js')
+        ? [join(dir, entry.name)]
+        : []
+  );
+}
+
+const problems: string[] = [];
+
+for (const name of PACKAGES) {
+  const root = resolve('packages', name);
+  const dist = join(root, 'dist');
+  const { sideEffects } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+  if (!existsSync(dist))
+    throw new Error(`packages/${name}/dist is missing - run \`bun run build\` first.`);
+
+  const files = walk(dist);
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const from = relative(dist, file);
+
+    for (const [, specifier] of source.matchAll(IMPORTS)) {
+      if (!specifier.startsWith('.')) continue;
+
+      if (!existsSync(resolve(dirname(file), specifier)))
+        problems.push(
+          `@expressive/${name}: dist/${from} imports "${specifier}", which was not emitted` +
+          ` (Node ESM will not add an extension).`
+        );
+    }
+
+    for (const [, specifier] of source.matchAll(SIDE_EFFECT)) {
+      if (!specifier.startsWith('.')) continue;
+
+      const target = relative(dist, resolve(dirname(file), specifier));
+
+      if (!covered(sideEffects, `dist/${target}`))
+        problems.push(
+          `@expressive/${name}: dist/${from} imports "${specifier}" for side effects only,` +
+          ` but dist/${target} is not listed in "sideEffects" - tree-shaking will drop it.`
+        );
+    }
+  }
+
+  console.log(`@expressive/${name}: ${files.length} emitted modules checked`);
+}
+
+if (problems.length)
+  throw new Error(`Built dist is not consumable:\n\n${problems.map((p) => `  ${p}`).join('\n')}`);
+
+console.log('\nAll relative specifiers resolve; side-effect imports are declared.');

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,9 +2,11 @@
 
 ## pr.yml (pull requests -> main)
 
-Blocking: `bun run test` and `bun run build`. The frozen-lockfile install in
-the `setup` action doubles as the internal-dependency desync guard - a
-workspace version that falls outside a sibling's range cannot reach main.
+Blocking: `bun run test`, `bun run build` and `bun run dist` (static invariants
+on the emitted dist - relative specifiers resolve, side-effect imports are
+declared). The frozen-lockfile install in the `setup` action doubles as the
+internal-dependency desync guard - a workspace version that falls outside a
+sibling's range cannot reach main.
 
 Non-blocking signals: `changeset status` (a preview of which packages would
 bump) and `npm publish --dry-run` pack validation for the publishable packages.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,9 @@ jobs:
 
       - run: bun run build
 
+      - name: Dist is consumable
+        run: bun run dist
+
       - name: Bundle size
         continue-on-error: true
         run: bun run size
@@ -37,6 +40,6 @@ jobs:
       - name: Pack validation
         continue-on-error: true
         run: |
-          for pkg in mvc react; do
+          for pkg in mvc react router; do
             (cd packages/$pkg && npm publish --dry-run)
           done

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ci:publish": "bun run --filter='./packages/*' build && changeset publish",
     "pr": "bash .github/scripts/pr.sh",
     "size": "bun .github/scripts/size-limit.ts",
+    "dist": "bun .github/scripts/dist-check.ts",
     "docs": "bun .github/scripts/docs-check.ts",
     "tunnel": "cloudflared tunnel --no-autoupdate ${TUNNEL_NAME:+run} --url http://localhost:5173 ${TUNNEL_NAME:-}",
     "watch": "bun test --watch --only-failures",

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   dts: true,
   sourcemap: true,
   outDir: 'dist',
-  external: ['./adapter'],
   outExtensions: () => ({ js: '.js' }),
   entry: {
     index: 'src/index.ts',


### PR DESCRIPTION
Packaging only — no public surface added or changed.

## The defect

Shipped `@expressive/react` 0.84.1 cannot be imported by native Node ESM.

`packages/react/tsdown.config.ts` declared `external: ['./adapter']`, so
`dist/index.js` emitted `from "./adapter"` — extensionless. Bundlers tolerate
that; Node's ESM resolver does not, so any unbundled consumer (plain node,
native-ESM SSR) fails at import with `ERR_MODULE_NOT_FOUND .../dist/adapter`.
`mvc` and `router` are unaffected — react was the only package using the pattern.

The external was legacy: it predates `adapter` being its own build entry (it was
`external: ['./state']` when the module was `state.ts`). Because the adapter *is*
an entry now, rolldown already emits a shared chunk and links entries to each
other; the external only suppressed the extension. Dropping it emits
`./adapter.js` and changes nothing else — same chunk graph, same exports, same
`sideEffects` globs, bundle sizes flat (all seven size-limit shapes still `ok`).

One incidental emit change: `dist/adapter.d.ts` now re-exports from a
`chunk-*.d.ts` instead of inlining the declarations. Both files ship under
`files: ["dist"]`, and `bun run docs` plus `tsc --noEmit` are green.

## Verification actually run

Negative control first — the pre-fix build, packed and installed into a
throwaway project outside the repo, then imported by Node 24:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/private/var/.../expressive-dist-smoke-tA5AxI/node_modules/@expressive/react/dist/adapter'
    imported from /private/var/.../node_modules/@expressive/react/dist/index.js
    at finalizeResolution (node:internal/modules/esm/resolve:271:11)
  code: 'ERR_MODULE_NOT_FOUND',
```

Same probe after the fix — `dist/adapter.js` resolves, and `Component` / `get` /
`set` / `ref` / `def` / `has` / `map` are all live. That probe harness is not part
of this PR (see **Scope** below); it ran locally on Node 24.

`bun run test` (100% on all four metrics, every package), `bun run build`,
`bun run size`, `bun run docs`: green.

## CI addition

**`bun run dist` — `.github/scripts/dist-check.ts`** (blocking). Two static
invariants over the emitted modules of all three publishable packages:

1. Every relative specifier resolves to a file that was actually emitted. This
   is the static counterpart of the bug above, so it cannot come back silently.
2. Every side-effect-only import (`import "./chunk-x.js"`) lands on a path
   covered by that package's `sideEffects`. This is the #296 guard: those
   imports exist only to pull in the prototype patches, the chunk filenames are
   content-hashed, and a bundler told the target is pure drops the import
   outright. Files imported *for bindings* are deliberately not required to be
   covered — `has.js` / `map.js` carry patches and are meant to be droppable
   when their exports go unused.

Both arms were verified to fail, not just pass:

- renaming `chunkFileNames` to `part-[name]-[hash].js` →
  `dist/index.js imports "./part-element-BLXL1DJ0.js" for side effects only, but dist/part-element-BLXL1DJ0.js is not listed in "sideEffects" - tree-shaking will drop it.`
- restoring `external: ['./adapter']` →
  `dist/index.js imports "./adapter", which was not emitted (Node ESM will not add an extension).`

It runs after `bun run build` with no network and no second toolchain.

The non-blocking `npm publish --dry-run` pack step also gains `router`, which was
simply missing from the loop.

## Scope

A second script — `dist-smoke.ts`, which packs each publishable package,
installs the tarballs into an `mkdtemp` project outside the repo and *executes*
a probe per package under `node` — was cut from this PR and parked on the
`ci/dist-smoke` branch.

Reasons it does not belong on the per-PR path:

- It is a blocking step that hits the npm registry (three `npm pack`s plus an
  `npm install` of `react`/`react-dom` at `^19`, unpinned, no lockfile, no
  cache). A blocking gate with an unpinned network dependency eventually reds a
  PR for reasons unrelated to its diff.
- It adds `setup-node` and 30–60s+ to every PR for a bug class the free static
  check already catches — the specifier failure is statically detectable, so
  `dist-check` alone prevents recurrence.
- Its `finally { rmSync(fixture) }` deletes the fixture on failure, leaving
  nothing to inspect the one time it fires.

`release.yml` is the plausible home instead — publishing is when "does the
tarball execute" matters, it already sets up Node, and it runs per release rather
than per PR — where it would also make the `continue-on-error`
`npm publish --dry-run` step redundant, since that executes nothing. Not decided
in this PR.

Known gap either way: `.github/scripts` is in no vitest project, so
`dist-check`'s regex scan of generated JS has no coverage of its own. A future
minified or reformatted emit could stop matching silently.

## Commits

- `fix(react): emit a resolvable specifier for the adapter entry` + changeset (patch)
- `ci: assert the built dist stays consumable`
