### PR TITLE
ci(size): annotate a budget breach so the advisory step is visible

### DIFF
--- a/.github/scripts/size-limit.ts
+++ b/.github/scripts/size-limit.ts
@@ -1,5 +1,6 @@
 import { gzipSync } from 'bun';
 import { mkdirSync, rmSync } from 'node:fs';
+import { appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { withWorkspaceLinks } from './workspace-links';
 
@@ -106,9 +107,17 @@ await Bun.write(
   JSON.stringify(Object.fromEntries(results.map(({ name, bytes }) => [name, bytes])), null, 2)
 );
 
-// Surfaced on the run's summary page so growth is visible without opening logs.
+// Advisory step (`continue-on-error`), so a breach cannot rely on a red check to
+// be seen - the annotation reaches the PR's Checks tab, the table the run page.
+if (over.length)
+  console.log(
+    `::warning title=Bundle size::` +
+    over.map(({ name, bytes, limit }) =>
+      `${name} is ${kb(bytes)}, over its ${kb(limit)} budget`).join('; ')
+  );
+
 if (process.env.GITHUB_STEP_SUMMARY)
-  await Bun.write(
+  await appendFile(
     process.env.GITHUB_STEP_SUMMARY,
     [
       '## Bundle size',
@@ -121,7 +130,8 @@ if (process.env.GITHUB_STEP_SUMMARY)
       '',
       over.length
         ? `${over.length} shape(s) over budget. Advisory - raise budgets in \`.github/scripts/size-limit.ts\` if intended.`
-        : 'All shapes within budget.'
+        : 'All shapes within budget.',
+      ''
     ].join('\n')
   );
 


### PR DESCRIPTION
Follow-on to #314. The budget breach it fixed had been on `main` for several
merges without anyone noticing, and this is why.

## What actually happened

`Bundle size` is `continue-on-error: true`. GitHub reports that step as
`conclusion: success` even when the script exits non-zero — confirmed against the
run for #313:

```
$ gh api .../actions/runs/30879485467/jobs --jq '.jobs[0].steps[] | ...'
Bundle size: success
```

while the log for that same green step read:

```
react: State only          7.94 kB /   7.91 kB  FAIL
error: Bundle size regressed:
  react: State only: 7.94 kB exceeds budget 7.91 kB
```

The script does already write a summary table with a `:warning:` on the offending
row, so this was not literally silent — but the only signals were a table on the
run page and a log line, both behind opening the run. Nothing appeared on the PR.

## Change

- **`::warning title=Bundle size::` when over budget.** Annotations surface on the
  PR's Checks tab without opening the run, and do not depend on the step's
  conclusion, so the advisory semantics are preserved — no new blocking gate.
- **Summary write switches `Bun.write` → `appendFile`.** `GITHUB_STEP_SUMMARY` is
  one file per *job*, not per step, so `Bun.write` truncated anything an earlier
  step had contributed. Nothing else writes to it in `pr.yml` today, so this was
  latent rather than active. A trailing newline terminates the block so a later
  step's content cannot run into the table.

Deliberately not changed: the step stays advisory. Making it blocking would let
toolchain drift block unrelated PRs, and CI measures ~20 bytes above local
(7.94 vs 7.92 kB, since CI does not pin a Bun version), so the margin that
absorbs drift is exactly what a blocking gate would spend.

## Verified

Both paths driven locally with a real `GITHUB_STEP_SUMMARY` file seeded with
prior content.

Within budget — prior content intact, table appended:

```
## Earlier step

some prior summary content
## Bundle size
...
| react: State only | 7.92 kB | 8.00 kB |
...
All shapes within budget.
```

Over budget (budget temporarily forced to 6.84 kB) — annotation emitted on
stdout, where the Actions runner picks it up:

```
react: State only          7.92 kB /   6.84 kB  FAIL
::warning title=Bundle size::react: State only is 7.92 kB, over its 6.84 kB budget
  react: State only: 7.92 kB exceeds budget 6.84 kB
```

The annotation itself renders only on GitHub, so its appearance on the Checks tab
is unverified until this PR's own run — nothing is over budget on `main`, so this
PR will not produce one. That is the last mile and I am stating it rather than
claiming it works.

No changeset: CI script only.
