### PR TITLE
test: unmask assertion diffs on State proxies, stop swallowing console.error

### DIFF
--- a/.changeset/proxy-own-is.md
+++ b/.changeset/proxy-own-is.md
@@ -1,0 +1,12 @@
+---
+"@expressive/mvc": patch
+---
+
+Tracking proxies now carry `is` as an own writable property.
+
+Value is unchanged - `is` still resolves to the subject instance - but the
+property no longer comes from the non-writable one on the instance. Test runners
+that diff a proxy (the value handed to effects and renders) against a State
+crashed while building the diff: vitest clones both sides through the prototype
+chain and assigns onto the clone, which threw `Cannot assign to read only
+property 'is'` and replaced the real assertion failure with a TypeError.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,11 @@ await expect(state).not.toHaveUpdated();
 - `mockPromise<T>()` - controllable promise with `.resolve()` / `.reject()`
 - `mockWarn()` / `mockError()` - spy on console, auto-clear between tests
 
+`packages/mvc/test.setup.ts` also registers a serializer so State instances and
+tracking proxies print their managed values in diffs and snapshots. A spy that
+silences `console.error` must be scoped with `beforeEach`/`afterEach`, restored
+(not cleared), and asserted empty - an unexpected React warning is a failure.
+
 ### Naming Convention
 
 - Positive: `it('will create instance')`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,11 @@ await expect(state).not.toHaveUpdated();
 - `mockPromise<T>()` - controllable promise with `.resolve()` / `.reject()`
 - `mockWarn()` / `mockError()` - spy on console, auto-clear between tests
 
-`packages/mvc/test.setup.ts` also registers a serializer so State instances and
-tracking proxies print their managed values in diffs and snapshots. A spy that
-silences `console.error` must be scoped with `beforeEach`/`afterEach`, restored
-(not cleared), and asserted empty - an unexpected React warning is a failure.
+`packages/mvc/test.setup.ts` defines `toJSON` on `State.prototype` so tracking
+proxies print their managed values in assertion diffs rather than internals. A
+spy that silences `console.error` must be scoped with `beforeEach`/`afterEach`,
+restored (not cleared), and asserted empty - an unexpected React warning is a
+failure.
 
 ### Naming Convention
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@types/node": "^25.2.0",
         "@types/react": "^19",
         "@vitest/coverage-istanbul": "^4.1.10",
+        "@vitest/utils": "^4.1.10",
         "happy-dom": "^20.11.1",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^25.2.0",
     "@types/react": "^19",
     "@vitest/coverage-istanbul": "^4.1.10",
+    "@vitest/utils": "^4.1.10",
     "happy-dom": "^20.11.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"

--- a/packages/mvc/src/observable.test.ts
+++ b/packages/mvc/src/observable.test.ts
@@ -1,3 +1,5 @@
+import { printDiffOrStringify } from '@vitest/utils/diff';
+
 import { event, listener, touch, watch, observer } from './observable';
 import { set } from './field/set';
 import { def } from './field/def';
@@ -692,6 +694,40 @@ describe('observable', () => {
       expect(() => listener(test, () => {})).toThrow(
         `${test} was destroyed - cannot be rendered, watched or updated.`
       );
+    });
+  });
+
+  describe('proxy', () => {
+    class Test extends State {
+      foo = 'foo';
+    }
+
+    it('will expose is as a writable own property', () => {
+      const test = Test.new();
+
+      test.get(($) => {
+        expect(Object.getOwnPropertyDescriptor($, 'is')).toEqual({
+          value: test,
+          writable: true,
+          enumerable: false,
+          configurable: false
+        });
+      });
+    });
+
+    it('will diff against its own subject', () => {
+      const test = Test.new();
+      const other = Test.new();
+      let output: string | undefined;
+
+      other.foo = 'bar';
+
+      test.get(($) => {
+        output = printDiffOrStringify($, other, {});
+      });
+
+      expect(output).toContain('"foo": "foo"');
+      expect(output).toContain('"foo": "bar"');
     });
   });
 });

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -99,6 +99,12 @@ function observe<T extends object>(
 
   const proxy = Object.create(object) as T;
 
+  if ('is' in object)
+    Object.defineProperty(proxy, 'is', {
+      value: (object as { is?: unknown }).is,
+      writable: true
+    });
+
   return Object.defineProperty(proxy, Observing, {
     value: { callback, watching, required } as Observing
   });

--- a/packages/mvc/test.setup.ts
+++ b/packages/mvc/test.setup.ts
@@ -1,4 +1,3 @@
-import { getDefaultFormatOptions } from '@vitest/utils/diff';
 import { afterAll, afterEach, expect, vi, type MockInstance } from 'vitest';
 import { Context, State } from './src';
 import { listener } from './src/observable';
@@ -20,74 +19,17 @@ declare module 'vitest' {
 
 expect.extend({ toHaveUpdated, toHaveText });
 
-/**
- * State instances (and the tracking proxies handed to effects and renders) keep
- * their values in a private store, so the default serializer prints internals
- * instead of state. Print the class and its managed values instead.
- */
-const serializer = {
-  test: (value: unknown) => value instanceof State,
-  serialize(
-    value: State,
-    config: any,
-    indentation: string,
-    depth: number,
-    refs: unknown[],
-    printer: (
-      value: unknown,
-      config: any,
-      indentation: string,
-      depth: number,
-      refs: unknown[]
-    ) => string
-  ) {
-    const name = value.constructor.name;
+Object.defineProperty(State.prototype, 'toJSON', {
+  value: function (this: object) {
+    const output: Record<string, unknown> = {};
 
-    if (refs.includes(value)) return `[Circular ${name}]`;
+    for (let owner = this; owner; owner = Object.getPrototypeOf(owner))
+      for (const key of Object.keys(owner))
+        if (!(key in output)) output[key] = (owner as any)[key];
 
-    if (depth > config.maxDepth) return `[${name}]`;
-
-    return (
-      name +
-      ' ' +
-      printer(
-        managed(value),
-        config,
-        indentation,
-        depth,
-        refs.concat([value])
-      )
-    );
+    return output;
   }
-};
-
-/**
- * Values visible through a State - own fields, plus those a tracking proxy
- * inherits from its subject. Read from the owner to avoid registering
- * subscriptions while a value is being printed.
- */
-function managed(value: object) {
-  const output: Record<string, unknown> = {};
-
-  for (let owner = value; owner; owner = Object.getPrototypeOf(owner))
-    for (const key of Object.keys(owner))
-      if (!(key in output)) output[key] = (owner as any)[key];
-
-  return output;
-}
-
-expect.addSnapshotSerializer(serializer);
-
-// Assertion diffs use a fixed plugin list which addSnapshotSerializer does not
-// reach; the array behind getDefaultFormatOptions is that list.
-const plugins = getDefaultFormatOptions({}).plugins!;
-
-plugins.unshift(serializer);
-
-if (plugins[0] !== serializer)
-  throw new Error(
-    'Failed to register State serializer for assertion diffs - vitest internals moved.'
-  );
+});
 
 afterEach(() => Context.root.pop());
 

--- a/packages/mvc/test.setup.ts
+++ b/packages/mvc/test.setup.ts
@@ -1,3 +1,4 @@
+import { getDefaultFormatOptions } from '@vitest/utils/diff';
 import { afterAll, afterEach, expect, vi, type MockInstance } from 'vitest';
 import { Context, State } from './src';
 import { listener } from './src/observable';
@@ -18,6 +19,75 @@ declare module 'vitest' {
 }
 
 expect.extend({ toHaveUpdated, toHaveText });
+
+/**
+ * State instances (and the tracking proxies handed to effects and renders) keep
+ * their values in a private store, so the default serializer prints internals
+ * instead of state. Print the class and its managed values instead.
+ */
+const serializer = {
+  test: (value: unknown) => value instanceof State,
+  serialize(
+    value: State,
+    config: any,
+    indentation: string,
+    depth: number,
+    refs: unknown[],
+    printer: (
+      value: unknown,
+      config: any,
+      indentation: string,
+      depth: number,
+      refs: unknown[]
+    ) => string
+  ) {
+    const name = value.constructor.name;
+
+    if (refs.includes(value)) return `[Circular ${name}]`;
+
+    if (depth > config.maxDepth) return `[${name}]`;
+
+    return (
+      name +
+      ' ' +
+      printer(
+        managed(value),
+        config,
+        indentation,
+        depth,
+        refs.concat([value])
+      )
+    );
+  }
+};
+
+/**
+ * Values visible through a State - own fields, plus those a tracking proxy
+ * inherits from its subject. Read from the owner to avoid registering
+ * subscriptions while a value is being printed.
+ */
+function managed(value: object) {
+  const output: Record<string, unknown> = {};
+
+  for (let owner = value; owner; owner = Object.getPrototypeOf(owner))
+    for (const key of Object.keys(owner))
+      if (!(key in output)) output[key] = (owner as any)[key];
+
+  return output;
+}
+
+expect.addSnapshotSerializer(serializer);
+
+// Assertion diffs use a fixed plugin list which addSnapshotSerializer does not
+// reach; the array behind getDefaultFormatOptions is that list.
+const plugins = getDefaultFormatOptions({}).plugins!;
+
+plugins.unshift(serializer);
+
+if (plugins[0] !== serializer)
+  throw new Error(
+    'Failed to register State serializer for assertion diffs - vitest internals moved.'
+  );
 
 afterEach(() => Context.root.pop());
 

--- a/packages/preact/src/context.test.tsx
+++ b/packages/preact/src/context.test.tsx
@@ -1,15 +1,31 @@
 /** @jsxImportSource preact */
 import { StrictMode, Suspense } from 'preact/compat';
-import { vi, afterAll, expect, it, describe } from 'vitest';
+import {
+  vi,
+  afterEach,
+  beforeEach,
+  expect,
+  it,
+  describe,
+  type MockInstance
+} from 'vitest';
 
 import { act, render, screen } from '@testing-library/preact';
 import { State, Consumer, Context, get, Provider, set } from '.';
 import { flushMicrotasks } from '../test.setup';
 
-const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+let error: MockInstance<Console['error']>;
 
-afterAll(() => {
-  error.mockReset();
+beforeEach(() => {
+  error = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  const { calls } = error.mock;
+
+  error.mockRestore();
+
+  expect(calls).toEqual([]);
 });
 
 class Foo extends State {

--- a/packages/preact/src/state.test.tsx
+++ b/packages/preact/src/state.test.tsx
@@ -1,7 +1,15 @@
 /** @jsxImportSource preact */
 import { StrictMode, Suspense } from 'preact/compat';
 import { get, State, Provider, set } from '.';
-import { vi, expect, it, describe, afterEach, afterAll } from 'vitest';
+import {
+  vi,
+  expect,
+  it,
+  describe,
+  beforeEach,
+  afterEach,
+  type MockInstance
+} from 'vitest';
 import { act, render, renderHook, waitFor } from '@testing-library/preact';
 import { mockPromise, flushMicrotasks } from '../test.setup';
 
@@ -328,13 +336,19 @@ describe('State.use', () => {
 });
 
 describe('State.get', () => {
-  const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+  let error: MockInstance<Console['error']>;
 
-  afterEach(() => {
-    error.mockReset();
+  beforeEach(() => {
+    error = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  afterAll(() => error.mockClear());
+  afterEach(() => {
+    const { calls } = error.mock;
+
+    error.mockRestore();
+
+    expect(calls).toEqual([]);
+  });
 
   it('will fetch model', () => {
     class Test extends State {}

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -1,15 +1,31 @@
 import React, { Suspense } from 'react';
 import { renderToString } from 'react-dom/server';
-import { vi, afterAll, expect, it, describe } from 'vitest';
+import {
+  vi,
+  afterEach,
+  beforeEach,
+  expect,
+  it,
+  describe,
+  type MockInstance
+} from 'vitest';
 
 import { act, render, screen } from '@testing-library/react';
 import { State, Consumer, Context, get, Provider, set } from '.';
 import { flushMicrotasks } from '../test.setup';
 
-const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+let error: MockInstance<Console['error']>;
 
-afterAll(() => {
-  error.mockReset();
+beforeEach(() => {
+  error = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  const { calls } = error.mock;
+
+  error.mockRestore();
+
+  expect(calls).toEqual([]);
 });
 
 class Foo extends State {

--- a/packages/react/src/state.get.test.tsx
+++ b/packages/react/src/state.get.test.tsx
@@ -1,6 +1,14 @@
 import React, { Suspense } from 'react';
 import { Component, Context, get, State, Provider, set, transition } from '.';
-import { vi, expect, it, describe, beforeEach, afterEach, afterAll } from 'vitest';
+import {
+  vi,
+  expect,
+  it,
+  describe,
+  beforeEach,
+  afterEach,
+  type MockInstance
+} from 'vitest';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { mockPromise, flushMicrotasks } from '../test.setup';
 import { Runtime } from './runtime';
@@ -16,14 +24,19 @@ function renderWith<T>(Type: State.Type | State, hook: () => T) {
 }
 
 describe('State.get', () => {
-  const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+  let error: MockInstance<Console['error']>;
 
-  afterEach(() => {
-    // expect(error).not.toBeCalled();
-    error.mockReset();
+  beforeEach(() => {
+    error = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  afterAll(() => error.mockClear());
+  afterEach(() => {
+    const { calls } = error.mock;
+
+    error.mockRestore();
+
+    expect(calls).toEqual([]);
+  });
 
   it('will fetch model', () => {
     class Test extends State {}


### PR DESCRIPTION
Fixes the H3 test-infrastructure pair from the 2026-08-03 followups audit. Both defects hid signal; the second is a prerequisite for verifying the React render-attempt subscription-leak campaign (H14).

## 1 - Assertion diffs involving a tracking proxy crashed

A failing assertion between a tracking proxy (the value handed to effects and renders) and a State instance reported `TypeError: Cannot assign to read only property 'is'` instead of the diff.

Mechanism, traced through vitest 4.1.10:

- `printDiffOrStringify` deep-clones both sides via `@vitest/utils` `deepClone`. A proxy is `Object.create(subject)`, so its clone is `Object.create(subject)` too - `is` is not an own property and stays inherited from the instance, where `state.ts:214` defines it non-writable.
- `replaceAsymmetricMatcher` then does `actual[key] = ...` for every own key of the expected side. `is` is an own key of any State instance, so the assignment hits the non-writable inherited property and throws - before any formatting happens.

Two consequences for the fix:

- **A serializer alone cannot fix this.** The crash precedes formatting entirely. Verified by keeping the serializer and reverting the source change: the TypeError comes straight back.
- So `observe()` now defines `is` as an own writable property on the proxy, with the same value (`subject.is`). Non-enumerable, so nothing that enumerates a proxy changes. A shadowing assignment on a derived object now creates an own property instead of throwing. Patch changeset included - it is a (tiny) behavior change that fixes a crash any downstream consumer's test suite can hit.

With the crash gone, the diff was still useless: State values live in a private store, and a proxy has no own value properties at all, so pretty-format printed only internals (`Symbol(Observer)`).

`packages/mvc/test.setup.ts` therefore defines `toJSON` on `State.prototype`, gathering values from the prototype chain and reading from the owner so printing never registers a subscription. pretty-format honors `toJSON`, so this reaches the assertion-diff path with no dependency on vitest internals. `observable.test.ts` pins the end-to-end result: a proxy-vs-subject diff contains both values.

An earlier revision of this branch instead registered a pretty-format serializer and pushed it onto the plugin array behind the exported `getDefaultFormatOptions`, because `expect.addSnapshotSerializer` does not reach assertion diffs. That reached into undocumented vitest internals and would break on a bump. Measured, both claims held - `addSnapshotSerializer` alone regresses the diff straight back to `Symbol(Observer)` - but `toJSON` gets the same result without the internals, so the serializer and its guard-throw are gone. The snapshot half went with it: no suite uses `toMatchSnapshot` or `JSON.stringify`, so it served nothing.

Cost of the swap: diffs lose the `Test {` class-name prefix. `toJSON` on the prototype is also a small test/prod divergence in `JSON.stringify` behavior, currently unexercised.

Before:

```
TypeError: Cannot assign to read only property 'is' of object '[object Object]'
```

After:

```
  {
-   "foo": "bar",
+   "foo": "foo",
  }
```

## 2 - console.error swallowed suite-wide

`state.get.test.tsx:19` installed the spy at collection time, `afterEach` used `mockReset`, `afterAll` used `mockClear` (never `mockRestore`), and the assertion that would have caught unexpected warnings was commented out. Silence therefore leaked into the four later top-level describes in that file.

The same pattern was in three sibling suites, all with no assertion at all: `packages/react/src/context.test.tsx`, `packages/preact/src/context.test.tsx`, `packages/preact/src/state.test.tsx`.

All four now spy per test in `beforeEach`, and in `afterEach` capture the calls, `mockRestore`, then assert the calls are empty - so an unexpected React warning fails the test that produced it and the spy cannot leak past it.

### What surfaced: nothing

Honest result: at this HEAD, un-commenting the assertion and un-scoping the spies surfaced **zero** previously-swallowed warnings. The whole suite is green with no stderr output. The hole was real, but currently empty - nothing had to be scoped narrowly, and no adapter defect is being reported out of this.

Because "nothing found" is only meaningful if the guard can fire, both were verified against deliberate probes (removed again before commit):

- A scratch `console.error` inside the guarded describe fails the test with the expected diff.
- React warnings do reach `console.error` in this environment (happy-dom + React 19): a missing-`key` render produced one call, and a render error caught by an error boundary produced one call.

Known limit, not addressed here: `@testing-library` `cleanup()` runs in the package-level `afterEach`, which is outer, so it runs *after* these assertions - warnings emitted during unmount still print but do not fail.

## Verification

`bun run test` green across all four packages, coverage at 100% statements/branches/functions/lines everywhere. `bun run build` clean.

Re-verified after rebasing onto `main` (through #315). The one conflict was an import block in `packages/react/src/context.test.tsx` - #309 added the `react-dom/server` import beside the vitest import this branch rewrote; both kept. #309's new SSR tests do not trip the new zero-`console.error` guard.


