### PR TITLE
chore(ci): raise the react State-only budget to 8 kB

### DIFF
--- a/.github/scripts/size-limit.ts
+++ b/.github/scripts/size-limit.ts
@@ -11,7 +11,9 @@ import { withWorkspaceLinks } from './workspace-links';
  * Each carries ~3.5% headroom over the measured figure, because CI does not pin
  * a Bun version and minifier output drifts a little between them - measured at
  * <=0.5% across 1.3.1 and 1.3.14, so the margin is mostly slack. Real growth is
- * structural and clears it; toolchain drift does not.
+ * structural and clears it; toolchain drift does not. The react floor is the
+ * exception: pinned to a round 8 kB, so ~1% - still above observed drift, but it
+ * will flag sooner than the rest.
  */
 const CASES = [
   {
@@ -26,7 +28,7 @@ const CASES = [
   },
   {
     name: 'react: State only',
-    limit: 8100,
+    limit: 8192,
     code: `import State from '@expressive/react'; console.log(State);`
   },
   {

--- a/website/content/docs/guides/bundle-size.mdx
+++ b/website/content/docs/guides/bundle-size.mdx
@@ -13,13 +13,13 @@ Minified, then gzipped. React is a peer dependency and excluded, as it would alr
 | --- | --- |
 | `@expressive/mvc` — `State` only (headless) | ~4.6 kB |
 | `@expressive/mvc` — every export | ~8.0 kB |
-| `@expressive/react` — `State` only | ~7.6 kB |
-| `@expressive/react` — `State`, `Component`, instructions | ~8.2 kB |
-| `@expressive/react` — every export | ~10.4 kB |
-| `@expressive/router` — every export | ~10.1 kB |
-| `@expressive/react` + `@expressive/router` | ~13.7 kB |
+| `@expressive/react` — `State` only | ~7.9 kB |
+| `@expressive/react` — `State`, `Component`, instructions | ~8.5 kB |
+| `@expressive/react` — every export | ~10.5 kB |
+| `@expressive/router` — every export | ~10.3 kB |
+| `@expressive/react` + `@expressive/router` | ~13.9 kB |
 
-A typical React app lands around **8 kB**. There are no runtime dependencies, so that is the whole cost — nothing else arrives behind it.
+A typical React app lands around **8.5 kB**. There are no runtime dependencies, so that is the whole cost — nothing else arrives behind it.
 
 ## Methodology, and why the numbers differ elsewhere
 
@@ -35,14 +35,14 @@ If a third-party size service quotes something different from this table, the me
 
 The headless core shakes properly: importing only `State` costs ~4.6 kB against ~8.0 kB for everything, so unused instructions genuinely do not ship. It is built unbundled — one module per source file, `sideEffects: false` — and its module-level work only touches classes the same module exports, which is what makes that declaration safe.
 
-The React adapter has a **floor you cannot shake below: ~7.6 kB**, reached by importing anything at all from it. That is deliberate and worth being plain about. The adapter works by patching types it does not own, at import time:
+The React adapter has a **floor you cannot shake below: ~7.9 kB**, reached by importing anything at all from it. That is deliberate and worth being plain about. The adapter works by patching types it does not own, at import time:
 
 - `Component.prototype.$$typeof`, so an instance can be placed directly as JSX
 - `Component.contextType`, wiring the class into React context
 - `isReactComponent`, so React treats it as a class component
 - the host runtime registry, which hands the core its renderer
 
-Cross-package prototype patches cannot be tree-shaken away without breaking the library, so the wiring arrives whole or not at all. Above the floor, shaking resumes normally — `has`, `map` and `transition` together account for the remaining ~1.9 kB and drop out when unused.
+Cross-package prototype patches cannot be tree-shaken away without breaking the library, so the wiring arrives whole or not at all. Above the floor, shaking resumes normally — `has`, `map` and `transition` together account for the remaining ~2.6 kB and drop out when unused.
 
 The practical consequence: Expressive rewards using more of what you have already paid for, and is a poor fit for shipping one tiny piece of it into an otherwise dependency-free bundle.
 

--- a/website/content/docs/guides/packaging.mdx
+++ b/website/content/docs/guides/packaging.mdx
@@ -27,7 +27,7 @@ A component library or shared package built on Expressive should **not** bundle 
 - Mark `@expressive/*` external in your build, so your dist imports it rather than inlining a private copy - an inlined copy is the two-worlds problem above, shipped on purpose.
 - Keep the peer range wide (`^` on the minor you develop against, pre-1.0) and move it deliberately: pre-1.0 minors are the breaking channel.
 
-Consumers of your library install `@expressive/react` themselves - the same contract as `react` itself. What that costs them: the adapter has an irreducible floor of about 7.6 kB min+gzip (measured, budgeted in CI - see [Bundle size](/docs/guides/bundle-size)), paid once per application regardless of how many libraries share it.
+Consumers of your library install `@expressive/react` themselves - the same contract as `react` itself. What that costs them: the adapter has an irreducible floor of about 7.9 kB min+gzip (measured, budgeted in CI - see [Bundle size](/docs/guides/bundle-size)), paid once per application regardless of how many libraries share it.
 
 State classes your library exports are ordinary exports. Subclassing, `Provider`-ing, and `get()`-ing them works across package boundaries because everyone resolves the same core - which is the point of the rules above.
 

--- a/website/content/docs/why-classes.mdx
+++ b/website/content/docs/why-classes.mdx
@@ -208,7 +208,7 @@ To be honest about the trade-off:
 
 - **`this`** - you have to use it. If your team has a strict "functional only" rule, Expressive isn't for you.
 - **A runtime footprint** - reactive proxies, lifecycle tracking, context management: ~8 kB min+gzip for a typical app, ~10 kB with every export used ([measured and CI-gated](/docs/guides/bundle-size)). Tracked reads are proxy reads during render; reads in handlers or through `is` subscribe nothing. Measurable, not zero.
-- **An adapter floor you cannot tree-shake** - the React adapter works by patching things it does not own at import: `Component.prototype`, `contextType`, `isReactComponent`, the host runtime registry. Cross-package prototype patches cannot be shaken away, so importing anything from `@expressive/react` costs ~7.6 kB before your first field. The headless core does shake properly (~4.6 kB for `State` alone, ~8 kB for all of it).
+- **An adapter floor you cannot tree-shake** - the React adapter works by patching things it does not own at import: `Component.prototype`, `contextType`, `isReactComponent`, the host runtime registry. Cross-package prototype patches cannot be shaken away, so importing anything from `@expressive/react` costs ~7.9 kB before your first field. The headless core does shake properly (~4.6 kB for `State` alone, ~8 kB for all of it).
 - **Familiarity for new hires** - engineers used to Redux or Zustand will need a brief ramp-up on classes and instructions.
 
 Expressive does not try to replace hooks wholesale. It coexists. Use `useState` where it's fine; reach for a class where the complexity justifies it.


### PR DESCRIPTION
Clears the red `Bundle size` step on `main`.

## The failure

```
react: State only          7.92 kB /   7.91 kB  FAIL
error: Bundle size regressed:
  react: State only: 7.92 kB exceeds budget 7.91 kB
```

Ten bytes over, from #305 (`subcomponents` setter + promotion) and #309 (upstream
guard in `state.get.ts`) landing. Both are correctness fixes worth keeping, so the
budget absorbs them.

## Change

`react: State only` → **8192 bytes**, which the report prints as exactly
`8.00 kB`. A round ceiling rather than a high-water mark two bytes above whatever
was last measured.

The file's header claims every budget carries ~3.5% headroom over measured, since
CI does not pin a Bun version and minifier output drifts (observed ≤0.5%). At 8 kB
this shape carries ~1%, so the comment now says so — still above observed drift,
but it will flag sooner than the others. That is the tradeoff of a round number
and seemed worth stating in the file rather than leaving the comment false.

## Docs

`size-limit.ts`'s own error message says to update the figures quoted in the
docs. Doing that surfaced that the react floor was stale in three places
independently of this bump — quoted at **~7.6 kB** while it measures 7.92 kB:

- `guides/bundle-size.mdx` — the import-shape table (5 rows), the "typical React
  app" figure (8 kB → 8.5 kB), the floor callout, and the above-the-floor
  remainder (`has`/`map`/`transition`: ~1.9 kB → ~2.6 kB, which is
  `everything − floor` and moved with the floor)
- `guides/packaging.mdx` — the irreducible-floor figure
- `why-classes.mdx` — the same floor, quoted in the tradeoffs section

Every number now matches a measured shape. `mvc: State only` (~4.6 kB) and
`mvc: everything` (~8.0 kB) were already correct and are untouched.

## Verified

- `bun .github/scripts/size-limit.ts` → all seven shapes `ok`, exit 0.
- `bun .github/scripts/docs-check.ts` → `Checked 50 documents. Every documented symbol is exported and every internal link resolves.`
- No `7.6 kB` or `1.9 kB` occurrences left under `website/`, `skills/`, or `README.md`.

No changeset: CI budget and docs prose, no published package changed.
