### PR TITLE
feat(mvc): admit ready-made instance into class-mode pool

### DIFF
--- a/.changeset/pool-admit-instance.md
+++ b/.changeset/pool-admit-instance.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": minor
+---
+
+`has(Type)` pools now admit a ready-made member. `add(value)` with a lone instance of the pool's class (or a subclass) holds that value instead of forwarding it to the constructor, so one field both spawns and injects - a second pool over members of a first (`selected = has(Item)`) and fetch hydration (`items.add(new Item(data))`) no longer need an identity factory. Ownership is unchanged and still follows freshness: a fresh instance is adopted and destroyed with the pool, an already-activated one is a guest. Only a single argument is treated this way, so multi-argument constructors are unaffected, and factory pools never admit - their arguments are their own.

--- a/packages/mvc/src/field/has.test.ts
+++ b/packages/mvc/src/field/has.test.ts
@@ -9,7 +9,7 @@ function reactive<T>(initial?: Iterable<T> | false | null): has.List<T>;
 
 function reactive<T extends State>(
   Type: new (...args: State.Args<T>) => T
-): has.Pool<T, State.Args<T>>;
+): has.Pool<T, State.Args<T> | [T]>;
 
 function reactive<T, A extends unknown[]>(
   make: (...args: A) => T
@@ -622,6 +622,69 @@ describe('pool', () => {
     expect(pool.has(guest)).toBe(true);
   });
 
+  it('will admit instance of class instead of constructing', () => {
+    const pool = reactive(Item);
+    const guest = Item.new();
+
+    expect(pool.add(guest)).toBe(guest);
+    expect(pool.size).toBe(1);
+  });
+
+  it('will admit subclass instance', () => {
+    class Special extends Item {}
+
+    const pool = reactive(Item);
+    const special = Special.new();
+
+    expect(pool.add(special)).toBe(special);
+    expect(pool.has(special)).toBe(true);
+  });
+
+  it('will still construct from props object', () => {
+    const pool = reactive(Item);
+    const item = pool.add({ value: 7 });
+
+    expect(item).toBeInstanceOf(Item);
+    expect(item.value).toBe(7);
+  });
+
+  it('will construct when args are not a lone instance', () => {
+    const pool = reactive(Item);
+    const item = pool.add({ value: 1 }, { value: 2 });
+
+    expect(item).toBeInstanceOf(Item);
+    expect(item.value).toBe(2);
+  });
+
+  it('will own admitted instance which is fresh', () => {
+    const pool = reactive(Item);
+    const item = new Item();
+
+    pool.add(item);
+    pool.delete(item);
+
+    expect(item.get(null)).toBe(true);
+  });
+
+  it('will not destroy admitted instance which is active', () => {
+    const pool = reactive(Item);
+    const guest = Item.new();
+
+    pool.add(guest);
+
+    expect(pool.delete(guest)).toBe(true);
+    expect(guest.get(null)).toBe(false);
+  });
+
+  it('will not admit instance in factory mode', () => {
+    const pool = reactive((value: Item) => new Item({ value: value.value + 1 }));
+    const seed = Item.new({ value: 1 });
+    const made = pool.add(seed);
+
+    expect(made).not.toBe(seed);
+    expect(made.value).toBe(2);
+  });
+
   it('will ignore repeat add of same value', async () => {
     const pool = reactive((value?: Item) => value || Item.new());
     const guest = Item.new();
@@ -758,6 +821,45 @@ describe('pool adoption', () => {
     host.set(null);
 
     expect(guest.get(null)).toBe(false);
+  });
+
+  it('will hold a member of one pool in another', () => {
+    class Thing extends State {}
+
+    class Store extends State {
+      items = has(Thing);
+      selected = has(Thing);
+    }
+
+    const store = Store.new();
+    const item = store.items.add();
+
+    expect(store.selected.add(item)).toBe(item);
+
+    store.selected.delete(item);
+
+    expect(item.get(null)).toBe(false);
+    expect(store.items.has(item)).toBe(true);
+
+    item.set(null);
+
+    expect(store.items.has(item)).toBe(false);
+  });
+
+  it('will own instances injected into pool', () => {
+    class Thing extends State {}
+
+    class Store extends State {
+      items = has(Thing);
+    }
+
+    const store = Store.new();
+    const injected = new Thing();
+
+    store.items.add(injected);
+    store.set(null);
+
+    expect(injected.get(null)).toBe(true);
   });
 });
 

--- a/packages/mvc/src/field/has.ts
+++ b/packages/mvc/src/field/has.ts
@@ -22,7 +22,7 @@ function has<T>(initial?: Iterable<T> | false | null): List<T>;
 
 function has<T extends State>(
   Type: new (...args: State.Args<T>) => T
-): Pool<T, State.Args<T>>;
+): Pool<T, State.Args<T> | [T]>;
 
 function has<T, A extends unknown[]>(
   make: (...args: A) => T
@@ -181,9 +181,11 @@ class Pool<T, A extends unknown[] = unknown[]> {
     const make = MAKE.get(target)!;
 
     const value = (
-      State.is(make)
-        ? new (make as State.Type)(...(args as State.Args))
-        : make(...args)
+      !State.is(make)
+        ? make(...args)
+        : args.length == 1 && args[0] instanceof make
+          ? args[0]
+          : new (make as State.Type)(...(args as State.Args))
     ) as T;
 
     if (!values.has(value)) {

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -18,9 +18,9 @@ The argument selects the mode:
 | call | interface | insert | identity |
 | --- | --- | --- | --- |
 | `has<T>()` / `has(values)` | `has.List<T>` | `push` / `put` / `set(index)` | position |
-| `has(StateClass)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns | the value itself |
+| `has(StateClass)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns, `add(value)` admits | the value itself |
 
-A list stores values you give it, in order, addressed by index. A pool admits values only by spawning them - `add` returns the member, the call site holds the reference, and the value is its own identity for `has`, `delete`, and eviction.
+A list stores values you give it, in order, addressed by index. A pool spawns its members - `add` returns the member, the call site holds the reference, and the value is its own identity for `has`, `delete`, and eviction. A class-mode pool also takes a ready-made instance.
 
 ## List
 
@@ -50,7 +50,7 @@ history.push('a'); // reruns - length changed re-resolves the index
 
 ## Pool
 
-A `State` class or factory makes a pool: an owned collection of members that exist only by being spawned through it.
+A `State` class or factory makes a pool: a collection of members it owns, addressed by identity rather than position.
 
 ```ts
 class Roster extends State {
@@ -63,6 +63,21 @@ class Roster extends State {
 ```
 
 `add(...args)` forwards its arguments - to the class constructor exactly as `Type.new()` accepts them, or as the factory's own parameters - and returns the member. With a `Component` class, identity `key` arrives this way before the `new()` lifecycle hook runs. In `@expressive/react` a pool of `Component` values renders directly - `<ul>{roster.players}</ul>` - through the facade; `[...roster.players]` is the manual alternative.
+
+A class-mode pool also admits a ready-made member: `add(value)` with a lone instance of the class (or a subclass) holds that value instead of constructing. So one field both spawns and injects - use it for a second pool over members of a first, or to hydrate from a fetch.
+
+```ts
+class Store extends State {
+  items = has(Item);
+  selected = has(Item);
+}
+
+store.items.add({ value: 1 });           // spawns - owned
+store.items.add(new Item(fetched));      // injects fresh - owned
+store.selected.add(item);                // holds an active member - guest
+```
+
+Only a single argument is treated this way; `add(a, b)` always constructs, so multi-argument constructors are unaffected. A factory pool never admits - its arguments are its own, so route instances through the factory body (`has((item?: Item) => item || new Item())`).
 
 A pool has no initial argument: it spawns, so seed it imperatively from the `new()` hook, which runs once the field has resolved. This is the single seeding seam - it also covers conditional, ordered, and derived members, which a static initializer could not.
 
@@ -84,7 +99,7 @@ class Board extends State {
 const cell = board.cells.add('a1', 'black');
 ```
 
-Ownership follows freshness, not where the value came from: a member the factory constructs fresh (`new Item()`) is owned, while an already-activated value it returns (`Item.new()`, or one handed through its arguments) is a guest.
+The same rule holds through a factory: a member it constructs fresh (`new Item()`) is owned, while an already-activated value it returns (`Item.new()`, or one handed through its arguments) is a guest.
 
 ```ts
 class Basket extends State {
@@ -99,7 +114,7 @@ basket.items.add(Item.new());             // already activated - guest
 
 ## Ownership
 
-Ownership follows freshness: a fresh (never-activated) `State` member - a `new Item()` the factory constructs or a class the pool instantiates - is adopted and owned, and the pool destroys it when it is deleted, cleared, or the owner dies. An already-activated value (`Item.new()`) is a guest: held but never destroyed. Non-State members are never owned.
+Ownership follows freshness, not how the member arrived: a fresh (never-activated) `State` - one the pool instantiates, a factory constructs, or `add` admits directly - is adopted and owned, and the pool destroys it when it is deleted, cleared, or the owner dies. An already-activated value (`Item.new()`) is a guest: held but never destroyed. Non-State members are never owned.
 
 Every collection is adopted by its hosting state at activation. Fresh `State` members are parented to the owner and activate inside its context: `get(Owner)` resolves directly and providers above the owner resolve from members.
 
@@ -144,7 +159,7 @@ Calling `get()` with no arguments returns a shallow snapshot array; nested value
 
 ```ts
 function has<T>(initial?: Iterable<T> | false | null): has.List<T>;
-function has<T extends State>(Type: new (...args: State.Args<T>) => T): has.Pool<T, State.Args<T>>;
+function has<T extends State>(Type: new (...args: State.Args<T>) => T): has.Pool<T, State.Args<T> | [T]>;
 function has<T, A extends unknown[]>(make: (...args: A) => T): has.Pool<T, A>;
 
 class has.List<T> {
@@ -163,7 +178,7 @@ class has.List<T> {
 
 class has.Pool<T, A extends unknown[] = unknown[]> {
   readonly size: number;
-  add(...args: A): T;                          // the constructor's or factory's own signature
+  add(...args: A): T;                          // constructor's or factory's own signature; class mode also takes [T]
   get(): State.Export<T>[];                    // snapshot
   get(predicate): T | undefined;
   has(value: T): boolean;


### PR DESCRIPTION
## Scope

`has(Type)` pools could only spawn. `Pool.add(...args)` forwarded every call to the
constructor, so the ordinary two-pool shape was not expressible:

```ts
class Store extends State {
  items = has(Item);
  selected = has(Item);   // selected.add(item) constructed a NEW Item
}
```

`add(value)` with a lone instance of the pool's class (or a subclass) now holds that value
instead of constructing. One field both spawns and injects.

## Why this is not new surface

The instance arm of `State.Args` was uninhabited. `Assign<T>` is intersected with
`Record<string, unknown>` (`state.ts:99`) and a class instance gets no implicit index
signature, so `add(instance)` was a type error before this change:

```
TS2345: Type 'Item' is not assignable to type 'Assign<Item>'.
  Type 'Item' is not assignable to type 'Record<string, unknown>'.
```

`Args<T>` is an array and `Init<T>` a function - neither collides either. No previously
type-checking call changes meaning, so the copy-constructor ambiguity that normally makes
an `instanceof` bypass unsafe cannot be expressed here. No new method or exported name:
the class-mode overload widens to `Pool<T, State.Args<T> | [T]>` and `Pool` stays generic.

## Decisions

- **Single argument only.** `add(a, b)` always constructs, so multi-argument constructors
  are unaffected, and the multi-arg slot stays uncommitted for a future decision.
- **Class mode only.** A factory's arguments are its own; `State.is(make)` gates the check,
  so factory pools never admit. Route instances through the factory body instead
  (`has((item?: Item) => item || new Item())`).
- **Subclass instances admit.** A `SpecialItem` belongs in an `Item` pool.
- **Ownership untouched.** Everything downstream of `adopt` is unchanged, so freshness
  still decides: a fresh instance is adopted, parented, activated in the owner's context
  and destroyed with it; an already-activated one is a guest, held but never destroyed.

## Rejected: bulk `add(...results)`

Considered for fetch hydration and set aside. Adds already coalesce - 5 sequential adds
produce exactly 1 notify - so a `for` loop is behaviorally identical, not merely close.
Overloading `add` to mean both "constructor args" and "member list" would also flip its
return type between `T` and `T[]` on a method whose disambiguation already leans on the
type-slot subtlety above.

## Tests

8 new in `has.test.ts`; **4 fail without the implementation** (verified by reverting
`has.ts` and re-running). The other 4 are regression guards on behavior that must not
change: props-object construction, multi-arg construction, factory mode not admitting.

One initially passed vacuously - `delete` returned `false` for a value never in the pool,
so "not destroyed" held for the wrong reason. It now asserts `delete` returns `true` first.

2 integration tests in `pool adoption` drive the real shape through actual fields: two
class-mode pools, cross-pool hold, guest survival on `delete`, eviction from both pools on
member death, and owner destruction killing injected-fresh members.

## Verification

- Workspace: 1315 passed, 35 files
- `tsc --noEmit` clean across all packages
- `packages/mvc` coverage: 100% statements / branches / functions / lines

Not runtime-exercised in a browser - core-only change with no browser-facing surface.

## Docs

Pool section documents admit with the two-pool example. Three statements the change
falsified were corrected: the pool intro ("members that exist only by being spawned
through it"), the ownership rule (now "follows freshness, not how the member arrived"),
and the factory-ownership paragraph. Changeset: `minor`.

Followup item: "has(Type) Pool cannot admit a pre-built instance; add() always constructs"
