### PR TITLE
ci: execute the packed dist before publishing

### DIFF
--- a/.github/scripts/dist-smoke.ts
+++ b/.github/scripts/dist-smoke.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+/**
+ * Pack every publishable package, install the tarballs into a throwaway project
+ * outside the repo, and execute the result under native Node ESM. Nothing else
+ * in CI resolves the built dist the way a consumer does: vitest aliases the
+ * scope onto sources, and `npm publish --dry-run` runs no code at all.
+ *
+ * Runs from `ci:publish`, so it gates the publish itself rather than every merge.
+ */
+const PACKAGES = ['mvc', 'react', 'router'];
+
+const PROBES: Record<string, string> = {
+  mvc: `
+import assert from 'node:assert/strict';
+import State from '@expressive/mvc';
+
+class Store extends State {
+  count = 0;
+  get double() { return this.count * 2 }
+}
+
+const store = Store.new();
+const seen = [];
+
+store.get(({ count }) => { seen.push(count) });
+
+store.count = 2;
+
+const update = await store.set();
+
+assert.deepEqual(update, ['count']);
+assert.equal(store.double, 4);
+assert.deepEqual(seen, [0, 2]);
+
+store.set(null);
+
+console.log('mvc: State round-trip ok');
+`,
+  react: `
+import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import State, { Component, Provider, Consumer, get, set, ref, def, has, map } from '@expressive/react';
+
+for (const [name, value] of Object.entries({ State, Component, Provider, Consumer, get, set, ref, def, has, map }))
+  assert.equal(typeof value, 'function', name + ' is not exported by the built dist');
+
+class Counter extends State {
+  value = 5;
+}
+
+const View = () => createElement('span', null, Counter.use().value);
+
+assert.equal(renderToStaticMarkup(createElement(View)), '<span>5</span>');
+
+class Widget extends Component {
+  label = 'unset';
+
+  render() {
+    return createElement('b', null, this.label);
+  }
+}
+
+assert.equal(
+  renderToStaticMarkup(createElement(Widget, { label: 'patched' })),
+  '<b>patched</b>'
+);
+
+console.log('react: hook render + Component render ok');
+`,
+  router: `
+import assert from 'node:assert/strict';
+import { Router, BrowserRouter, Route, Link, Redirect, NavLinks, matchPattern } from '@expressive/router';
+
+for (const [name, value] of Object.entries({ Router, BrowserRouter, Route, Link, Redirect, NavLinks, matchPattern }))
+  assert.equal(typeof value, 'function', name + ' is not exported by the built dist');
+
+assert.deepEqual(matchPattern('/user/:id', '/user/42').params, { id: '42' });
+
+console.log('router: import shape ok');
+`
+};
+
+function run(cmd: string[], cwd: string) {
+  const { exitCode, stdout, stderr } = Bun.spawnSync(cmd, { cwd, stdout: 'pipe', stderr: 'pipe' });
+  const out = stdout.toString();
+  const err = stderr.toString();
+
+  if (exitCode !== 0)
+    throw new Error(`\`${cmd.join(' ')}\` failed in ${cwd}:\n${out}\n${err}`);
+
+  return out;
+}
+
+const fixture = mkdtempSync(join(tmpdir(), 'expressive-dist-smoke-'));
+const tarballs: Record<string, string> = {};
+
+try {
+  for (const name of PACKAGES) {
+    const packed = run(
+      ['npm', 'pack', '--json', '--pack-destination', fixture],
+      resolve('packages', name)
+    );
+    const [{ filename }] = JSON.parse(packed);
+
+    tarballs[`@expressive/${name}`] = `file:./${filename}`;
+    console.log(`packed @expressive/${name} -> ${filename}`);
+  }
+
+  writeFileSync(
+    join(fixture, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'dist-smoke',
+        version: '0.0.0',
+        private: true,
+        type: 'module',
+        dependencies: { ...tarballs, react: '^19', 'react-dom': '^19' },
+        overrides: tarballs
+      },
+      null,
+      2
+    )
+  );
+
+  run(['npm', 'install', '--no-audit', '--no-fund', '--loglevel=error'], fixture);
+
+  for (const [name, source] of Object.entries(PROBES)) {
+    const probe = `probe.${name}.mjs`;
+
+    writeFileSync(join(fixture, probe), source);
+    process.stdout.write(run(['node', probe], fixture));
+  }
+} catch (error) {
+  console.error(`Fixture kept for inspection: ${fixture}`);
+  throw error;
+}
+
+rmSync(fixture, { recursive: true, force: true });
+
+console.log('\nPublished dist imports and executes under Node ESM.');

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,7 +16,13 @@ bump) and `npm publish --dry-run` pack validation for the publishable packages.
 
 `changesets/action` maintains the "Version Packages" PR (`changeset version`
 + `bun install` so the lockfile stays consistent with the bumps). Merging that
-PR builds the packages and runs `changeset publish`.
+PR builds the packages, runs `dist-smoke.ts`, then `changeset publish`.
+
+`dist-smoke.ts` packs each publishable package, installs the tarballs into a
+throwaway project outside the repo and executes them under native Node ESM - the
+only consumer-shaped check of the built dist, since tests alias the `@expressive`
+scope onto sources. It sits in `ci:publish` rather than `pr.yml` so a failure
+blocks the publish, and ordinary merges pay nothing for it.
 
 Publishing authenticates via npm OIDC trusted publishing - no token secrets.
 Each published package's npm settings trust this exact workflow filename under

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "changeset": "changeset",
     "wrap": "changeset",
     "ci:version": "changeset version && bun install",
-    "ci:publish": "bun run --filter='./packages/*' build && changeset publish",
+    "ci:publish": "bun run --filter='./packages/*' build && bun .github/scripts/dist-smoke.ts && changeset publish",
     "pr": "bash .github/scripts/pr.sh",
     "tunnel": "cloudflared tunnel --no-autoupdate ${TUNNEL_NAME:+run} --url http://localhost:5173 ${TUNNEL_NAME:-}",
     "watch": "bun test --watch --only-failures",


### PR DESCRIPTION
Closes the standing "no in-repo consumer exercises the published dist" gap. Carved
out of #308 during review, reworked to gate the publish instead of every PR.

## Why

`@expressive/react` 0.84.1 shipped an extensionless specifier and could not be
imported by native Node ESM (#308). Nothing in CI would have caught it as a
*consumer*: `bun run test` aliases the `@expressive` scope onto sources, and the
`npm publish --dry-run` pack step executes no code. #308's `dist-check.ts` catches
that particular bug statically, but nothing runs the tarball.

## What runs

`.github/scripts/dist-smoke.ts` packs mvc, react and router, installs the tarballs
into an `mkdtemp` project outside the repo (`overrides` so the internal
`@expressive/mvc` dep resolves to the local tarball, not the registry), then
executes a probe per package under `node`:

- **mvc** — construct a `State`, mutate, `await state.set()`, assert the update
  payload, a computed getter, and an effect's observed sequence.
- **react** — assert every export is live, then `renderToStaticMarkup` both a
  `State.use()` hook render and a `Component` subclass render. The Component path
  exercises the prototype patches in the side-effect chunks, so it covers the #296
  concern at runtime rather than only via `sideEffects` globs.
- **router** — import shape plus a `matchPattern` round-trip; strictly
  client-side, so nothing is instantiated.

## Where it is wired, and why not `pr.yml`

```json
"ci:publish": "bun run --filter='./packages/*' build && bun .github/scripts/dist-smoke.ts && changeset publish"
```

`changesets/action` invokes `ci:publish` only on the publish path, which makes this
the precise seam:

- A failure **blocks the publish** rather than reporting after the fact.
- Ordinary merges and PRs pay nothing — no registry traffic, no second toolchain,
  no added minutes.
- `release.yml` already sets up Node, so no new workflow steps at all.
- Re-running a failed release is safe: `changeset publish` skips versions already
  on the registry, as the workflows README documents.

The earlier revision on the abandoned branch put it in `pr.yml` as a blocking step
with an unpinned `npm install` of `react`/`react-dom` on every PR. That was
rejected in review — a blocking gate with an unpinned network dependency
eventually reds a PR for reasons unrelated to its diff.

## Also changed from that revision

`finally { rmSync(fixture) }` deleted the temp project on failure, so the one time
it fired there was nothing left to inspect. It now keeps the fixture and names it:

```
Fixture kept for inspection: /var/folders/.../expressive-dist-smoke-gpzbh5
```

## Verified

Both paths driven locally against a real build.

Success — exit 0:

```
packed @expressive/mvc -> expressive-mvc-0.83.1.tgz
packed @expressive/react -> expressive-react-0.84.1.tgz
packed @expressive/router -> expressive-router-0.7.0.tgz
mvc: State round-trip ok
react: hook render + Component render ok
router: import shape ok

Published dist imports and executes under Node ESM.
```

Failure — the original #308 defect reintroduced (`external: ['./adapter']`
restored), run as `dist-smoke && echo "WOULD PUBLISH"`:

```
Fixture kept for inspection: /var/folders/.../expressive-dist-smoke-gpzbh5
error: `node probe.react.mjs` failed in /var/folders/.../expressive-dist-smoke-gpzbh5:
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../@expressive/react/dist/adapter'
  code: 'ERR_MODULE_NOT_FOUND',
```

`WOULD PUBLISH` never printed — the `&&` chain stops before `changeset publish`.
The retained fixture contained the three tarballs, `node_modules` and the probes.

Not verified: the step running inside an actual release. #304 is the next publish,
so that is the first real exercise. Stating it rather than claiming it.

No changeset: CI wiring only, no published package changed.
