### PR TITLE
fix(website): pin sandbox @expressive deps to workspace versions

### DIFF
--- a/website/app/components/Sandbox.tsx
+++ b/website/app/components/Sandbox.tsx
@@ -25,6 +25,8 @@ import CodeLabel from './CodeLabel';
 import { createSandboxTs, type SandboxTs } from './sandbox/client';
 import { intellisense } from './sandbox/intellisense';
 
+declare const __SANDBOX_DEPS__: Record<string, string>;
+
 class Panes extends State {
   mode: 'preview' | 'code' = 'preview';
   stacked = false;
@@ -117,14 +119,21 @@ export default function Sandbox({
   const dark = resolvedTheme === 'dark';
 
   // Each example declares its own @expressive/* deps via its imports - scan
-  // the source so router (or any future package) resolves without a hardcoded list.
+  // the source so router (or any future package) resolves without a hardcoded
+  // list. Versions are pinned to the workspace at build time.
   const dependencies = useMemo(() => {
     const deps: Record<string, string> = {};
 
     for (const entry of Object.values(files) as (string | { code: string })[]) {
       const code = typeof entry === 'string' ? entry : entry.code;
-      for (const [pkg] of code.matchAll(/@expressive\/[a-z-]+/g))
-        deps[pkg] = 'latest';
+      for (const [pkg] of code.matchAll(/@expressive\/[a-z-]+/g)) {
+        const version = __SANDBOX_DEPS__[pkg];
+
+        if (!version)
+          throw new Error(`${pkg} is not a published package - a sandbox example cannot import it.`);
+
+        deps[pkg] = version;
+      }
     }
 
     return deps;

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,13 +9,14 @@ import { cp, glob, readFile, writeFile } from 'fs/promises';
 import { readdirSync, readFileSync } from 'fs';
 import { createGetUrl, getSlugs } from 'fumadocs-core/source';
 
-export default defineConfig({
+export default defineConfig(async ({ command }) => ({
   define: {
     __LIB_VERSION__: JSON.stringify(
       JSON.parse(readFileSync(resolve(__dirname, '../packages/react/package.json'), 'utf8')).version
     ),
     __LIB_TESTS__: countTests(resolve(__dirname, '../packages')),
     __LIB_SIZE__: readSize(resolve(__dirname, '../size-report.json')),
+    __SANDBOX_DEPS__: JSON.stringify(await sandboxDeps(command === 'build')),
   },
   optimizeDeps: {
     include: [
@@ -51,7 +52,7 @@ export default defineConfig({
     tsconfigPaths(),
     serveSkills()
   ]
-});
+}));
 
 function countTests(dir: string): number {
   let total = 0;
@@ -63,6 +64,87 @@ function countTests(dir: string): number {
       total += (readFileSync(path, 'utf8').match(/^\s*(it|test)\(/gm) ?? []).length;
   }
   return total;
+}
+
+/**
+ * Sandpack installs each example's `@expressive/*` deps from npm, where
+ * `latest` made the live site disagree with local review - that resolves the
+ * workspace, which is never behind. Pin to workspace versions instead, and
+ * report the ways the workspace can still be ahead of the registry.
+ */
+async function sandboxDeps(build: boolean) {
+  const dir = resolve(__dirname, '../packages');
+  const deps: Record<string, string> = {};
+
+  for (const entry of readdirSync(dir)) {
+    const pkg = JSON.parse(readFileSync(join(dir, entry, 'package.json'), 'utf8'));
+
+    if (!pkg.private) deps[pkg.name] = pkg.version;
+  }
+
+  warnPending(deps);
+
+  if (build) await assertPublished(deps);
+
+  return deps;
+}
+
+async function assertPublished(deps: Record<string, string>) {
+  const missing: string[] = [];
+
+  await Promise.all(
+    Object.entries(deps).map(async ([name, version]) => {
+      const url = `https://registry.npmjs.org/${name.replace('/', '%2f')}/${version}`;
+
+      let response: Response;
+
+      try {
+        response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+      } catch (error) {
+        console.warn(
+          `Sandbox: npm unreachable, cannot verify ${name}@${version} - ${(error as Error).message}`
+        );
+        return;
+      }
+
+      if (response.status === 404) missing.push(`${name}@${version}`);
+      else if (!response.ok)
+        console.warn(
+          `Sandbox: npm answered ${response.status} for ${name}@${version}, cannot verify`
+        );
+    })
+  );
+
+  if (missing.length)
+    throw new Error(
+      'Sandbox dependencies are pinned to versions npm does not have: ' +
+        `${missing.join(', ')}.\nEvery live example would fail to install. ` +
+        'Publish first, or roll the workspace version back to a released one.'
+    );
+}
+
+function warnPending(deps: Record<string, string>) {
+  const dir = resolve(__dirname, '../.changeset');
+  const pending = new Map<string, string[]>();
+
+  for (const entry of readdirSync(dir)) {
+    if (!entry.endsWith('.md') || entry === 'README.md') continue;
+
+    const text = readFileSync(join(dir, entry), 'utf8');
+    const front = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text);
+
+    if (!front) continue;
+
+    for (const [, name] of front[1].matchAll(/^\s*["']?(@expressive\/[a-z-]+)["']?\s*:/gm))
+      if (name in deps) pending.set(name, [...(pending.get(name) ?? []), entry]);
+  }
+
+  for (const [name, files] of pending)
+    console.warn(
+      `Sandbox: ${name} pins ${deps[name]}, the last published version, but ` +
+        `${files.join(', ')} describes changes not in it. Examples relying on ` +
+        'unreleased behavior will not work on the live site until the next release.'
+    );
 }
 
 function readSize(report: string): string {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -9,14 +9,14 @@ import { cp, glob, readFile, writeFile } from 'fs/promises';
 import { readdirSync, readFileSync } from 'fs';
 import { createGetUrl, getSlugs } from 'fumadocs-core/source';
 
-export default defineConfig(async ({ command }) => ({
+export default defineConfig({
   define: {
     __LIB_VERSION__: JSON.stringify(
       JSON.parse(readFileSync(resolve(__dirname, '../packages/react/package.json'), 'utf8')).version
     ),
     __LIB_TESTS__: countTests(resolve(__dirname, '../packages')),
     __LIB_SIZE__: readSize(resolve(__dirname, '../size-report.json')),
-    __SANDBOX_DEPS__: JSON.stringify(await sandboxDeps(command === 'build')),
+    __SANDBOX_DEPS__: JSON.stringify(sandboxDeps()),
   },
   optimizeDeps: {
     include: [
@@ -52,7 +52,7 @@ export default defineConfig(async ({ command }) => ({
     tsconfigPaths(),
     serveSkills()
   ]
-}));
+});
 
 function countTests(dir: string): number {
   let total = 0;
@@ -70,9 +70,9 @@ function countTests(dir: string): number {
  * Sandpack installs each example's `@expressive/*` deps from npm, where
  * `latest` made the live site disagree with local review - that resolves the
  * workspace, which is never behind. Pin to workspace versions instead, and
- * report the ways the workspace can still be ahead of the registry.
+ * report where the workspace is ahead of what has been published.
  */
-async function sandboxDeps(build: boolean) {
+function sandboxDeps() {
   const dir = resolve(__dirname, '../packages');
   const deps: Record<string, string> = {};
 
@@ -84,43 +84,7 @@ async function sandboxDeps(build: boolean) {
 
   warnPending(deps);
 
-  if (build) await assertPublished(deps);
-
   return deps;
-}
-
-async function assertPublished(deps: Record<string, string>) {
-  const missing: string[] = [];
-
-  await Promise.all(
-    Object.entries(deps).map(async ([name, version]) => {
-      const url = `https://registry.npmjs.org/${name.replace('/', '%2f')}/${version}`;
-
-      let response: Response;
-
-      try {
-        response = await fetch(url, { signal: AbortSignal.timeout(15_000) });
-      } catch (error) {
-        console.warn(
-          `Sandbox: npm unreachable, cannot verify ${name}@${version} - ${(error as Error).message}`
-        );
-        return;
-      }
-
-      if (response.status === 404) missing.push(`${name}@${version}`);
-      else if (!response.ok)
-        console.warn(
-          `Sandbox: npm answered ${response.status} for ${name}@${version}, cannot verify`
-        );
-    })
-  );
-
-  if (missing.length)
-    throw new Error(
-      'Sandbox dependencies are pinned to versions npm does not have: ' +
-        `${missing.join(', ')}.\nEvery live example would fail to install. ` +
-        'Publish first, or roll the workspace version back to a released one.'
-    );
 }
 
 function warnPending(deps: Record<string, string>) {


### PR DESCRIPTION
Closes the H7 sandbox-pinning half of the 2026-08-03 followups audit.

## Problem

`Sandbox.tsx` resolved every `@expressive/*` dependency an example imports at npm `latest`:

```ts
for (const [pkg] of code.matchAll(/@expressive\/[a-z-]+/g))
  deps[pkg] = 'latest';
```

Local verification resolves those packages through the workspace alias, which is never behind npm. An example authored against unreleased API therefore passes review locally and silently breaks - or silently demos nonexistent behavior - on the live site, with nothing anywhere reporting the mismatch.

The reverse drift is the more durable problem: with `latest`, an already-deployed site's examples change behavior the moment a publish happens, with no rebuild and no signal. The prose comes from the commit; the demo comes from whatever npm now serves, so the two can disagree with nobody touching the site.

## Change

- `website/vite.config.ts` derives `__SANDBOX_DEPS__` from the non-private packages under `packages/` (name -> workspace version) and inlines it. No hardcoded package list, so a future published package is covered automatically; `@expressive/preact` is excluded because it is private.
- `Sandbox.tsx` pins each scanned import to that map, and throws for a scoped package that is not in it. An example importing something unpublishable previously handed `latest` to Sandpack and failed inside the visitor's iframe, where no CI signal exists; it now fails immediately in dev.
- **Pending changeset for a pinned package -> build-log warning**, naming the package, the version pinned, and the changeset file.

## What pinning does and does not buy

Changesets bump versions only at `changeset version` time, so on `main` the workspace version *is* the last published version (mvc 0.83.1, react 0.84.1, router 0.7.0 all match `dist-tags.latest`). As a version *string* this is therefore a no-op at steady state, and pinning alone cannot detect the drift H7 is about.

What it does buy is that docs prose and running demo can no longer disagree: an example is tied to the version its surrounding text was written against, instead of following `latest` after a publish. Where the workspace is genuinely ahead of the registry - pending changesets, the state `main` is in now via `react-peer-floor.md` - pinning cannot fix it, so the build says so.

An earlier revision also fetched `registry.npmjs.org` during the build and hard-failed when a pinned version was absent (mid-publish window, or a hand-bump). That was cut in review: it guarded a state nothing legitimate on `main` produces, at the cost of a registry dependency in every website build including Cloudflare Pages. Both remaining signals are local file reads, so the config no longer needs to be async either. Emitted output is unchanged by the cut - same `Sandbox-BNmfviwm.js` chunk hash before and after.

## Verified

- `bun run test` (all four packages, 100% coverage gates) and `bun run --filter website types:check` pass.
- `bun run --filter website build` succeeds; the emitted `Sandbox-BNmfviwm.js` chunk carries `{"@expressive/mvc":"0.83.1","@expressive/react":"0.84.1","@expressive/router":"0.7.0"}` and contains zero `"latest"` occurrences.
- Pending-changeset warning observed in `build`, `types:check`, and `dev`, naming `@expressive/react` / `0.84.1` / `react-peer-floor.md`.
- Runtime, not just build: the built site was served and `/examples/essentials/counter` returned 200 with the pinned map present in the chunk it loads; under `react-router dev`, `/@vite/env` injects `__SANDBOX_DEPS__` with the pinned map, so the identifier resolves in the browser in dev as well as in the build (Vite skips `define` substitution for client modules in dev and injects them as globals instead - checked, because a `define`-based approach would otherwise have been dev-broken). The final in-iframe Sandpack npm install was not driven - that needs a browser, so the Pages preview is the last mile.
- Deployed preview checked on the pre-cut revision (`verify` and `Cloudflare Pages` both green): `https://fix-sandbox-pinned-deps.expressive-state.pages.dev/examples/essentials/counter` serves 200, and the `Sandbox-BNmfviwm.js` chunk it lazy-loads carries the pinned map. The cut does not change that chunk.

No changeset: website is not a published package.

The examples-payload half of H7 (eager raw-source glob, 474 KB per visitor) is not in this PR.
