### PR TITLE
docs: document the followup board's status ladder and priority

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,36 @@ gh project item-create 6 --owner gabeklein --title "..." --body "$(cat note.md)"
 
 Requires `gh auth refresh -s project` (`read:project` can list but not create). `item-create` prints nothing and exits 0 on success, and `item-list`'s table output silently drops rows - verify with `gh project item-list 6 --owner gabeklein --format json`, where bodies live under `content.body`, not top-level `body`. Re-running a create that looked like it failed duplicates the item.
 
+A draft has no open/closed state, so `Status` is the board's only progression signal. Set it on create and move it as the item advances - an unset item is invisible. Four states, deliberately no `Ready` or `In progress`: work here goes from picked-up to PR in minutes, so those columns only ever held stale rows.
+
+| Status | Option id | Means |
+| --- | --- | --- |
+| `Issues` | `ad4b7e6a` | Bugs - a defect in current behavior, wants attention now |
+| `Backlog` | `95f4fe41` | Known but not pressing - features, chores, docs, open questions |
+| `In review` | `d4e312b2` | Has an open PR |
+| `Done` | `dbd6afac` | Merged |
+
+The split is defect versus not-pressing, so a bug files into `Issues` however well diagnosed it is, and a missing capability files into `Backlog` however sharply it bit. Move to `Done` in the same pass that lands the fix. Residual open questions on a resolved finding get their own item rather than holding the original open.
+
+Set `Priority` (field `PVTSSF_lAHOAQ6js84BewtBzhZIhgI`) alongside it. Judge by consequence, not by how interesting the finding is:
+
+| Priority | Option id | Means |
+| --- | --- | --- |
+| `P0` | `79628723` | Breaks a documented or ordinary path with no workaround, or blocks other work |
+| `P1` | `0a877460` | Real but survivable - a workaround exists, or a consumer is waiting |
+| `P2` | `da944a9c` | Latent, low-impact, speculative, or a decision record |
+
+Record the PR in the item body, since `Linked pull requests` is populated by GitHub for real issues and cannot be set on a draft. `In review` items carry an **Open PR:** line; `Done` items carry a **Resolved by** line naming the PR and what it actually changed, which is what makes the board auditable later without re-deriving the fix from git.
+
+```bash
+gh project item-edit --id "$ITEM" \
+  --project-id PVT_kwHOAQ6js84BewtB \
+  --field-id PVTSSF_lAHOAQ6js84BewtBzhZIhUI \
+  --single-select-option-id dbd6afac
+```
+
+Item ids come from `gh project item-list 6 --owner gabeklein --format json`. Do not edit the option set with `updateProjectV2Field` - `singleSelectOptions` has no `id` input, so a write replaces every option and silently clears every item's `Status`.
+
 ## Guardrails
 
 - Don't modify `packages/mvc` to fix React-only concerns - use adapter packages.


### PR DESCRIPTION
## Why

Every one of the 74 items on the **MVC Followups** board was sitting in `To triage`, including a dozen whose findings had already been fixed and merged. The cause is structural: a draft issue has no open/closed state, so `Status` is the only progression signal the board has - and the followup recipe in AGENTS.md never mentioned it. Items were filed correctly and then never moved, because nothing told anyone to move them.

## Board changes (already applied, no code here)

- `Ready` and `In progress` deleted - work here goes from picked-up to PR in minutes, so those columns only held stale rows.
- `To triage` renamed **Issues**: bugs, a defect in current behavior. `Backlog`: known but not pressing. `In review`: has an open PR. `Done`: merged.
- All 77 items classified: **Issues 23 · Backlog 34 · In review 9 · Done 11**, each Done verified against `origin/main` rather than taken from the item's own text.
- Two residual items filed for open questions left behind by resolved findings (the Context seam #309 left, and dev-mode detection for the `fallback={false}` retry loop).

## This diff

Documents the ladder, the three priorities, and two things learned the hard way:

- The linked-PR field cannot be set on a draft, so a PR has to be named in the body - **Open PR:** on `In review`, **Resolved by** on `Done`.
- `updateProjectV2Field` is the only way to edit an option set (`gh` has no `field-edit`), and because `singleSelectOptions` takes no option `id`, every write replaces all options and silently clears every item's `Status`. Hit twice while doing this; all 77 assignments had to be reapplied both times.

## Not addressed

The ladder has no **won't-do / decision-record** state, and two items are currently in `Backlog` pretending to be pending work: the Version-PR approval note ("decided to leave as-is"), and the size-limit item whose fix merged but whose lesson about `continue-on-error` outlives it. Worth a fifth option, deliberately left for a separate decision.