### PR TITLE
feat(router): transition seam - deferred presentation on navigation

### DIFF
--- a/.changeset/router-transition-seam.md
+++ b/.changeset/router-transition-seam.md
@@ -1,0 +1,5 @@
+---
+"@expressive/router": minor
+---
+
+Navigation now commits through a protected `Router.transition` seam, defaulting to the host scheduler's non-urgent bracket (React `startTransition`). In-app navigation to a page that isn't ready - a loading lazy chunk, a pending async entry guard - holds the current screen until the next is ready instead of flashing the route's `fallback`. Cold load still shows `fallback`; the URL updates immediately either way. Subclasses may override `transition(commit)` to stage the swap (e.g. View Transitions).

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -29,12 +29,13 @@ Style:
 
 ## Runtime smoke pass
 
-A page that type-checks and builds can still be broken. Run every new or edited batch through a throwaway harness, then delete the file before committing (this package ships no test script):
+A page that type-checks and builds can still be broken. Run every new or edited batch through a throwaway harness, then delete both files before committing (this package ships no test script):
 
 ```bash
-cd examples && bun test --preload ../packages/react/test.dom.ts smoke.test.tsx
+cd examples && bun test --preload ./smoke.dom.ts smoke.test.tsx
 ```
 
+- `smoke.dom.ts` is a two-line throwaway: import `GlobalRegistrator` from `@happy-dom/global-registrator` and `register()` it, so `document` exists before `@testing-library/*` evaluates. (The old `packages/react/test.dom.ts` preload was deleted in the vitest migration.)
 - `import.meta.glob` is Vite-only and undefined under `bun test` - enumerate `pages/<group>/<example>/App.tsx` with `readdirSync` and `await import()` each. CSS imports resolve fine.
 - A render-only pass catches crashes, not dead reactivity. Drive interactions with `fireEvent` and assert on `container.textContent`.
 - Flush pattern: `await act(async () => fireEvent.click(x)); await settle()` where `settle = ms => act(() => new Promise(r => setTimeout(r, ms)))`. Nesting the settle *inside* the same `act` callback reports the previous render's DOM and invents phantom bugs.

--- a/examples/pages/router/guards/App.tsx
+++ b/examples/pages/router/guards/App.tsx
@@ -54,9 +54,10 @@ const Frame = (props: { children?: ReactNode }) => (
     <div className="view">{props.children}</div>
     <small>
       Signed out, both vault links land on the sign-in page. The verdict is cached
-      for the space it was decided in, so return to the lobby between attempts -
-      and since the check is async, the route’s <code>fallback</code> covers the
-      wait.
+      for the space it was decided in, so return to the lobby between attempts.
+      While an async check runs, navigation holds your current page; the route’s{' '}
+      <code>fallback</code> appears only when there is nothing to hold (a cold
+      load).
     </small>
   </div>
 );

--- a/examples/pages/router/index.ts
+++ b/examples/pages/router/index.ts
@@ -3,5 +3,6 @@ export default {
   params: 'Params',
   query: 'Query',
   guards: 'Guards',
+  transitions: 'Transitions',
   nav: 'Navigation'
 };

--- a/examples/pages/router/transitions/App.css
+++ b/examples/pages/router/transitions/App.css
@@ -1,0 +1,77 @@
+.address {
+  display: block;
+  width: 100%;
+  padding: var(--s2) var(--s3);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+  color: var(--muted);
+}
+
+.nav {
+  display: flex;
+  gap: var(--s3);
+  width: 100%;
+  padding-bottom: var(--s3);
+  border-bottom: 1px solid var(--accent-soft);
+}
+
+.nav a {
+  cursor: pointer;
+}
+
+.view {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 7rem;
+}
+
+.room {
+  margin: 0;
+  padding: var(--s3) var(--s4);
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r);
+}
+
+.room h2 {
+  margin: 0 0 var(--s2);
+}
+
+.room p {
+  margin: 0;
+}
+
+.room.rose {
+  background: oklch(0.62 0.18 20 / 0.1);
+  border-color: oklch(0.62 0.18 20 / 0.4);
+}
+
+.room.gold {
+  background: oklch(0.7 0.14 85 / 0.1);
+  border-color: oklch(0.7 0.14 85 / 0.4);
+}
+
+.room.teal {
+  background: oklch(0.65 0.12 190 / 0.1);
+  border-color: oklch(0.65 0.12 190 / 0.4);
+}
+
+.gate {
+  margin: 0;
+  padding: var(--s3) var(--s4);
+  width: 100%;
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--r);
+  color: var(--muted);
+}
+
+.mode {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  width: 100%;
+}

--- a/examples/pages/router/transitions/App.tsx
+++ b/examples/pages/router/transitions/App.tsx
@@ -1,0 +1,104 @@
+import './App.css';
+
+import { Provider } from '@expressive/react';
+import { Link, Route, Router } from '@expressive/router';
+import type { ReactNode } from 'react';
+
+class Museum extends Router {
+  static global = false;
+
+  deferred = true;
+
+  toggle() {
+    this.deferred = !this.deferred;
+  }
+
+  protected transition(commit: () => void) {
+    if (this.deferred) super.transition(commit);
+    else commit();
+  }
+}
+
+const router = new Museum();
+
+const unlock = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 700));
+};
+
+export default () => (
+  <Provider for={router}>
+    <Route as={Frame}>
+      <Route as={Foyer} />
+      <Route to="paintings" label="Paintings" meta={{ tone: 'rose' }} as={Wing} redirect={unlock} fallback={<Opening />} />
+      <Route to="sculpture" label="Sculpture" meta={{ tone: 'gold' }} as={Wing} redirect={unlock} fallback={<Opening />} />
+      <Route to="archives" label="Archives" meta={{ tone: 'teal' }} as={Wing} redirect={unlock} fallback={<Opening />} />
+    </Route>
+  </Provider>
+);
+
+const Frame = (props: { children?: ReactNode }) => (
+  <div className="container">
+    <h1>Transitions</h1>
+    <p>
+      Every navigation commits through the router&apos;s protected{' '}
+      <code>transition</code> seam. The default marks the commit non-urgent
+      (React <code>startTransition</code>), so moving to a page that is not
+      ready yet <em>holds the current screen</em> until the next one is - no
+      fallback flash between pages that were already up.
+    </p>
+    <Address />
+    <nav className="nav">
+      <Link to="/">Foyer</Link>
+      <Link to="/paintings">Paintings</Link>
+      <Link to="/sculpture">Sculpture</Link>
+      <Link to="/archives">Archives</Link>
+    </nav>
+    <div className="view">{props.children}</div>
+    <Deferral />
+    <small>
+      Each wing takes 700ms to unlock (an async entry guard). With deferral,
+      nothing moves until the next wing is ready - address and page swap
+      together, no flash. Untick the box to override the seam with an urgent
+      commit: the address jumps at once and the wing flashes its fallback while
+      it unlocks. A cold load falls back either way - there is no previous
+      screen to hold.
+    </small>
+  </div>
+);
+
+const Address = () => {
+  const { path } = Museum.get();
+
+  return <code className="address">museum.example{path}</code>;
+};
+
+const Deferral = () => {
+  const { deferred, toggle } = Museum.get();
+
+  return (
+    <label className="mode">
+      <input type="checkbox" checked={deferred} onChange={toggle} />
+      hold the screen while the next page loads (default)
+    </label>
+  );
+};
+
+const Foyer = () => (
+  <section className="room">
+    <h2>Foyer</h2>
+    <p>Pick a wing. Each one is behind a slow door.</p>
+  </section>
+);
+
+const Wing = () => {
+  const { label, meta } = Route.get();
+
+  return (
+    <section className={`room ${meta!.tone}`}>
+      <h2>{label}</h2>
+      <p>The {label!.toLowerCase()} wing, fully loaded.</p>
+    </section>
+  );
+};
+
+const Opening = () => <p className="gate">unlocking…</p>;

--- a/packages/router/FEATURE.md
+++ b/packages/router/FEATURE.md
@@ -121,15 +121,18 @@ Rejected alternatives:
 
 ## 7. Plan (in order)
 
-1. **`transition(commit)` seam** on Router; `goto` routes through it; default =
-   deferred presentation.
+1. **`transition(commit)` seam (DONE)** on Router; every navigation commit
+   (goto/back/forward, and BrowserRouter's popstate/pushState sync) routes
+   through it; default = deferred presentation via mvc `transition()`.
 2. **MVC transition dispatch** (the core, done): normal path updates carry
-   non-urgent priority through batched subscriber dispatch. Verify router
-   computeds (`matched`/`match`) and Route presentation use that contract.
+   non-urgent priority through batched subscriber dispatch. Router
+   computeds (`matched`/`match`) and Route presentation verified against
+   that contract in tests.
 3. **`pending`** flag via a hook-resident `useTransition` member on Router.
-4. **Verify** against page-level loading: a suspending page holds the old screen
-   on in-app nav, shows its own `fallback` on cold load. Dogfood by making one
-   example's `as` suspend.
+4. **Verify (tests DONE)** against page-level loading: a suspending page (lazy
+   chunk or pending guard) holds the old screen on in-app nav, shows its own
+   `fallback` on cold load - covered in route.test.tsx. Example dogfood still
+   open.
 5. **fallback realignment (DONE)** - §6 option A: no-match branch is now the
    `default` prop; `fallback` reverts to Component's Suspense/error meaning.
 

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -1174,7 +1174,7 @@ describe('Route', () => {
 
           gate = mockPromise<string | void>();
           await act(async () => router.current.goto('/admin/secret'));
-          expect(screen.getByText('checking')).toBeDefined();
+          expect(screen.getByText('open')).toBeDefined();
           expect(ran).toBe(2);
 
           await act(async () => gate.resolve(undefined));
@@ -2030,5 +2030,53 @@ describe('a lazy page as `as`', () => {
 
     expect(view.container.textContent).toBe('about');
     expect(page).not.toHaveBeenCalled();
+  });
+});
+
+describe('deferred presentation', () => {
+  it('holds the current screen while the next page loads', async () => {
+    location('/');
+    const module = mockPromise<{ default: () => any }>();
+
+    const view = await renderAct(
+      <>
+        <Route to="/" as={Home} />
+        <Route to="/next" fallback={<span>loading</span>} as={lazy(() => module)} />
+      </>
+    );
+    expect(view.container.textContent).toBe('Home');
+
+    await act(async () => router.current.goto('/next'));
+
+    expect(window.location.pathname).toBe('/next');
+    expect(view.container.textContent).toBe('Home');
+
+    await act(async () => {
+      module.resolve({ default: () => <h1>next</h1> });
+      await module;
+    });
+
+    expect(view.container.textContent).toBe('next');
+  });
+
+  it('holds the current screen while an entry guard pends', async () => {
+    location('/');
+    const gate = mockPromise<string | void>();
+
+    const view = await renderAct(
+      <>
+        <Route to="/" as={Home} />
+        <Route to="/secret" fallback={<span>checking</span>} redirect={() => gate} as={() => <h1>secret</h1>} />
+      </>
+    );
+    expect(view.container.textContent).toBe('Home');
+
+    await act(async () => router.current.goto('/secret'));
+
+    expect(view.container.textContent).toBe('Home');
+
+    await act(async () => gate.resolve(undefined));
+
+    expect(view.container.textContent).toBe('secret');
   });
 });

--- a/packages/router/src/router.test.tsx
+++ b/packages/router/src/router.test.tsx
@@ -334,3 +334,80 @@ describe('BrowserRouter', () => {
     }
   });
 });
+
+describe('transition seam', () => {
+  it('brackets goto, back and forward', () => {
+    const log: string[] = [];
+
+    class Test extends Router {
+      static global = false;
+
+      protected transition(commit: () => void) {
+        log.push('bracket');
+        commit();
+      }
+    }
+
+    const router = Test.new();
+    router.goto('/a');
+    router.goto('/b');
+    router.back();
+    router.forward();
+
+    expect(log).toEqual(['bracket', 'bracket', 'bracket', 'bracket']);
+    expect(router.path).toBe('/b');
+  });
+
+  it('applies navigation only once the bracket runs commit', () => {
+    let staged!: () => void;
+
+    class Test extends Router {
+      static global = false;
+
+      protected transition(commit: () => void) {
+        staged = commit;
+      }
+    }
+
+    const router = Test.new();
+    router.goto('/next');
+
+    expect(router.path).toBe('/');
+    expect(router.entries).toEqual(['/']);
+
+    staged();
+
+    expect(router.path).toBe('/next');
+    expect(router.entries).toEqual(['/', '/next']);
+  });
+
+  it('brackets browser navigation, popstate included', () => {
+    window.history.replaceState(null, '', '/');
+    const log: string[] = [];
+
+    class Test extends BrowserRouter {
+      static global = false;
+
+      protected transition(commit: () => void) {
+        log.push('bracket');
+        commit();
+      }
+    }
+
+    const router = Test.new();
+    expect(log.length).toBe(1);
+
+    router.goto('/a');
+    expect(router.path).toBe('/a');
+    expect(log.length).toBe(2);
+
+    act(() => {
+      window.history.pushState(null, '', '/b');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(router.path).toBe('/b');
+    expect(log.length).toBe(4);
+
+    router.set(null);
+  });
+});

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,4 +1,4 @@
-import { Component, map, State } from '@expressive/mvc';
+import { Component, map, State, transition as scheduleTransition } from '@expressive/mvc';
 import { listener } from '@expressive/mvc/observable';
 
 import { Route } from './route';
@@ -82,19 +82,34 @@ export class Router extends Component {
     assertAbsolute(to);
     const url = normalize(to);
 
-    if (replace) this.entries[this.index] = url;
-    else pushEntry(this, url);
+    this.transition(() => {
+      if (replace) this.entries[this.index] = url;
+      else pushEntry(this, url);
 
-    this.locate(url);
+      this.locate(url);
+    });
   }
 
   back() {
-    if (this.index > 0) this.locate(this.entries[--this.index]);
+    if (this.index > 0)
+      this.transition(() => this.locate(this.entries[--this.index]));
   }
 
   forward() {
     if (this.index < this.entries.length - 1)
-      this.locate(this.entries[++this.index]);
+      this.transition(() => this.locate(this.entries[++this.index]));
+  }
+
+  /**
+   * Presentation bracket around every navigation commit. The default marks the
+   * commit non-urgent through the host scheduler (React `startTransition`), so
+   * in-app navigation to a not-yet-ready page holds the current screen instead
+   * of flashing a fallback. Override to stage the swap differently (e.g.
+   * `document.startViewTransition`); `commit` applies the navigation and must
+   * run.
+   */
+  protected transition(commit: () => void) {
+    scheduleTransition(commit);
   }
 
   /** Apply a normalized url (path + optional `?query`) to state, reconciling `query` in place. */
@@ -157,7 +172,9 @@ export class BrowserRouter extends Router {
     if (typeof window == 'undefined') return () => {};
 
     const sync = () => {
-      this.locate(window.location.pathname + window.location.search);
+      this.transition(() => {
+        this.locate(window.location.pathname + window.location.search);
+      });
     };
     sync();
     window.addEventListener('popstate', sync);

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -1,6 +1,6 @@
 # Router
 
-Runnable source: the [`router`](https://expressive.dev/examples/router/overview) section - [`overview`](https://expressive.dev/examples/router/overview), [`params`](https://expressive.dev/examples/router/params), [`query`](https://expressive.dev/examples/router/query), [`guards`](https://expressive.dev/examples/router/guards), [`nav`](https://expressive.dev/examples/router/nav). Complete programs, served as HTML.
+Runnable source: the [`router`](https://expressive.dev/examples/router/overview) section - [`overview`](https://expressive.dev/examples/router/overview), [`params`](https://expressive.dev/examples/router/params), [`query`](https://expressive.dev/examples/router/query), [`guards`](https://expressive.dev/examples/router/guards), [`transitions`](https://expressive.dev/examples/router/transitions), [`nav`](https://expressive.dev/examples/router/nav). Complete programs, served as HTML.
 
 `@expressive/router` is a host-agnostic, class-based router built on Expressive MVC. Routes are declared as nested JSX, matching is lexical (computed from the JSX tree, not a separate config), and navigation state lives on a reactive `Router` State that any component can read or drive.
 

--- a/skills/router/router.md
+++ b/skills/router/router.md
@@ -80,7 +80,7 @@ A `default` always needs an authored parent scope - a root `default` is the app 
 | `''` / `undefined` / `false` | allow normal render |
 | `null` | **force-404**: cede the path so the scope falls through to its nearest `default` |
 
-The guard may be **async** (return a `Promise`); the route's `fallback` shows while it pends. The verdict is cached for navigation within the matched space and re-evaluated on re-entry.
+The guard may be **async** (return a `Promise`); while it pends, the route's `fallback` shows on cold load, and in-app navigation holds the current screen (see [Deferred presentation](#deferred-presentation)). The verdict is cached for navigation within the matched space and re-evaluated on re-entry.
 
 ```tsx
 <Route to="document/:id"
@@ -99,7 +99,7 @@ Force-404 is path-keyed: it marks only the concrete URL that was declined, so na
 
 ## Code-split pages
 
-`as` takes a lazy component - `React.lazy`, or anything that suspends while its module loads. A `Route` is its own suspense boundary: `fallback` shows while the chunk loads, then the page resolves in place - the Route instance, its `match`, and any ancestor layout survive.
+`as` takes a lazy component - `React.lazy`, or anything that suspends while its module loads. A `Route` is its own suspense boundary: on cold load `fallback` shows while the chunk loads, then the page resolves in place - the Route instance, its `match`, and any ancestor layout survive. On in-app navigation the previous screen holds instead (see [Deferred presentation](#deferred-presentation)).
 
 ```tsx
 const Document = lazy(() => import('./Document'));
@@ -108,6 +108,25 @@ const Document = lazy(() => import('./Document'));
 ```
 
 A lazy *layout* suspends its whole scope - child routes register only after its module resolves. Navigating away mid-load abandons the page; it never mounts. A failed chunk is an error, not a suspension - handle it with `catch` on a `Route` subclass, or it propagates to the nearest ancestor boundary.
+
+## Deferred presentation
+
+Every navigation (`goto`, `Link`, `back`/`forward`, popstate) commits through `Router.transition`, a protected seam whose default marks the commit non-urgent via the host scheduler (React `startTransition`). In-app navigation to a page that isn't ready - a loading chunk, a pending entry guard - holds the current screen until the next resolves, instead of flashing `fallback`. Cold load (initial mount, no prior screen) still shows `fallback`. The URL updates immediately either way; only presentation defers.
+
+Override `transition(commit)` on a subclass to stage the swap differently - `commit` applies the navigation state and must run:
+
+```ts
+class MyRouter extends BrowserRouter {
+  static global = true;   // subclasses re-declare global explicitly
+
+  protected transition(commit: () => void) {
+    // bracket the swap (e.g. View Transitions), then defer as usual
+    super.transition(commit);
+  }
+}
+```
+
+Hosts without a scheduler (no `HostRuntime.transition`) apply navigation at normal priority - same timing as before the seam.
 
 ## Reading match state inside a page
 


### PR DESCRIPTION
## Scope

Router-side consumption of the MVC transition seam (#284) and transition dispatch (#291), per the staged plan in `packages/router/FEATURE.md` (§7 items 1, 2-verify, 4-verify).

## What changed

- **`Router.transition(commit)`** - new protected seam. Every navigation commit routes through it:
  - memory `Router`: `goto` (entry bookkeeping + locate), `back`, `forward`
  - `BrowserRouter`: the `sync` applied on `popstate` and patched `pushState`/`replaceState` - which covers its `goto`, browser back/forward, and external history use
- Default implementation is mvc `transition()` - the host's non-urgent bracket (React `startTransition`). Hosts without a scheduler retain prior timing.

## Behavior

In-app navigation to a page that isn't ready - a loading lazy chunk, a pending async entry guard - now **holds the current screen** until the next is ready, instead of flashing the route's `fallback`. Cold load (initial mount) still shows `fallback`. The URL/history update stays immediate; only presentation defers.

One existing test flipped, which is the feature: re-entering a pending async guard used to blank to `checking`, now holds the previous page (route.test.tsx caching suite).

## Key decisions

- **Bracket at the commit site, not only `goto`** - FEATURE.md sketched `goto`; bracketing `BrowserRouter.sync` as well is what covers popstate (browser back/forward) and external `pushState`, so every navigation defers uniformly.
- **History bookkeeping inside the bracket** - memory `entries`/`index` move with the commit, so a watcher reading both path and entries isn't split across priorities (an urgent write to the same watcher strips transition priority in dispatch).
- **No new public surface beyond the protected seam** already specified in FEATURE.md. The `pending` flag (FEATURE.md §7.3, hook-resident) and View Transitions guidance (§5) stay out - tracked on the followups board.

## Tests

- Seam bracketing: goto/back/forward, BrowserRouter goto + popstate, and a deferring override that stages `commit` (navigation applies only when it runs).
- Deferred presentation: lazy page and pending entry guard both hold the previous screen on in-app navigation, then resolve in place; cold-load fallback behavior unchanged (existing coverage).
- Full workspace suite green; router package at 100% coverage thresholds.

Runtime note: verified via the vitest/react-dom suite (real `startTransition` under happy-dom); no browser smoke pass was run for this change.

## Example (added after initial review copy)

`examples/router/transitions` - a memory-router museum with 700ms entry guards, a faux address readout, and a checkbox flipping the seam between the deferred default and an urgent commit, so hold-vs-flash is directly comparable in the live editor. Doubles as the FEATURE.md §7.4 dogfood. Guards example copy updated to match the new behavior (fallback covers cold loads only). Smoke pass run per examples/AGENTS.md (whose preload instruction pointed at a file deleted in #287 - repaired here).

Preview: https://feat-router-transitions.expressive-state.pages.dev (examples → Router → Transitions), exact URL in the check-run output.
