### PR TITLE
docs: accuracy sweep (llms.txt use(), has() signatures, suspense ownership, override limits)

### DIFF
--- a/.github/scripts/docs-check.ts
+++ b/.github/scripts/docs-check.ts
@@ -11,6 +11,9 @@ import { withWorkspaceLinks } from './workspace-links';
  */
 const SCOPES = ['@expressive/mvc', '@expressive/react', '@expressive/router'];
 
+/** Written at build time by the serve-llm plugin, so it has no source file. */
+const GENERATED_LLM = 'examples/index.md';
+
 const release = withWorkspaceLinks();
 const exported = new Map<string, Set<string>>();
 
@@ -33,7 +36,7 @@ type Doc = { path: string; text: string };
 
 const docs: Doc[] = [];
 
-for (const pattern of ['skills/**/*.md', 'website/content/**/*.{md,mdx}'])
+for (const pattern of ['skills/**/*.md', 'website/content/**/*.{md,mdx}', 'website/public/llms.txt'])
   for await (const path of new Glob(pattern).scan('.'))
     docs.push({ path, text: await Bun.file(path).text() });
 
@@ -82,6 +85,21 @@ for (const { path, text } of docs) {
           `${at(path, text, match.index)}  imports { ${name} } from '${scope}', which does not export it`
         );
     }
+  }
+
+  // --- /llm/ links must resolve to a file the build actually publishes ---
+  for (const match of text.matchAll(/\]\((\/llm\/[^)#\s]+)\)/g)) {
+    const target = match[1].slice(5);
+
+    if (target === GENERATED_LLM)
+      continue;
+
+    const found = await Promise.all(
+      ['skills', 'website/content/llm'].map((dir) => Bun.file(`${dir}/${target}`).exists())
+    );
+
+    if (!found.includes(true))
+      problems.push(`${at(path, text, match.index)}  links /llm/${target}, but no such document exists`);
   }
 
   // --- internal docs links must resolve, anchors included ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,5 +137,6 @@ Requires `gh auth refresh -s project` (`read:project` can list but not create). 
 - Instructions (`def`, `ref`, `get`, `set`) are re-exported from adapters - don't duplicate implementations.
 - `new()` lifecycle hook is optional; don't add it unnecessarily.
 - `@expressive/router` is strictly client-side - no SSR or server coupling. Its roadmap priority is stability over features: `to`, `as`, `default`, `fallback`, `redirect`, the protected `children` getter, `Component.catch`, `Link`, and `BrowserRouter` form a de facto compatibility contract consumed by downstream tooling, so treat changes to them as breaking and design new seams once, carefully.
+- `@expressive/mvc` and `@expressive/router` declare `"sideEffects": false`, so a bundler may drop any module a consumer does not import from. Import must therefore mutate nothing outside the module - no registry writes, global patching, or feature probes at module scope. Anything that must run belongs behind a call. (`@expressive/react` opts specific files back in via a glob - see its `package.json`.)
 - Event dispatch is batched via `queueMicrotask()` - not synchronous.
 - `State.new()` constructs + activates; plain `new State()` doesn't dispatch ready.

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -105,7 +105,7 @@ Every collection is adopted by its hosting state at activation. Fresh `State` me
 
 Death also flows the other way: a `State` member that dies evicts itself from the pool - owned or guest - so a pool never serves destroyed members. Destroying a member (`member.set(null)`) is a complete removal gesture on its own. Lists do not adopt, destroy, or evict on death - they store values by position; use a pool (`has(Item)`) when members are owned `State`s.
 
-Destruction is an eviction concern, separate from context, so the underlying `has.Pool` and `has.List` can be constructed directly without an owner (`new has.Pool(null, Item)`, chiefly for testing) - fresh members are still owned and destroyed on eviction, just not parented into a context.
+Destruction is an eviction concern, separate from context, so the underlying `has.Pool` and `has.List` can be constructed directly without an owner (`new has.Pool(Item)`, chiefly for testing) - fresh members are still owned and destroyed on eviction, just not parented into a context.
 
 ```ts
 class Member extends State {
@@ -143,7 +143,7 @@ Calling `get()` with no arguments returns a shallow snapshot array; nested value
 ## Type Signature
 
 ```ts
-function has<T>(initial?: Iterable<T> | null): has.List<T>;
+function has<T>(initial?: Iterable<T> | false | null): has.List<T>;
 function has<T extends State>(Type: new (...args: State.Args<T>) => T): has.Pool<T, State.Args<T>>;
 function has<T, A extends unknown[]>(make: (...args: A) => T): has.Pool<T, A>;
 

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -309,6 +309,8 @@ class DataView extends Component {
 }
 ```
 
+`fallback={false}` declines the component's own boundary so suspension bubbles to an ancestor - valid only when the pending value is owned **above** the boundary that catches it. A boundary rebuilds the subtree it retries, so state owned below is reconstructed on every retry and requests again: a silent infinite retry loop.
+
 ## Error Boundaries
 
 Override `catch()` to handle child render errors:

--- a/skills/state/computed.md
+++ b/skills/state/computed.md
@@ -77,6 +77,25 @@ class Extra extends Base {
 
 Subclasses can override or extend a parent's getter. `super.total` invokes the parent's getter under the same tracking proxy, so dependencies on both classes are picked up.
 
+### Getter vs Field Across Classes
+
+A getter overrides a base *getter*. Swapping kinds across the boundary is what TypeScript refuses - a getter over a base plain field is `TS2611`, a plain field over a base getter is `TS2610` - even though the runtime resolves either one (the getter wins and tracks normally). The errors are not suppressible on the subclass; the escape is on whichever side you control:
+
+```ts
+class Cart extends State {
+  rate = 0.1;
+  total = 0;
+}
+
+class TaxedCart extends Cart {
+  // get total() {}                              // TS2611
+  total = set((self: TaxedCart) => 100 * (1 + self.rate));
+}
+```
+
+- **Own the subclass only:** override the field with a field. `set(self => ...)` is a computed in property position, so it is legal TS and reactive.
+- **Own the base:** a member subclasses are expected to derive belongs on the prototype - a getter, or an accessor pair (`get`/`set`, still writable and managed). A base `set(...)` field does not help: it is a property too, so a subclass getter still errors.
+
 ## Self-Reference
 
 A computed can read its own previous value without infinite looping:

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -34,7 +34,7 @@ declared on the `UseState` interface instead, which a class satisfies
 structurally: they stay optional and unadvertised on States that are never
 rendered, at the cost of a looser check than a declared override gets.
 
-> **`new()` runs on the server.** It is part of activation, so it fires wherever the state is constructed - including during `renderToString`. Anything touching `window`, timers or subscriptions belongs in the adapter's commit hook instead: see `mount()` in [../react/react.md](../react/react.md), which runs only on the client and only for a state some component owns.
+> **`new()` runs on the server.** It is part of activation, so it fires wherever the state is constructed - including during `renderToString`. The teardown it returns never does: there is no unmount on the server, so a resource opened in `new()` - a socket, a subscription, a file handle - leaks there, once per render. Anything touching `window`, timers or subscriptions belongs in the adapter's commit hook instead: see `mount()` in [../react/react.md](../react/react.md), which runs only on the client and only for a state some component owns.
 
 > **`new()` is for consumers and own-state.** Avoid it in reusable state meant to be subclassed: it's a public method, so an extending class that defines its own `new()` silently overrides yours and loses the base behavior (with no error). For internal init logic in a shippable base class, pass a trailing init callback to `super` instead - it runs in the same phase as `new()` but can't be clobbered:
 >

--- a/website/content/docs/guides/components.mdx
+++ b/website/content/docs/guides/components.mdx
@@ -410,6 +410,8 @@ class DataView extends Component {
 
 The JSX `fallback` prop overrides the class property for that instance. Set `fallback` to `false` (prop or property) to opt out of the component's own boundary entirely - suspension then bubbles to the nearest ancestor.
 
+Opting out only works when the pending value is owned *above* the boundary that catches the suspension. A boundary rebuilds the subtree it retries, so state owned below it is reconstructed on every retry and requests again - a silent infinite retry loop. [See both halves side by side](/examples/component/suspense).
+
 <br />
 
 ## Error boundaries

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -33,7 +33,7 @@ This documentation is also distributed as an installable skill: `npx skills add 
 - [def()](/llm/field/def.md): Low-level custom property behavior
 
 ## React
-- [React Adapter](/llm/react/react.md): use(), State.use(), State.get(), Provider, Consumer, ForceRefresh
+- [React Adapter](/llm/react/react.md): State.use(), State.get(), Provider, Consumer, ForceRefresh
 - [Component](/llm/react/component.md): Component class, props, children, subcomponents, error boundaries
 - [Refactoring Guide](/llm/react/refactor.md): Hook-migration algorithm - ownership triage, dependency snapshots, review checklist
 - [Style Profile](/llm/react/style.md): Snapshot formatting, affirmative conditions, render fallthrough

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -5,7 +5,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import mdx from 'fumadocs-mdx/vite';
 import * as MdxConfig from './source.config';
 import { resolve, join, dirname } from 'path';
-import { cp, glob, readFile, writeFile } from 'fs/promises';
+import { cp, glob, mkdir, readFile, writeFile } from 'fs/promises';
 import { readdirSync, readFileSync } from 'fs';
 import { createGetUrl, getSlugs } from 'fumadocs-core/source';
 
@@ -136,6 +136,8 @@ function serveSkills(): Plugin {
     },
     async writeBundle({ dir: outDir }) {
       if (!outDir) return;
+
+      await mkdir(join(outDir, 'llm'), { recursive: true });
 
       for (const dir of dirs)
         await cp(dir, join(outDir, 'llm'), { recursive: true });


### PR DESCRIPTION
Mechanical accuracy sweep of item **T1** from the 2026-08-03 followups audit. Docs, one guard widening, one build-hardening line. No published package code changes, so no changeset.

## What changed

**1. `llms.txt` + drift guard** (`2f2a7fc4`)
- `website/public/llms.txt:36` still advertised the standalone `use()` deleted in #289. Removed; `State.use()` stays.
- The file sat outside `docs-check.ts`'s globs, which is why #294's purge missed it. Globs now include `website/public/llms.txt`.
- The existing checks are import-statement and `/docs/`-link based, so the widening alone would be vacuous for this file - it has neither. Added `/llm/` link resolution (against `skills/` + `website/content/llm/`, with the build-generated `examples/index.md` exempt) so its 26 links are actually checked. Verified with a negative control: renaming one target fails the run.

**2. skills accuracy** (`8aa8df15`)
- `field/has.md:108` documented `new has.Pool(null, Item)`; the constructor takes one argument. Now `new has.Pool(Item)` - type-checked and run against the real class.
- `field/has.md:146` list overload union was missing `| false` (`has.ts:21,31,43`).
- `state/lifecycle.md:37` described `new()` running on the server without the half that bites - the teardown it returns never runs there, so a resource opened in `new()` leaks per render. Wording follows `guides/server.mdx`.

**3. new doc sections** (`97d37177`)
- `fallback={false}` ownership rule, previously only a comment in the suspense example: opting out is valid only when the pending value is owned *above* the catching boundary, since a boundary rebuilds the subtree it retries. One paragraph in `skills/react/component.md`, one in `guides/components.mdx`.
- Getter/field override across a class boundary, in `skills/state/computed.md` under Inheritance - documented from probes rather than the audit's description, see below.

**4. build + invariant** (`dc4128c9`)
- `website/vite.config.ts` writeBundle now `mkdir`s `outDir/llm` instead of relying on the preceding recursive `cp` as a side effect.
- AGENTS.md guardrail for `sideEffects: false` on mvc/router: import must mutate nothing at module scope.

## Correction to the audit note

The subclass-getter item was filed as an "unfixable-at-runtime limitation". It is not a runtime limitation at all - **only TypeScript refuses it**. Probed at HEAD:

- `get count()` over a base `count = 1` errors `TS2611`, and a plain field over a base getter errors `TS2610`, but at runtime the prototype getter wins in both directions and tracks normally (`initial 20` → `after factor=3 30`; assignment throws `read-only`, as a computed should).
- The suggested escape - declaring the base member with `set(fn)` - does **not** work: an instruction field is still a property, so a subclass getter over it errors `TS2611` too. What works is field-over-field (`total = set(self => ...)` in the subclass) or an accessor pair on the base. The new section documents those two.

## Verification

`bun run test` (all packages, coverage gates green), `bun run build`, `bun run docs`, website `types:check`, plus a full website build to exercise the patched `writeBundle` - `build/client/llm/**` and `llm/examples/index.md` emit as expected.

## Deliberately untouched

- `skills/field/ref.md:76` - deferred to the ref-proxy item, per the audit.
- `skills/SKILL.md:350` carries the same `use(), State.use(), ...` phrasing as the llms.txt line, inside docs-check's globs but undetectable by it (prose, not an import). Left alone because `react/react.md` documents a live class-level `use()` method, so the entry can be read as legitimate - flagging rather than guessing.
