### PR TITLE
chore(ci): invoke .github/scripts directly instead of via package scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,11 +2,12 @@
 
 ## pr.yml (pull requests -> main)
 
-Blocking: `bun run test`, `bun run build` and `bun run dist` (static invariants
+Blocking: `bun run test`, `bun run build` and `dist-check.ts` (static invariants
 on the emitted dist - relative specifiers resolve, side-effect imports are
-declared). The frozen-lockfile install in the `setup` action doubles as the
-internal-dependency desync guard - a workspace version that falls outside a
-sibling's range cannot reach main.
+declared). Steps backed by a script under `.github/scripts` invoke it directly;
+only workspace-wide commands are `package.json` entries. The frozen-lockfile
+install in the `setup` action doubles as the internal-dependency desync guard -
+a workspace version that falls outside a sibling's range cannot reach main.
 
 Non-blocking signals: `changeset status` (a preview of which packages would
 bump) and `npm publish --dry-run` pack validation for the publishable packages.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,14 +24,14 @@ jobs:
       - run: bun run build
 
       - name: Dist is consumable
-        run: bun run dist
+        run: bun .github/scripts/dist-check.ts
 
       - name: Bundle size
         continue-on-error: true
-        run: bun run size
+        run: bun .github/scripts/size-limit.ts
 
       - name: Docs agree with code
-        run: bun run docs
+        run: bun .github/scripts/docs-check.ts
 
       - name: Changeset reminder
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -10,15 +10,12 @@
   "scripts": {
     "test": "bun run --filter='./packages/*' test",
     "build": "bun run --filter='./packages/*' build",
-    "build:site": "bun run build && bun run size && bun run --filter website build",
+    "build:site": "bun run build && bun .github/scripts/size-limit.ts && bun run --filter website build",
     "changeset": "changeset",
     "wrap": "changeset",
     "ci:version": "changeset version && bun install",
     "ci:publish": "bun run --filter='./packages/*' build && changeset publish",
     "pr": "bash .github/scripts/pr.sh",
-    "size": "bun .github/scripts/size-limit.ts",
-    "dist": "bun .github/scripts/dist-check.ts",
-    "docs": "bun .github/scripts/docs-check.ts",
     "tunnel": "cloudflared tunnel --no-autoupdate ${TUNNEL_NAME:+run} --url http://localhost:5173 ${TUNNEL_NAME:-}",
     "watch": "bun test --watch --only-failures",
     "nuke": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +"


### PR DESCRIPTION
Settles the followup filed during #308 review: `.github/scripts/*` was reachable
two different ways and neither was the convention.

## Before

- `pr.yml` ran `bun run size`, `bun run dist`, `bun run docs` — through
  `package.json` wrappers.
- `coverage.yml` ran `bun .github/scripts/coverage-badge.ts` — directly, no
  wrapper.

## After

Steps backed by a script under `.github/scripts` invoke it directly. The `size`,
`dist` and `docs` entries are gone; `coverage.yml` is unchanged and is now the
pattern rather than the exception.

Kept deliberately:

- **`pr`** (`bash .github/scripts/pr.sh`) — no CI caller. It exists only as a
  local command, so the entry is the only way it is invoked.
- **`build:site`** — this is the site's build command, not a CI step wrapper. It
  keeps its entry and inlines the size-limit path, since dropping the `size`
  wrapper is what made the chain need updating.

Nothing else in the repo referenced the removed names (`grep` over json/yml/md,
excluding build output).

## Verified

Each script driven directly after `bun install --frozen-lockfile` and
`bun run build`, which is the state `pr.yml` invokes them in:

- `dist-check.ts` → `All relative specifiers resolve; side-effect imports are declared.`
- `docs-check.ts` → `Checked 50 documents. Every documented symbol is exported and every internal link resolves.`
- `size-limit.ts` → runs and reports all seven shapes.

## Note, unrelated to this PR

`size-limit.ts` currently **fails on `main`**: `react: State only` measures
7.92 kB against a 7.91 kB budget, ~10 bytes over, most likely from #305 and #309
landing. The step is `continue-on-error: true`, so it does not block, but this
PR's own CI will show the `Bundle size` step red for that pre-existing reason —
it is not caused by the invocation change (this diff touches no package source).
Filed separately; the call is whether to raise the budget and update the figures
quoted in `website/content/docs/guides/bundle-size.mdx`, or trim the shape back
under.

No changeset: CI wiring only, no published package affected.
