### PR TITLE
fix(react): keep consumers on their nearest upstream Provider

### DIFF
--- a/.changeset/context-sibling-provider.md
+++ b/.changeset/context-sibling-provider.md
@@ -1,0 +1,6 @@
+---
+"@expressive/react": patch
+---
+
+Keep context consumers attached to their nearest upstream Provider when nested
+Providers render in sibling branches, including during server rendering.

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import { renderToString } from 'react-dom/server';
 import { vi, afterAll, expect, it, describe } from 'vitest';
 
 import { act, render, screen } from '@testing-library/react';
@@ -769,6 +770,38 @@ describe('Consumer', () => {
         </Provider>
       </Provider>
     );
+  });
+
+  it('will not select nested instance from outer sibling', () => {
+    const Value = () => Foo.get().value;
+
+    const element = render(
+      <Provider for={Foo} value="outer">
+        <Value />
+        <Provider for={Foo} value="inner">
+          <Value />
+        </Provider>
+        <Value />
+      </Provider>
+    );
+
+    expect(element.container.textContent).toBe('outerinnerouter');
+  });
+
+  it('will not select nested instance from outer sibling on server', () => {
+    const Value = () => <Consumer for={Foo}>{({ value }) => value}</Consumer>;
+
+    const html = renderToString(
+      <Provider for={Foo} value="outer">
+        <Value />
+        <Provider for={Foo} value="inner">
+          <Value />
+        </Provider>
+        <Value />
+      </Provider>
+    );
+
+    expect(html.replace(/<!--[^>]*-->/g, '')).toBe('outerinnerouter');
   });
 
   it('will select closest match over best match', () => {

--- a/packages/react/src/state.get.ts
+++ b/packages/react/src/state.get.ts
@@ -74,6 +74,7 @@ State.get = function get<T extends State>(
   this: State.Extends<T>,
   argument?: boolean | State.GetFactory<T, unknown>
 ) {
+  const Type = this;
   const next = Runtime.useState(0)[1];
   const local = Context.get();
   const render = useFactory(() => {
@@ -106,6 +107,8 @@ State.get = function get<T extends State>(
     }
 
     function attach(next: T) {
+      if (local.get(Type, false) !== next) return;
+
       unwatch?.();
 
       if (observer(next) === null) {
@@ -147,12 +150,12 @@ State.get = function get<T extends State>(
       return release;
     }
 
-    const unsubscribe = local.get(this, attach);
+    const unsubscribe = local.get(Type, attach);
 
     if (!unwatch) {
       unsubscribe();
       if (argument === false) return () => undefined;
-      throw new Error(`Could not find ${this} in context.`);
+      throw new Error(`Could not find ${Type} in context.`);
     }
 
     if (value === null) {


### PR DESCRIPTION
Recovered from uncommitted work in an abandoned worktree sitting on an old commit from #245 — a fix plus changeset that never landed. The fix was re-derived against current `state.get.ts` (rewritten by #293); the rescued diff was not applied.

**The bug was live on `main` (88606452).** Both new tests fail without the fix.

## Symptom

A consumer rendered as a *sibling* of a nested `Provider` picked up the nested instance instead of its own nearest upstream one:

```tsx
<Provider for={Foo} value="outer">
  <Value />                              {/* outer */}
  <Provider for={Foo} value="inner">
    <Value />                            {/* inner */}
  </Provider>
  <Value />                              {/* inner  <-- wrong, want outer */}
</Provider>
```

Rendered `outerinnerinner`. Reproduces identically under `renderToString` (no commit phase needed) and, since preact re-exports the react implementation, in `@expressive/preact` as well.

## Cause

`State.get` subscribes with `local.get(this, attach)` — no `downstream` filter — so `Context.get` both traverses child scopes at registration time and, via `Context.add`, notifies the consumer when any state of that type appears in a context at or below its own. The third `<Value />` attaches correctly to the outer instance, then the already-mounted inner provider's context is walked and `attach` is called again with the inner instance, replacing the subscription.

The unfiltered subscription is load-bearing: passing `downstream: false` fixes the sibling case but breaks legitimate same-context late arrivals (a `has`/`map` child appearing on an already-provided parent, and provider instance replacement) — 6 existing tests fail that way.

## Fix

Guard in `attach`: accept only the instance an upstream-only lookup from the consumer's own context resolves to.

```ts
if (local.get(Type, false) !== next) return;
```

Late arrivals in the consumer's own context still win (they are what the upstream lookup then resolves to); states from sibling or descendant contexts no longer hijack an attachment. No public surface added.

## Scope

- `Consumer` is `props.for.get(...)`, so it shared the defect and is fixed by the same change — the server-render test uses the `Consumer` form for that reason.
- `@expressive/preact` needs no mirror: it re-exports react's `State.get`. Verified by temporary probe (failed before, passes after).
- `State.use` and `Component`'s `Element` are unaffected — they `push` a child context rather than subscribing, so nothing re-targets them.
- `get(Type)` instruction already subscribes with `downstream: false` (upstream) or `true` (`get.below`), so it was never ambiguous.

## Tests

Two tests in `packages/react/src/context.test.tsx` (committed failing-first), DOM and `renderToString`. Full suite green, coverage 100% on all four packages.
