### PR TITLE
docs(skills): close one-shot refactor gaps

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -53,7 +53,7 @@ Counter-rules:
 2. Separate headless workflow state from display-intrinsic state.
 3. Choose `State`, `Component`, or a plain function component for each owner.
 4. Give every repeated UI entry its own class in a `has` pool; actions about an item belong on the item.
-5. Split unrelated clusters remaining on a page State into owned region States (`recipe = new RecipePanel()`).
+5. Split unrelated clusters remaining on a page State into owned region States (`composer = new Composer()`).
 6. Provide state classes directly (`<Provider for={AppState}>`); never create an instance only to provide it.
 7. Move source fields and behavioral methods first; do not mechanically translate setters.
 8. Keep shared, semantic derivations as getters; leave single-consumer display derivations in their consuming component.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -36,6 +36,8 @@ For every stateful concern, pick exactly one owner:
 - **`State`** - headless model or workflow: network operations, domain rules, cross-view coordination. Views subscribe via `State.get()` / `State.use()`.
 - **Plain function component** - simple presentation, or trivial local UI state. Not everything needs a class.
 
+Concerns include the rows: when UI state describes an entry in a collection - selection, status, progress - the entry is its own `State` or `Component` spawned in a `has` pool, and actions about an item belong on the item. Id-keyed fields (`Record<Id, T>`, parallel `Map`s) and `(id, value)` methods are a missing class.
+
 Counter-rules:
 
 - Do not create `FooState` plus `FooView` just because hooks were present. If the behavior and rendering are one unit, `class Foo extends Component` is the refactor.
@@ -50,15 +52,19 @@ Counter-rules:
 1. Identify lifecycle and ownership boundaries before translating any hooks.
 2. Separate headless workflow state from display-intrinsic state.
 3. Choose `State`, `Component`, or a plain function component for each owner.
-4. Provide state classes directly (`<Provider for={AppState}>`); never create an instance only to provide it.
-5. Move source fields and behavioral methods first; do not mechanically translate setters.
-6. Keep shared, semantic derivations as getters; leave single-consumer display derivations in their consuming component.
-7. Let contextual children call `.get()` themselves instead of receiving drilled props.
-8. At every `.get()` / `.use()`, destructure an exact nested dependency snapshot.
-9. Assign directly through subscribed proxies; use `is` only to retain the root object alongside sibling destructuring.
-10. Gate optional children at the call site; inside, assert requirements with `.get(true)`.
-11. Extract long conditional JSX into named scopes, then consolidate scopes that share dependencies and hold no nested logic.
-12. Audit the result against the checklist in [react/refactor.md](react/refactor.md).
+4. Give every repeated UI entry its own class in a `has` pool; actions about an item belong on the item.
+5. Split unrelated clusters remaining on a page State into owned region States (`recipe = new RecipePanel()`).
+6. Provide state classes directly (`<Provider for={AppState}>`); never create an instance only to provide it.
+7. Move source fields and behavioral methods first; do not mechanically translate setters.
+8. Keep shared, semantic derivations as getters; leave single-consumer display derivations in their consuming component.
+9. Let contextual children call `.get()` themselves instead of receiving drilled props.
+10. At every `.get()` / `.use()`, destructure an exact nested dependency snapshot.
+11. Assign directly through subscribed proxies; use `is` only to retain the root object alongside sibling destructuring.
+12. Gate optional children at the call site; inside, assert requirements with `.get(true)`.
+13. Extract long conditional JSX into named scopes, then consolidate scopes that share dependencies and hold no nested logic.
+14. Audit the result against the checklist in [react/refactor.md](react/refactor.md).
+
+For large apps, scope a one-shot conversion to route/page controllers and their domain pools; leave mature leaf widgets on hooks until parent domains stabilize.
 
 Write output in the conventions of [react/style.md](react/style.md). They are opinion, not semantics - but they exist to keep reactive dependencies auditable, and the golden path applies them by default.
 
@@ -110,7 +116,7 @@ Field initializers that configure reactive behavior. Each has multiple overloads
 | `get()` | Context lookup between States - required or optional upstream, downstream collection                   | [field/get.md](field/get.md) |
 | `ref()` | Mutable refs (`.current`), ref callbacks with cleanup, ref proxies                                      | [field/ref.md](field/ref.md) |
 | `map()` | Reactive `Map` field - keyed entries or a keyed spawner, with owned `State` members and direct render    | [field/map.md](field/map.md) |
-| `has()` | Owned collections - an ordered list of values, or a pool of spawned members                             | [field/has.md](field/has.md) |
+| `has()` | Owned collections - an ordered list of values, or a pool of spawned members. Pools are the home for per-item UI state (selection, progress, row actions) | [field/has.md](field/has.md) |
 | `def()` | Low-level custom property behavior                                                                      | [field/def.md](field/def.md) |
 
 For **computed values**, declare a normal class getter - getters on a State subclass are auto-promoted to memoized, dependency-tracked properties. See [state/computed.md](state/computed.md) for tracking rules and when a derivation should *not* be a getter.
@@ -312,6 +318,7 @@ Every broad rule here has a locality constraint. Apply both halves. When auditin
 | PascalCase subcomponents compose renders                    | Only for genuine extension points a subclass would replace or wrap. Implementation scopes are freestanding FCs using `.get()`.        |
 | Extract long conditional JSX (~10+ lines or ~5+ levels)     | Keep branches together when they share dependencies, read locally, and contain no nested logic.                                      |
 | `is` retains the raw instance                               | Only alongside sibling destructuring from the same snapshot. Writes through proxies are transparent; nested objects need no unwrapping. |
+| State about a collection entry lives on the entry's class   | Payload keys that never drive UI stay as one `info` subobject on the member - a reactive field without a reader is pure cost.           |
 
 ## File Reference
 
@@ -349,7 +356,7 @@ Fetch these for detailed documentation when the task requires deeper knowledge. 
 
 - [react/react.md](react/react.md) - use(), State.use(), State.get() (optional lookup, required values `get(true)`, computed selector), Provider, Consumer, transparent writes, ForceRefresh
 - [react/component.md](react/component.md) - Component class, props, children, render composition, subcomponent extension points, error boundaries
-- [react/patterns.md](react/patterns.md) - Recipes: forms, async, nested state, presence boundary, contextual children, debounce, effects
+- [react/patterns.md](react/patterns.md) - Recipes: forms, async, domain-row and form-chip pools, region controllers, router bridge, presence boundary, contextual children, debounce, effects
 
 ### Router
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -36,7 +36,7 @@ For every stateful concern, pick exactly one owner:
 - **`State`** - headless model or workflow: network operations, domain rules, cross-view coordination. Views subscribe via `State.get()` / `State.use()`.
 - **Plain function component** - simple presentation, or trivial local UI state. Not everything needs a class.
 
-Concerns include the rows: when UI state describes an entry in a collection - selection, status, progress - the entry is its own `State` or `Component` spawned in a `has` pool, and actions about an item belong on the item. Id-keyed fields (`Record<Id, T>`, parallel `Map`s) and `(id, value)` methods are a missing class.
+Concerns include the rows: when UI state describes an entry in a collection - selection, status, progress - the entry is its own `State` or `Component` spawned in a `has` pool, and actions about an item belong on the item. Id-keyed fields (`Record<Id, T>`, parallel `Map`s) and `(id, value)` methods are a missing class; subsets (selection, comparison) are a second pool admitting the same members.
 
 Counter-rules:
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -163,6 +163,8 @@ function Parent({ counter }: { counter: Counter }) {
 }
 ```
 
+Static `.use()` and `.get()` are React hooks - call them unconditionally at the top of a component or `render()`, never inside event handlers, loops, or helpers a render calls conditionally. They build green when misused and crash at runtime. (Instance `this.get(...)` is not a hook.)
+
 Use `State.use()` when the component should create and own the instance. Use `State.get()` when the instance comes from context. To render an instance you already hold, make it a `Component` and place as `{instance}` - subscription belongs to the placed instance, not the surrounding function. See [react/react.md](react/react.md) for overloads (optional lookup, required values, computed selector).
 
 ## The Dependency Snapshot

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -36,7 +36,7 @@ For every stateful concern, pick exactly one owner:
 - **`State`** - headless model or workflow: network operations, domain rules, cross-view coordination. Views subscribe via `State.get()` / `State.use()`.
 - **Plain function component** - simple presentation, or trivial local UI state. Not everything needs a class.
 
-Concerns include the rows: when UI state describes an entry in a collection - selection, status, progress - the entry is its own `State` or `Component` spawned in a `has` pool, and actions about an item belong on the item. Id-keyed fields (`Record<Id, T>`, parallel `Map`s) and `(id, value)` methods are a missing class; subsets (selection, comparison) are a second pool admitting the same members.
+Concerns include the rows: UI state describing an entry in a collection - selection, status, progress - is its own `State` or `Component` spawned in a `has` pool; actions about item belong on item. Id-keyed fields (`Record<Id, T>`, parallel `Map`s) and `(id, value)` methods are a missing class; subsets are a second pool admitting the same members.
 
 Counter-rules:
 
@@ -52,16 +52,16 @@ Counter-rules:
 1. Identify lifecycle and ownership boundaries before translating any hooks.
 2. Separate headless workflow state from display-intrinsic state.
 3. Choose `State`, `Component`, or a plain function component for each owner.
-4. Give every repeated UI entry its own class in a `has` pool; actions about an item belong on the item.
-5. Split unrelated clusters remaining on a page State into owned region States (`composer = new Composer()`).
-6. Provide state classes directly (`<Provider for={AppState}>`); never create an instance only to provide it.
+4. Give every repeated UI entry own class in a `has` pool; actions about item belong on item.
+5. Split unrelated clusters remaining on page State to owned region States `composer = new Composer()`.
+6. Provide classes directly `<Provider for={AppState}>` never an instance if only to provide it.
 7. Move source fields and behavioral methods first; do not mechanically translate setters.
 8. Keep shared, semantic derivations as getters; leave single-consumer display derivations in their consuming component.
-9. Let contextual children call `.get()` themselves instead of receiving drilled props.
-10. At every `.get()` / `.use()`, destructure an exact nested dependency snapshot.
-11. Assign directly through subscribed proxies; use `is` only to retain the root object alongside sibling destructuring.
-12. Gate optional children at the call site; inside, assert requirements with `.get(true)`.
-13. Extract long conditional JSX into named scopes, then consolidate scopes that share dependencies and hold no nested logic.
+9. Let contextual children call `.get()` instead of receiving drilled props.
+10. At every `.get()` / `.use()`, destructure for exact nested dependency snapshot.
+11. May assign thru subscribed proxies; `is` only to retain the root object alongside sibling destructuring.
+12. Gate optional children at call site; inside, assert requirements with `.get(true)`.
+13. Extract long conditional JSX to named scopes, then consolidate scopes that share dependencies and hold no nested logic.
 14. Audit the result against the checklist in [react/refactor.md](react/refactor.md).
 
 For large apps, scope a one-shot conversion to route/page controllers and their domain pools; leave mature leaf widgets on hooks until parent domains stabilize.
@@ -116,7 +116,7 @@ Field initializers that configure reactive behavior. Each has multiple overloads
 | `get()` | Context lookup between States - required or optional upstream, downstream collection                   | [field/get.md](field/get.md) |
 | `ref()` | Mutable refs (`.current`), ref callbacks with cleanup, ref proxies                                      | [field/ref.md](field/ref.md) |
 | `map()` | Reactive `Map` field - keyed entries or a keyed spawner, with owned `State` members and direct render    | [field/map.md](field/map.md) |
-| `has()` | Owned collections - an ordered list of values, or a pool of spawned members. Pools are the home for per-item UI state (selection, progress, row actions) | [field/has.md](field/has.md) |
+| `has()` | Owned collections - an ordered list of values, or a pool of spawned members. Pools are for per-item UI state (selection, progress, row actions) | [field/has.md](field/has.md) |
 | `def()` | Low-level custom property behavior                                                                      | [field/def.md](field/def.md) |
 
 For **computed values**, declare a normal class getter - getters on a State subclass are auto-promoted to memoized, dependency-tracked properties. See [state/computed.md](state/computed.md) for tracking rules and when a derivation should *not* be a getter.
@@ -163,7 +163,7 @@ function Parent({ counter }: { counter: Counter }) {
 }
 ```
 
-Static `.use()` and `.get()` are React hooks - call them unconditionally at the top of a component or `render()`, never inside event handlers, loops, or helpers a render calls conditionally. They build green when misused and crash at runtime. (Instance `this.get(...)` is not a hook.)
+Static `.use()` and `.get()` are React hooks - call unconditionally at the top of a component or `render()`, never inside branch, event handlers, or loops. They build green when misused and crash at runtime. (Instance method get is not a hook.)
 
 Use `State.use()` when the component should create and own the instance. Use `State.get()` when the instance comes from context. To render an instance you already hold, make it a `Component` and place as `{instance}` - subscription belongs to the placed instance, not the surrounding function. See [react/react.md](react/react.md) for overloads (optional lookup, required values, computed selector).
 
@@ -382,6 +382,6 @@ Fetch these for detailed documentation when the task requires deeper knowledge. 
 
 ## Auditing & Evaluation
 
-Audit a conversion as a separate pass, not while authoring - self-audits under-report the author's own architecture gaps, and a fresh checklist pass over the diff recovers them.
+Audit a conversion as a separate pass, not while authoring - self-audits under-report the author's architecture gaps; a fresh checklist pass over the diff recovers them.
 
 Use [examples/audit.md](examples/audit.md) to assess fit and migration candidates. If migration is approved, follow [react/refactor.md](react/refactor.md) rather than translating hooks mechanically. For recorded design rationale, use [design.md](design.md); for adoption positioning and comparisons, use the website-only [why](https://expressive.dev/llm/why.md) and [comparisons](https://expressive.dev/llm/comparisons.md) pages.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expressive-mvc
-description: Class-based reactive state management for React (Expressive MVC). Use when writing or refactoring React state - converting useState/useEffect/useMemo hooks, fixing prop drilling, choosing state ownership (State vs Component), dependency snapshots, presence boundaries with get(true), Provider/context, async suspense, router - and when auditing a codebase for fit.
+description: Class-based reactive state management for React (Expressive MVC). Use when writing or refactoring React state - converting useState/useEffect/useMemo hooks, fixing prop drilling, choosing state ownership (State vs Component, has-pool domain rows, region controllers), dependency snapshots, presence boundaries with get(true), Provider/context, async suspense, router - and when auditing a codebase for fit.
 ---
 
 # Expressive MVC

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -382,4 +382,6 @@ Fetch these for detailed documentation when the task requires deeper knowledge. 
 
 ## Auditing & Evaluation
 
+Audit a conversion as a separate pass, not while authoring - self-audits under-report the author's own architecture gaps, and a fresh checklist pass over the diff recovers them.
+
 Use [examples/audit.md](examples/audit.md) to assess fit and migration candidates. If migration is approved, follow [react/refactor.md](react/refactor.md) rather than translating hooks mechanically. For recorded design rationale, use [design.md](design.md); for adoption positioning and comparisons, use the website-only [why](https://expressive.dev/llm/why.md) and [comparisons](https://expressive.dev/llm/comparisons.md) pages.

--- a/skills/examples/audit.md
+++ b/skills/examples/audit.md
@@ -129,7 +129,7 @@ function ThemeToggle() {
 
 1. **Start small** - pick one complex component, then decide whether its behavior belongs in a `Component` or a display-agnostic `State`
 2. **Coexist** - Expressive MVC works alongside existing hooks, no need to migrate everything
-3. **Bottom-up when coexisting** - migrate leaf components first, then work up to shared state. A one-shot conversion of a whole surface inverts this: route/page controllers first, domain pools second, mature leaf widgets last (see the refactor guide)
+3. **Bottom-up when coexisting** - migrate leaf components first, then work up to shared state. A one-shot conversion inverts this: route/page controllers first, domain pools second, mature leaf widgets last (see the refactor guide)
 4. **Test independently** - state classes can be tested without React, use this to improve coverage
 
 ## After Selection

--- a/skills/examples/audit.md
+++ b/skills/examples/audit.md
@@ -129,7 +129,7 @@ function ThemeToggle() {
 
 1. **Start small** - pick one complex component, then decide whether its behavior belongs in a `Component` or a display-agnostic `State`
 2. **Coexist** - Expressive MVC works alongside existing hooks, no need to migrate everything
-3. **Bottom-up** - migrate leaf components first, then work up to shared state
+3. **Bottom-up when coexisting** - migrate leaf components first, then work up to shared state. A one-shot conversion of a whole surface inverts this: route/page controllers first, domain pools second, mature leaf widgets last (see the refactor guide)
 4. **Test independently** - state classes can be tested without React, use this to improve coverage
 
 ## After Selection

--- a/skills/examples/basic.md
+++ b/skills/examples/basic.md
@@ -92,7 +92,7 @@ function TodoApp() {
 }
 ```
 
-Rows that should paint themselves become `Component` members placed as `{state.items}` - see the pool recipes in [patterns.md](../react/patterns.md).
+Rows that paint themselves become `Component` members placed as `{state.items}` - pool recipes in [patterns.md](../react/patterns.md).
 
 ## Async Data (with Suspense)
 

--- a/skills/examples/basic.md
+++ b/skills/examples/basic.md
@@ -32,21 +32,25 @@ function CounterApp() {
 }
 ```
 
-## Todo List (local state with collections)
+## Todo List (owned collection)
+
+Each entry is its own State in a `has` pool - `done` and `toggle` live on the item, not as `(id, value)` methods on the list:
 
 ```tsx
-import State, { set } from '@expressive/react';
+import State, { has } from '@expressive/react';
 
-interface TodoItem {
-  id: number;
-  text: string;
-  done: boolean;
+class TodoItem extends State {
+  text = '';
+  done = false;
+
+  toggle() {
+    this.done = !this.done;
+  }
 }
 
 class TodoState extends State {
-  items = set<TodoItem[]>([]);
+  items = has(TodoItem);
   input = '';
-  nextId = 1;
 
   get remaining() {
     return this.items.filter((i) => !i.done).length;
@@ -54,17 +58,8 @@ class TodoState extends State {
 
   add() {
     if (!this.input.trim()) return;
-    this.items = [
-      ...this.items,
-      { id: this.nextId++, text: this.input, done: false }
-    ];
+    this.items.add({ text: this.input });
     this.input = '';
-  }
-
-  toggle(id: number) {
-    this.items = this.items.map((i) =>
-      i.id === id ? { ...i, done: !i.done } : i
-    );
   }
 }
 
@@ -87,7 +82,7 @@ function TodoApp() {
       <p>{state.remaining} remaining</p>
       <ul>
         {state.items.map((item) => (
-          <li key={item.id} onClick={() => state.toggle(item.id)}>
+          <li key={String(item)} onClick={item.toggle}>
             {item.done ? <s>{item.text}</s> : item.text}
           </li>
         ))}
@@ -96,6 +91,8 @@ function TodoApp() {
   );
 }
 ```
+
+Rows that should paint themselves become `Component` members placed as `{state.items}` - see the pool recipes in [patterns.md](../react/patterns.md).
 
 ## Async Data (with Suspense)
 
@@ -236,6 +233,8 @@ function App() {
   return <Search />;
 }
 ```
+
+Explicit `loading` keeps previous results visible during refresh - the deliberate alternative to `set(async)` suspense for user-initiated fetches.
 
 ## Form Validation (setter callbacks)
 

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -177,7 +177,7 @@ const names = roster.players.map((p) => p.name);
 
 Calling `get()` with no arguments returns a shallow snapshot array; nested values with a `.get()` method are exported through it, matching State snapshots.
 
-Member fields read through a subscribed context track deeply - a parent rendering `players.filter((p) => p.online)` re-renders when any visited member's `online` changes. For per-row paint, prefer `Component` members owning `render()`: each row subscribes to itself and the parent tracks only shape. Never read a value solely to force tracking (`void x`) in a render - consume it, or move paint to the member.
+Member fields read through a subscribed context track deeply - a parent rendering `players.filter((p) => p.online)` re-renders when any visited member's `online` changes. A method call on a raw instance creates no subscription: `page.importFor(id).progress` in a render never repaints. Per-row async status must be a tracked read - a member field reached through the pool, or the member's own `render()`. Never read a value solely to force tracking (`void x`) in a render - consume it, or move paint to the member.
 
 ## Type Signature
 

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -112,6 +112,28 @@ basket.items.add(Item.new());             // already activated - guest
 
 `has(value)` and `delete(value)` take the member itself. Adding a value already present is a no-op - no duplicate, no events. There is no positional surface: no `set`, `put`, `push`, or index reads; iteration yields members in insertion order.
 
+### DTO boundary
+
+Pools are the home for per-item UI state. Accept API payloads through the factory (DTO in), read them back out at the boundary (DTO out); refill on fetch with `clear()` plus `add` per item:
+
+```ts
+class Gallery extends State {
+  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+
+  get dtos() {
+    return this.images.map((i) => i.info);
+  }
+
+  async refresh() {
+    const data = await api.list();
+    this.images.clear();
+    for (const meta of data) this.images.add(meta);
+  }
+}
+```
+
+Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently - the rest stays whole as one subobject field (`info`). Normalize API `null` to `undefined` here so presence fields stay optional.
+
 ## Ownership
 
 Ownership follows freshness, not how the member arrived: a fresh (never-activated) `State` - one the pool instantiates, a factory constructs, or `add` admits directly - is adopted and owned, and the pool destroys it when it is deleted, cleared, or the owner dies. An already-activated value (`Item.new()`) is a guest: held but never destroyed. Non-State members are never owned.
@@ -154,6 +176,8 @@ const names = roster.players.map((p) => p.name);
 ```
 
 Calling `get()` with no arguments returns a shallow snapshot array; nested values with a `.get()` method are exported through it, matching State snapshots.
+
+Member fields read through a subscribed context track deeply - a parent rendering `players.filter((p) => p.online)` re-renders when any visited member's `online` changes. For per-row paint, prefer `Component` members owning `render()`: each row subscribes to itself and the parent tracks only shape. Never read a value solely to force tracking (`void x`) in a render - consume it, or move paint to the member.
 
 ## Type Signature
 

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -114,7 +114,7 @@ basket.items.add(Item.new());             // already activated - guest
 
 ### DTO boundary
 
-Pools are the home for per-item UI state. Accept API payloads through the factory (DTO in), read them back out at the boundary (DTO out); refill on fetch with `clear()` plus `add` per item:
+Pools are for per-item UI state. Accept API payloads thru the factory (DTO in), read back out at the boundary (DTO out); refill on fetch with `clear()` plus `add` per item:
 
 ```ts
 class Inbox extends State {
@@ -132,9 +132,9 @@ class Inbox extends State {
 }
 ```
 
-Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently - the rest stays whole as one subobject field (`info`). Normalize API `null` to `undefined` here so presence fields stay optional.
+Keep members small: promote a payload key to reactive field only when views render it or it changes independently - the rest stays one subobject field (`info`). Normalize API `null` to `undefined` here so presence fields stay optional.
 
-Refill destroys member identity - references, flags, and second-pool membership die with it. Selection that must survive a refresh is a durable key (`selectedId`) plus a re-find getter; member references and flags fit pools that live between fetches.
+Refill destroys member identity - references, flags, second-pool membership die with it. Selection surviving refresh is a durable key (`selectedId`) plus re-find getter; references and flags fit pools stable between fetches.
 
 ## Ownership
 
@@ -179,7 +179,7 @@ const names = roster.players.map((p) => p.name);
 
 Calling `get()` with no arguments returns a shallow snapshot array; nested values with a `.get()` method are exported through it, matching State snapshots.
 
-Member fields read through a subscribed context track deeply - a parent rendering `players.filter((p) => p.online)` re-renders when any visited member's `online` changes. A method call on a raw instance creates no subscription: `page.importFor(id).progress` in a render never repaints. Per-row async status must be a tracked read - a member field reached through the pool, or the member's own `render()`. Never read a value solely to force tracking (`void x`) in a render - consume it, or move paint to the member.
+Member fields read thru a subscribed context track deeply - a parent rendering `players.filter((p) => p.online)` re-renders when any visited member's `online` changes. A method call on a raw instance creates no subscription: `page.importFor(id).progress` in a render never repaints. Per-row async status must be a tracked read - member field thru the pool, or the member's own `render()`. Never read solely to force tracking (`void x`) in a render - consume it, or move paint to the member.
 
 ## Type Signature
 

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -117,17 +117,17 @@ basket.items.add(Item.new());             // already activated - guest
 Pools are the home for per-item UI state. Accept API payloads through the factory (DTO in), read them back out at the boundary (DTO out); refill on fetch with `clear()` plus `add` per item:
 
 ```ts
-class Gallery extends State {
-  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+class Inbox extends State {
+  messages = has((dto: MessageDto) => new Message({ info: dto, id: dto.id }));
 
   get dtos() {
-    return this.images.map((i) => i.info);
+    return this.messages.map((m) => m.info);
   }
 
   async refresh() {
     const data = await api.list();
-    this.images.clear();
-    for (const meta of data) this.images.add(meta);
+    this.messages.clear();
+    for (const dto of data) this.messages.add(dto);
   }
 }
 ```

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -134,6 +134,8 @@ class Inbox extends State {
 
 Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently - the rest stays whole as one subobject field (`info`). Normalize API `null` to `undefined` here so presence fields stay optional.
 
+Refill destroys member identity - references, flags, and second-pool membership die with it. Selection that must survive a refresh is a durable key (`selectedId`) plus a re-find getter; member references and flags fit pools that live between fetches.
+
 ## Ownership
 
 Ownership follows freshness, not how the member arrived: a fresh (never-activated) `State` - one the pool instantiates, a factory constructs, or `add` admits directly - is adopted and owned, and the pool destroys it when it is deleted, cleared, or the owner dies. An already-activated value (`Item.new()`) is a guest: held but never destroyed. Non-State members are never owned.

--- a/skills/field/set.md
+++ b/skills/field/set.md
@@ -86,6 +86,8 @@ Zero-argument factory. Computed lazily on first access (unless `true` passed). R
 - Factory is bound to the state instance (`this` works).
 - Factories can suspend on other pending `set()` properties - resolution cascades.
 
+Suspense via factory fits load-once data a view cannot render without. Keep explicit `loading` / `error` fields instead when the operation is user-initiated (submit, refresh), stale content should stay visible during refetch, or errors render inline rather than through a boundary.
+
 ### Factory with Callback
 
 ```ts

--- a/skills/field/set.md
+++ b/skills/field/set.md
@@ -86,7 +86,7 @@ Zero-argument factory. Computed lazily on first access (unless `true` passed). R
 - Factory is bound to the state instance (`this` works).
 - Factories can suspend on other pending `set()` properties - resolution cascades.
 
-Suspense via factory fits load-once data a view cannot render without. Keep explicit `loading` / `error` fields instead when the operation is user-initiated (submit, refresh), stale content should stay visible during refetch, or errors render inline rather than through a boundary.
+Suspense via factory fits load-once data a view cannot render without. Keep explicit `loading` / `error` fields when the operation is user-initiated (submit, refresh), stale content stays visible during refetch, or errors render inline rather than thru a boundary.
 
 ### Factory with Callback
 

--- a/skills/react/component.md
+++ b/skills/react/component.md
@@ -206,16 +206,14 @@ Component instances survive across renders. `this` is stable - you can store ref
 ```tsx
 class ChatRoom extends Component {
   messages: Message[] = [];
-  socket: WebSocket | null = null;
-
   url = '';
 
   new() {
-    this.socket = new WebSocket(this.url);
-    this.socket.onmessage = (e) => {
+    const socket = new WebSocket(this.url);
+    socket.onmessage = (e) => {
       this.messages = [...this.messages, JSON.parse(e.data)];
     };
-    return () => this.socket?.close();
+    return () => socket.close();
   }
 
   render() {

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -157,7 +157,7 @@ function MessageList({ list }: { list: Message[] }) {
 
 Activated Components are React elements: the pool (`{inbox.messages}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one message re-renders one row.
 
-A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members, and `pool.has(value)` tracks that member only:
+A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members, and `pool.has(value)` tracks that member only. Members evict on destroy, so a refill clears the subset - use a durable key instead when selection must survive refresh:
 
 ```tsx
 class Inbox extends Component {

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -252,7 +252,7 @@ The page remains orchestrator - route identity, session, request dispatch, page-
 
 ## Bridging an Existing Router
 
-An outer FC reads the router hooks and passes them as props; alternatively the class encapsulates the hooks itself with `use()` (see [react.md](react.md)):
+Bridge, don't replace: a conversion keeps the app's router, and adopting `@expressive/router` instead is a separate decision needing explicit go-ahead. An outer FC reads the router hooks and passes them as props; alternatively the class encapsulates the hooks itself with `use()` (see [react.md](react.md)):
 
 ```tsx
 function InboxRoute() {

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -157,6 +157,20 @@ function ThumbGrid({ list }: { list: GalleryImage[] }) {
 
 Activated Components are React elements: the pool (`{page.images}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one image re-renders one row.
 
+A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members, and `pool.has(value)` tracks that member only:
+
+```tsx
+class GalleryPage extends Component {
+  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+  selected = has(GalleryImage);   // holds members of `images` as guests
+}
+
+// on the row
+get selected() {
+  return this.gallery.selected.has(this);
+}
+```
+
 **Anti-pattern:** `void selected;` in an FC to force tracking of member fields. Consume the value in JSX, or move paint into the row's `render()`.
 
 ## Form Chips in a Pool

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -93,42 +93,171 @@ class Profile extends Component {
 }
 ```
 
-## Nested / Child State
+Suspense fits load-once data the view cannot render without. Keep explicit `loading` / `error` fields when the fetch is user-initiated, stale content should stay visible during refresh, or errors render inline - see [set.md](../field/set.md).
+
+## Domain Rows in a Pool
+
+State about an entry in a collection lives on the entry's class, spawned through a `has` pool - not in id-keyed records or `(id, value)` methods on the page. The factory takes the API payload (DTO in); the page keeps fetch, the pool, and selection *policy*:
 
 ```tsx
-import State, { Component } from '@expressive/react';
+import State, { Component, get, has, set } from '@expressive/react';
 
-class TodoItem extends State {
-  text = '';
-  done = false;
-  toggle() {
-    this.done = !this.done;
+class GalleryImage extends Component {
+  info = set<ImageMeta>();   // payload stays one subobject - not exploded per key
+  name = set<string>();
+  selected = false;
+  gallery = get(GalleryPage);
+
+  toggle(event: MouseEvent) {
+    this.gallery.selectThumb(this, event);  // policy stays on the page
   }
-}
 
-class TodoList extends Component {
-  items: TodoItem[] = [];
-
-  add(text: string) {
-    const item = TodoItem.new();
-    item.text = text;
-    this.items = [...this.items, item];
+  async remove() {
+    await api.remove(this.name);
+    this.gallery.images.delete(this);
   }
 
   render() {
+    const {
+      name,
+      selected,
+      info: {
+        thumbUrl,
+      },
+    } = this;
+
     return (
-      <ul>
-        {this.items.map((item) => (
-          <li
-            key={item.text}
-            onClick={item.toggle}
-            style={{ textDecoration: item.done ? 'line-through' : 'none' }}>
-            {item.text}
-          </li>
-        ))}
-        <button onClick={() => this.add('New item')}>Add</button>
-      </ul>
+      <button className={selected ? 'thumb on' : 'thumb'} onClick={this.toggle}>
+        <img src={thumbUrl} alt={name} />
+      </button>
     );
+  }
+}
+
+class GalleryPage extends Component {
+  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+
+  get selected() {
+    return this.images.filter((i) => i.selected);
+  }
+
+  async refresh() {
+    const data = await api.list();
+    this.images.clear();
+    for (const meta of data) this.images.add(meta);
+  }
+
+  selectThumb(image: GalleryImage, event: MouseEvent) { /* shift/meta multi-select */ }
+}
+
+function ThumbGrid({ list }: { list: GalleryImage[] }) {
+  return <div className="thumbs">{list}</div>;
+}
+```
+
+Activated Components are React elements: the pool (`{page.images}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one image re-renders one row.
+
+**Anti-pattern:** `void selected;` in an FC to force tracking of member fields. Consume the value in JSX, or move paint into the row's `render()`.
+
+## Form Chips in a Pool
+
+The same shape covers form entries with their own async lifecycle - an upload, a pending download, an applied filter. The chip owns its status and removal; the form owns the pool and overall readiness, reading DTOs back out at the API boundary:
+
+```tsx
+class AppliedLora extends Component {
+  file = set<string>();
+  weight = 1;
+  importJob?: ImportJob;
+  recipe = get(RecipePanel);
+
+  get importing() {
+    return this.importJob?.phase === 'downloading';
+  }
+
+  toApi(): Lora {
+    return { file: this.file, weight: this.weight };
+  }
+
+  remove() {
+    this.recipe.loras.delete(this);
+  }
+
+  render() { /* card: weight nudge, progress, remove */ }
+}
+
+class RecipePanel extends State {
+  loras = has((dto: Lora) => new AppliedLora(dto));
+
+  get ready() {
+    return !this.loras.any((l) => l.importing);
+  }
+
+  get loraDtos() {
+    return this.loras.map((l) => l.toApi());
+  }
+}
+```
+
+## Region Controllers
+
+When a page State accumulates unrelated clusters - form config plus catalog plus job plus navigation - split each into its own State owned as a field. Ownership provides implicitly; views bind the region directly:
+
+```tsx
+class GeneratePage extends Component {
+  recipe = new RecipePanel();  // owned field - provided with the page
+  busy = false;
+
+  get canGenerate() {
+    return this.recipe.ready && !this.busy;
+  }
+
+  async generate() { /* orchestrates: recipe -> job -> session */ }
+}
+
+// Form sections bind the region; the footer mixes both
+function PromptFields() {
+  const { is: recipe, prompt } = RecipePanel.get();
+  ...
+}
+
+function Footer() {
+  const { canGenerate, generate } = GeneratePage.get();
+  ...
+}
+```
+
+The page remains orchestrator - route identity, session, job dispatch, page-level errors. Split when the second cluster appears, not as a late cleanup.
+
+## Bridging an Existing Router
+
+An outer FC reads the router hooks and passes them as props; alternatively the class encapsulates the hooks itself with `use()` (see [react.md](react.md)):
+
+```tsx
+function GalleryRoute() {
+  const navigate = useNavigate();
+  const { sessionId } = useParams();
+
+  return (
+    <GalleryPage navigate={navigate} urlSessionId={sessionId}>
+      <Toolbar />
+      <Thumbs />
+    </GalleryPage>
+  );
+}
+```
+
+Route params are props, not always working identity. When leaving a route must not clear the model, keep the working field separate and soft-sync with a reaction:
+
+```tsx
+class GeneratePage extends Component {
+  sessionId?: string;     // working identity - survives route changes
+  urlSessionId?: string;  // route param - undefined off /s/:id
+
+  mount() {
+    return this.get(($) => {
+      void $.urlSessionId;  // declare the trigger - legitimate in model effects, never in renders
+      this.syncRoute();
+    });
   }
 }
 ```
@@ -383,8 +512,13 @@ import State from '@expressive/react';
 
 class Timer extends State {
   elapsed = 0;
+
+  tick() {
+    this.elapsed++;
+  }
+
   protected new() {
-    const id = setInterval(() => this.elapsed++, 1000);
+    const id = setInterval(this.tick, 1000); // methods are auto-bound - no arrow wrapper
     return () => clearInterval(id);
   }
 }

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -93,11 +93,11 @@ class Profile extends Component {
 }
 ```
 
-Suspense fits load-once data the view cannot render without. Keep explicit `loading` / `error` fields when the fetch is user-initiated, stale content should stay visible during refresh, or errors render inline - see [set.md](../field/set.md).
+Suspense fits load-once data the view cannot render without. Keep explicit `loading` / `error` fields when the fetch is user-initiated, stale content stays visible during refresh, or errors render inline - see [set.md](../field/set.md).
 
 ## Domain Rows in a Pool
 
-State about an entry in a collection lives on the entry's class, spawned through a `has` pool - not in id-keyed records or `(id, value)` methods on the page. The factory takes the API payload (DTO in); the page keeps fetch, the pool, and selection *policy*:
+State about a collection entry lives on the entry's class, spawned thru a `has` pool - not id-keyed records or `(id, value)` methods on the page. Factory takes the API payload (DTO in); page keeps fetch, the pool, and selection *policy*:
 
 ```tsx
 import State, { Component, get, has, set } from '@expressive/react';
@@ -155,9 +155,9 @@ function MessageList({ list }: { list: Message[] }) {
 }
 ```
 
-Activated Components are React elements: the pool (`{inbox.messages}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one message re-renders one row.
+Activated Components are React elements: the pool `{inbox.messages}` and plain subsets `{list}` place directly, no `.map`. Each row paints from its own `render()` subscription - selecting one message re-renders one row.
 
-A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members, and `pool.has(value)` tracks that member only. Members evict on destroy, so a refill clears the subset - use a durable key instead when selection must survive refresh:
+A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members; `pool.has(value)` tracks that member only. Members evict on destroy, so refill clears the subset - use a durable key when selection must survive refresh:
 
 ```tsx
 class Inbox extends Component {
@@ -175,7 +175,7 @@ get selected() {
 
 ## Form Chips in a Pool
 
-The same shape covers form entries with their own async lifecycle - an upload, a pending download, an applied filter. The chip owns that lifecycle end to end: started in `new()`, handle in an unmanaged field, torn down on destroy. The form owns the pool and overall readiness, reading DTOs back out at the API boundary:
+The same shape covers form entries with their own async lifecycle - an upload, a pending download, an applied filter. The chip owns that lifecycle: started in `new()`, handle in an unmanaged field, torn down on destroy. The form owns the pool and readiness, reading DTOs back out at the API boundary:
 
 ```tsx
 class Attachment extends Component {
@@ -218,7 +218,7 @@ class Composer extends State {
 }
 ```
 
-The owner coordinates readiness only. A method that re-finds a chip by id to feed it progress (`attachments.get((a) => a.id === id)`) belongs on the chip.
+The owner coordinates readiness only. A method re-finding a chip by id to feed it progress belongs on the chip.
 
 ## Region Controllers
 
@@ -248,11 +248,11 @@ function Footer() {
 }
 ```
 
-The page remains orchestrator - route identity, session, request dispatch, page-level errors. Split when the second cluster appears, not as a late cleanup.
+The page remains orchestrator - route identity, session, request dispatch, page-level errors. Split when the second cluster appears, not as late cleanup.
 
 ## Bridging an Existing Router
 
-Bridge, don't replace: a conversion keeps the app's router, and adopting `@expressive/router` instead is a separate decision needing explicit go-ahead. An outer FC reads the router hooks and passes them as props; alternatively the class encapsulates the hooks itself with `use()` (see [react.md](react.md)):
+Bridge, don't replace: a conversion keeps the app's router; adopting `@expressive/router` needs explicit go-ahead. An outer FC reads router hooks and passes props; alternatively the class encapsulates hooks itself with `use()` (see [react.md](react.md)):
 
 ```tsx
 function InboxRoute() {
@@ -290,7 +290,7 @@ class ComposePage extends Component {
 }
 ```
 
-Assign the working field the moment identity is created. If methods thread fresh ids through arguments to outrun the route, or a shadow field remembers the last route seen, the working field is still a mirror.
+Assign the working field the moment identity is created. Fresh ids threaded thru arguments, or a shadow field remembering the last route - the working field is still a mirror.
 
 ## Context Sharing
 

--- a/skills/react/patterns.md
+++ b/skills/react/patterns.md
@@ -102,72 +102,72 @@ State about an entry in a collection lives on the entry's class, spawned through
 ```tsx
 import State, { Component, get, has, set } from '@expressive/react';
 
-class GalleryImage extends Component {
-  info = set<ImageMeta>();   // payload stays one subobject - not exploded per key
-  name = set<string>();
+class Message extends Component {
+  info = set<MessageDto>();   // payload stays one subobject - not exploded per key
+  id = set<string>();
   selected = false;
-  gallery = get(GalleryPage);
+  inbox = get(Inbox);
 
   toggle(event: MouseEvent) {
-    this.gallery.selectThumb(this, event);  // policy stays on the page
+    this.inbox.select(this, event);  // policy stays on the page
   }
 
-  async remove() {
-    await api.remove(this.name);
-    this.gallery.images.delete(this);
+  async archive() {
+    await api.archive(this.id);
+    this.inbox.messages.delete(this);
   }
 
   render() {
     const {
-      name,
       selected,
       info: {
-        thumbUrl,
+        sender,
+        subject,
       },
     } = this;
 
     return (
-      <button className={selected ? 'thumb on' : 'thumb'} onClick={this.toggle}>
-        <img src={thumbUrl} alt={name} />
+      <button className={selected ? 'row on' : 'row'} onClick={this.toggle}>
+        <b>{sender}</b> {subject}
       </button>
     );
   }
 }
 
-class GalleryPage extends Component {
-  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+class Inbox extends Component {
+  messages = has((dto: MessageDto) => new Message({ info: dto, id: dto.id }));
 
   get selected() {
-    return this.images.filter((i) => i.selected);
+    return this.messages.filter((m) => m.selected);
   }
 
   async refresh() {
     const data = await api.list();
-    this.images.clear();
-    for (const meta of data) this.images.add(meta);
+    this.messages.clear();
+    for (const dto of data) this.messages.add(dto);
   }
 
-  selectThumb(image: GalleryImage, event: MouseEvent) { /* shift/meta multi-select */ }
+  select(message: Message, event: MouseEvent) { /* shift/meta multi-select */ }
 }
 
-function ThumbGrid({ list }: { list: GalleryImage[] }) {
-  return <div className="thumbs">{list}</div>;
+function MessageList({ list }: { list: Message[] }) {
+  return <div className="messages">{list}</div>;
 }
 ```
 
-Activated Components are React elements: the pool (`{page.images}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one image re-renders one row.
+Activated Components are React elements: the pool (`{inbox.messages}`) and plain subsets (`{list}`) place directly, no `.map`. Each row paints from its own `render()` subscription, so selecting one message re-renders one row.
 
 A cross-cutting subset can be a second pool instead of a member flag - class-mode `add` admits ready-made members, and `pool.has(value)` tracks that member only:
 
 ```tsx
-class GalleryPage extends Component {
-  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
-  selected = has(GalleryImage);   // holds members of `images` as guests
+class Inbox extends Component {
+  messages = has((dto: MessageDto) => new Message({ info: dto, id: dto.id }));
+  selected = has(Message);   // holds members of `messages` as guests
 }
 
 // on the row
 get selected() {
-  return this.gallery.selected.has(this);
+  return this.inbox.selected.has(this);
 }
 ```
 
@@ -175,87 +175,95 @@ get selected() {
 
 ## Form Chips in a Pool
 
-The same shape covers form entries with their own async lifecycle - an upload, a pending download, an applied filter. The chip owns its status and removal; the form owns the pool and overall readiness, reading DTOs back out at the API boundary:
+The same shape covers form entries with their own async lifecycle - an upload, a pending download, an applied filter. The chip owns that lifecycle end to end: started in `new()`, handle in an unmanaged field, torn down on destroy. The form owns the pool and overall readiness, reading DTOs back out at the API boundary:
 
 ```tsx
-class AppliedLora extends Component {
-  file = set<string>();
-  weight = 1;
-  importJob?: ImportJob;
-  recipe = get(RecipePanel);
+class Attachment extends Component {
+  file = set<File>();
+  job?: UploadJob;
+  composer = get(Composer);
+  stop = put<(() => void) | null>(null);  // unmanaged - see state/state.md
 
-  get importing() {
-    return this.importJob?.phase === 'downloading';
+  get uploading() {
+    return !this.job?.done;
   }
 
-  toApi(): Lora {
-    return { file: this.file, weight: this.weight };
+  protected new() {
+    this.stop = api.upload(this.file, (job) => { this.job = job; });
+    return () => this.stop?.();
+  }
+
+  toApi(): AttachmentDto {
+    return { name: this.file.name, url: this.job!.url };
   }
 
   remove() {
-    this.recipe.loras.delete(this);
+    this.composer.attachments.delete(this);
   }
 
-  render() { /* card: weight nudge, progress, remove */ }
+  render() { /* chip: name, progress, remove */ }
 }
 
-class RecipePanel extends State {
-  loras = has((dto: Lora) => new AppliedLora(dto));
+class Composer extends State {
+  subject = '';
+  attachments = has((file: File) => new Attachment({ file }));
 
   get ready() {
-    return !this.loras.any((l) => l.importing);
+    return !this.attachments.any((a) => a.uploading);
   }
 
-  get loraDtos() {
-    return this.loras.map((l) => l.toApi());
+  get attachmentDtos() {
+    return this.attachments.map((a) => a.toApi());
   }
 }
 ```
 
+The owner coordinates readiness only. A method that re-finds a chip by id to feed it progress (`attachments.get((a) => a.id === id)`) belongs on the chip.
+
 ## Region Controllers
 
-When a page State accumulates unrelated clusters - form config plus catalog plus job plus navigation - split each into its own State owned as a field. Ownership provides implicitly; views bind the region directly:
+When a page State accumulates unrelated clusters - draft fields plus lookups plus request state plus navigation - split each into its own State owned as a field. Ownership provides implicitly; views bind the region directly:
 
 ```tsx
-class GeneratePage extends Component {
-  recipe = new RecipePanel();  // owned field - provided with the page
+class ComposePage extends Component {
+  composer = new Composer();  // owned field - provided with the page
   busy = false;
 
-  get canGenerate() {
-    return this.recipe.ready && !this.busy;
+  get canSend() {
+    return this.composer.ready && !this.busy;
   }
 
-  async generate() { /* orchestrates: recipe -> job -> session */ }
+  async send() { /* composer -> request -> thread */ }
 }
 
 // Form sections bind the region; the footer mixes both
-function PromptFields() {
-  const { is: recipe, prompt } = RecipePanel.get();
+function SubjectField() {
+  const { is: composer, subject } = Composer.get();
   ...
 }
 
 function Footer() {
-  const { canGenerate, generate } = GeneratePage.get();
+  const { canSend, send } = ComposePage.get();
   ...
 }
 ```
 
-The page remains orchestrator - route identity, session, job dispatch, page-level errors. Split when the second cluster appears, not as a late cleanup.
+The page remains orchestrator - route identity, session, request dispatch, page-level errors. Split when the second cluster appears, not as a late cleanup.
 
 ## Bridging an Existing Router
 
 An outer FC reads the router hooks and passes them as props; alternatively the class encapsulates the hooks itself with `use()` (see [react.md](react.md)):
 
 ```tsx
-function GalleryRoute() {
+function InboxRoute() {
   const navigate = useNavigate();
-  const { sessionId } = useParams();
+  const { folder } = useParams();
 
   return (
-    <GalleryPage navigate={navigate} urlSessionId={sessionId}>
+    <Inbox navigate={navigate} urlFolder={folder}>
       <Toolbar />
-      <Thumbs />
-    </GalleryPage>
+      <Messages />
+    </Inbox>
   );
 }
 ```
@@ -263,18 +271,26 @@ function GalleryRoute() {
 Route params are props, not always working identity. When leaving a route must not clear the model, keep the working field separate and soft-sync with a reaction:
 
 ```tsx
-class GeneratePage extends Component {
-  sessionId?: string;     // working identity - survives route changes
-  urlSessionId?: string;  // route param - undefined off /s/:id
+class ComposePage extends Component {
+  threadId?: string;     // working identity - survives route changes
+  urlThreadId?: string;  // route param - undefined off /t/:id
 
   mount() {
     return this.get(($) => {
-      void $.urlSessionId;  // declare the trigger - legitimate in model effects, never in renders
+      void $.urlThreadId;  // declare the trigger - legitimate in model effects, never in renders
       this.syncRoute();
     });
   }
+
+  async send() {
+    const tid = this.threadId ??= createId();       // working field leads
+    this.navigate(`/t/${tid}`, { replace: true });  // navigation confirms, never informs
+    ...
+  }
 }
 ```
+
+Assign the working field the moment identity is created. If methods thread fresh ids through arguments to outrun the route, or a shadow field remembers the last route seen, the working field is still a mirror.
 
 ## Context Sharing
 

--- a/skills/react/react.md
+++ b/skills/react/react.md
@@ -103,6 +103,8 @@ function SearchPage() {
 }
 ```
 
+This is the bridge for router hooks (`useParams`, `useLocation`, `useNavigate`); the alternative - an outer FC passing params as props - and route-identity guidance are in [patterns.md](patterns.md).
+
 When `use()` is defined, its parameter types become the static .use() argument types. They are passed to method instead of the constructor.
 
 ```tsx

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -58,7 +58,7 @@ export class ReviewStep extends Component {
 
 If a property or action is *about* an entry in a collection, it lives on that entry's class - not on the page. The page-level tells are syntactic:
 
-- a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures (`items` plus `selectedIds`)
+- a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures (`items` plus `selectedIds` - a second pool of the members themselves, `selected = has(Item)`, is the honest shape)
 - a method taking `(id, value)`: `setItemWeight(id, w)`, `toggle(id)`
 - reassigning a collection to update one entry: `this.items = this.items.map(...)`, `this.jobs = { ...this.jobs, [id]: job }`
 

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -67,36 +67,36 @@ Each tell is a missing class. Declare a `has` pool whose factory accepts the API
 
 ```tsx
 // Wrong: item state flattened onto the page
-class GalleryPage extends Component {
-  images: ImageMeta[] = [];
-  selectedNames = new Set<string>();
-  imports: Record<string, ImportJob> = {};
+class Inbox extends Component {
+  messages: MessageDto[] = [];
+  selectedIds = new Set<string>();
+  uploads: Record<string, UploadJob> = {};
 
-  setWeight(name: string, weight: number) {
-    this.images = this.images.map((i) => i.name === name ? { ...i, weight } : i);
+  setLabel(id: string, label: string) {
+    this.messages = this.messages.map((m) => m.id === id ? { ...m, label } : m);
   }
 }
 
 // Right: the entry is a class; the page keeps fetch, the pool, and policy
-class GalleryImage extends Component {
-  info = set<ImageMeta>();   // payload stays one subobject - not exploded per key
-  name = set<string>();
+class Message extends Component {
+  info = set<MessageDto>();   // payload stays one subobject - not exploded per key
+  id = set<string>();
   selected = false;
-  gallery = get(GalleryPage);
+  inbox = get(Inbox);
 
   render() { /* the row paints itself */ }
 }
 
-class GalleryPage extends Component {
-  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+class Inbox extends Component {
+  messages = has((dto: MessageDto) => new Message({ info: dto, id: dto.id }));
 
   get selected() {
-    return this.images.filter((i) => i.selected);
+    return this.messages.filter((m) => m.selected);
   }
 }
 ```
 
-Selection flags, per-row status, and row actions live on the member (`image.selected`, `image.remove()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows that own `render()` place directly - `{page.images}` or a subset `{list}` - no `.map`. If two views compute the same expression over an entry, that expression is a getter on the entry's class.
+Selection flags, per-row status, and row actions live on the member (`message.selected`, `message.archive()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows that own `render()` place directly - `{inbox.messages}` or a subset `{list}` - no `.map`. If two views compute the same expression over an entry, that expression is a getter on the entry's class.
 
 Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
 
@@ -104,31 +104,31 @@ Behavior parity does not exempt this step - parity constrains observable behavio
 
 ## 5. Split regions out of fat orchestrators
 
-When a page State still accumulates unrelated clusters after pools - form config plus catalog plus job plus navigation is the classic shape - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
+When a page State still accumulates unrelated clusters after pools - draft fields plus lookups plus request state plus navigation is the classic shape - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
 
 ```tsx
-class RecipePanel extends State {      // headless region
-  page = get(GeneratePage);
-  prompt = '';
-  loras = has((dto: Lora) => new AppliedLora(dto));
+class Composer extends State {        // headless region
+  page = get(ComposePage);
+  subject = '';
+  attachments = has((file: File) => new Attachment({ file }));
 
   get ready() { ... }
 }
 
-class GeneratePage extends Component { // orchestrator: route, session, job
-  recipe = new RecipePanel();
+class ComposePage extends Component { // orchestrator: route, session, request
+  composer = new Composer();
   busy = false;
 
-  get canGenerate() {
-    return this.recipe.ready && !this.busy;
+  get canSend() {
+    return this.composer.ready && !this.busy;
   }
 
-  async generate() { /* recipe -> job -> session */ }
+  async send() { /* composer -> request -> thread */ }
 }
 
 // Form sections bind the region; the footer mixes both
-const { is: recipe, prompt } = RecipePanel.get();
-const { canGenerate, generate } = GeneratePage.get();
+const { is: composer, subject } = Composer.get();
+const { canSend, send } = ComposePage.get();
 ```
 
 An owned region needs no cross-controller synchronization - the parent holds the instance and reads it directly; only views subscribe. Split when the second cluster appears, not as a late cleanup.

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -4,22 +4,22 @@ Read this in full before converting hook-based React code. The most common failu
 
 Examples follow the conventions in [style.md](style.md).
 
-**Scope for large apps:** convert route/page controllers and their domain pools first; leave mature leaf widgets (inputs, menus) on hooks until their parent domain is stable. Coexistence is fine mid-migration.
+**Scope for large apps:** convert route/page controllers and their domain pools first; leave mature leaf widgets (inputs, menus) on hooks until parent domain is stable. Coexistence is fine mid-migration.
 
 ## Ambiguity defaults
 
-A one-shot conversion cannot ask. Proceed on these defaults and declare any deviation in the deliverable; ask only when acting on an assumption would destroy something unrecoverable - a feature, a public API.
+A one-shot conversion cannot ask. Proceed on these defaults and declare deviations in the deliverable; ask only when an assumption would destroy something unrecoverable - a feature, a public API.
 
 | Ambiguity | Default |
 |---|---|
 | "No redesigns" / parity scope | Observable behavior and public contracts; internal structure is the task |
-| Does leaving a route clear its model? | Keep the model alive; soft-sync working identity from params |
+| Does leaving a route clear its model? | Keep model alive; soft-sync working identity from params |
 | Selection across refetch | Durable key + re-find getter; member references only in pools stable between fetches |
 | Loading UX for user-initiated ops | Explicit loading/error fields; suspense for load-once data |
-| File layout | Colocate a feature folder once a route has model classes; existing project convention wins |
-| Verification gate | The project's currently-green checks - a check broken at base is not yours to fix; report exactly what was exercised |
+| File layout | Colocate feature folder once a route has model classes; existing convention wins |
+| Verification gate | Currently-green checks only - a check broken at base is not yours to fix; report what was exercised |
 | Bug or dead branch found at base | Preserve behavior and note it; drop only provably dead code, and say so |
-| Routing | Bridge the existing router (step 7); adopting `@expressive/router` is a separate decision that needs explicit go-ahead, never part of a conversion |
+| Routing | Bridge the existing router (step 7); adopting `@expressive/router` needs explicit go-ahead, never part of a conversion |
 | Deliverable | Ownership map, assumptions taken, behavior deltas, filled checklist - in the PR or ledger |
 
 ## 1. Identify owners before touching hooks
@@ -72,14 +72,14 @@ export class ReviewStep extends Component {
 
 ## 4. Give repeated UI entries their own class
 
-If a property or action is *about* an entry in a collection, it lives on that entry's class - not on the page. The page-level tells are syntactic:
+A property or action *about* an entry in a collection lives on that entry's class - not the page. The tells are syntactic:
 
-- a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures (`items` plus `selectedIds` - a second pool of the members themselves, `selected = has(Item)`, is the honest shape)
+- a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures - `items` plus `selectedIds`; a second pool of the members, `selected = has(Item)`, is the honest shape
 - a method taking `(id, value)`: `setItemWeight(id, w)`, `toggle(id)`
-- a page method that re-finds a member by id (`pool.get((x) => x.id === id)`) - it is the member's method; behavior moves with the state
+- a page method re-finding a member by id `pool.get((x) => x.id === id)` - that is the member's method; behavior moves with state
 - reassigning a collection to update one entry: `this.items = this.items.map(...)`, `this.jobs = { ...this.jobs, [id]: job }`
 
-Each tell is a missing class. Declare a `has` pool whose factory accepts the API payload, and move the state and actions onto the member:
+Each tell is a missing class. Declare a `has` pool whose factory takes the API payload; move state and actions onto the member:
 
 ```tsx
 // Wrong: item state flattened onto the page
@@ -112,17 +112,17 @@ class Inbox extends Component {
 }
 ```
 
-Selection flags, per-row status, and row actions live on the member (`message.selected`, `message.archive()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows that own `render()` place directly - `{inbox.messages}` or a subset `{list}` - no `.map`. If two views compute the same expression over an entry, that expression is a getter on the entry's class.
+Selection flags, per-row status, and row actions live on the member (`message.selected`, `message.archive()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows owning `render()` place directly - `{inbox.messages}` or subset `{list}` - no `.map`. Two views computing the same expression over an entry means a getter on the entry's class.
 
-A row earns a pool when it has any of: mutable UI state (selection, expanded), an async lifecycle (upload, watch, progress), or actions (remove, retry) - one suffices. Demoting such a row to a plain DTO is not economy: its status then reads through lookups, and a method call on a raw instance creates no subscription - progress that only ever renders through `page.importFor(id)` never repaints. Tracked reads reach the member through the pool or its own `render()`.
+A row earns a pool with any of: mutable UI state (selection, expanded), async lifecycle (upload, watch, progress), actions (remove, retry) - one suffices. Demoting such a row to plain DTO is not economy: status then reads thru lookups, and a method call on a raw instance creates no subscription - progress rendered only thru `page.importFor(id)` never repaints. Tracked reads reach the member thru the pool or its own `render()`.
 
-Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
+Keep members small: promote a payload key to reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` here so presence fields stay optional. See [has.md](../field/has.md) for pool surface, [patterns.md](patterns.md) for worked recipes.
 
-Behavior parity does not exempt this step - parity constrains observable behavior, not code shape, and a task scoped "no redesigns" means the UI and public contracts, not internal structure; this conversion restructures by definition. Entry ownership is an invariant, not a stylistic option a conversion may decline.
+Behavior parity does not exempt this step - parity constrains observable behavior, not code shape; a task scoped "no redesigns" means UI and public contracts, not internal structure. Entry ownership is an invariant, not a style option a conversion may decline.
 
 ## 5. Split regions out of fat orchestrators
 
-When a page State still accumulates unrelated clusters after pools - draft fields plus lookups plus request state plus navigation is the classic shape - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
+When a page State still accumulates unrelated clusters after pools - draft fields plus lookups plus request state plus navigation - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
 
 ```tsx
 class Composer extends State {        // headless region
@@ -149,7 +149,7 @@ const { is: composer, subject } = Composer.get();
 const { canSend, send } = ComposePage.get();
 ```
 
-An owned region needs no cross-controller synchronization - the parent holds the instance and reads it directly; only views subscribe. Split when the second cluster appears, not as a late cleanup.
+An owned region needs no cross-controller synchronization - the parent holds the instance and reads it directly. Split when the second cluster appears, not as late cleanup.
 
 ## 6. Provide classes directly
 
@@ -183,10 +183,10 @@ Mapping for what remains after ownership is settled:
 - Values written by user input, browser events, timers, or network callbacks -> mutable class fields.
 - `useMemo` values and effects that only sync state -> class getters.
 - `useEffect` setup/teardown -> `protected new()` returning cleanup; browser-only resources -> `mount()` on a `Component`.
-- Chains of `useEffect`s reacting to each other -> tracked reactions (`this.get($ => ...)`) registered in `new()`/`mount()`. Updates batch, so each flush re-runs a reaction once, however many trigger fields changed.
-- `useCallback` handlers -> auto-bound class methods. Pass them directly to timers and listeners: `setInterval(this.tick, 1000)`, not `() => this.tick()`.
-- `useRef` handles - unsubscribe functions, snapshots, timer ids -> unmanaged fields ([state.md](../state/state.md#unmanaged-instance-data)), never reactive fields and never `#private`.
-- Route params -> props on the page owner. Keep working identity (current session, selection) as a separate field a reaction soft-syncs - never the URL param itself. The fused version announces itself as stale-prop workarounds: threading fresh ids through method arguments to outrun the route, or shadow fields remembering the last route seen. See the router recipe in [patterns.md](patterns.md).
+- Chains of `useEffect`s reacting to each other -> tracked reactions (`this.get($ => ...)`) registered in `new()`/`mount()`; updates batch, one re-run per flush however many trigger fields changed.
+- `useCallback` handlers -> auto-bound class methods - pass directly to timers and listeners: `setInterval(this.tick, 1000)`, not `() => this.tick()`.
+- `useRef` handles - unsubscribe functions, snapshots, timer ids -> unmanaged fields ([state.md](../state/state.md#unmanaged-instance-data)) - never reactive, never `#private`.
+- Route params -> props on the page owner. Working identity (session, selection) is a separate field a reaction soft-syncs - never the URL param itself. Fusion announces itself as stale-prop workarounds: fresh ids threaded thru arguments to outrun the route, shadow fields remembering the last route seen. Router recipe in [patterns.md](patterns.md).
 
 The route-identity split, concretely:
 
@@ -321,7 +321,7 @@ Pure presentation components (a `Metric`, a `StatusCallout`) may still take plai
 
 ## 10. Destructure an exact dependency snapshot
 
-Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place. These are React hooks: top of the component or `render()`, unconditionally - a `.get()` in an event handler or a conditionally-called helper builds green and crashes at runtime.
+Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place. These are React hooks: top of component or `render()`, unconditionally - in a branch, handler, or loop they build green and crash at runtime.
 
 ```tsx
 // Wrong: deep reads scattered through JSX, one hidden in a branch

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -6,6 +6,21 @@ Examples follow the conventions in [style.md](style.md).
 
 **Scope for large apps:** convert route/page controllers and their domain pools first; leave mature leaf widgets (inputs, menus) on hooks until their parent domain is stable. Coexistence is fine mid-migration.
 
+## Ambiguity defaults
+
+A one-shot conversion cannot ask. Proceed on these defaults and declare any deviation in the deliverable; ask only when acting on an assumption would destroy something unrecoverable - a feature, a public API.
+
+| Ambiguity | Default |
+|---|---|
+| "No redesigns" / parity scope | Observable behavior and public contracts; internal structure is the task |
+| Does leaving a route clear its model? | Keep the model alive; soft-sync working identity from params |
+| Selection across refetch | Durable key + re-find getter; member references only in pools stable between fetches |
+| Loading UX for user-initiated ops | Explicit loading/error fields; suspense for load-once data |
+| File layout | Colocate a feature folder once a route has model classes; existing project convention wins |
+| Verification gate | The project's currently-green checks - a check broken at base is not yours to fix; report exactly what was exercised |
+| Bug or dead branch found at base | Preserve behavior and note it; drop only provably dead code, and say so |
+| Deliverable | Ownership map, assumptions taken, behavior deltas, filled checklist - in the PR or ledger |
+
 ## 1. Identify owners before touching hooks
 
 List the stateful concerns in the code being converted - not the hooks, the *concerns*: a multi-step workflow, a settings draft, a preview toggle, a network resource. Each concern gets exactly one owner. Only after the owner list is stable should any hook be touched.

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -19,6 +19,7 @@ A one-shot conversion cannot ask. Proceed on these defaults and declare any devi
 | File layout | Colocate a feature folder once a route has model classes; existing project convention wins |
 | Verification gate | The project's currently-green checks - a check broken at base is not yours to fix; report exactly what was exercised |
 | Bug or dead branch found at base | Preserve behavior and note it; drop only provably dead code, and say so |
+| Routing | Bridge the existing router (step 7); adopting `@expressive/router` is a separate decision that needs explicit go-ahead, never part of a conversion |
 | Deliverable | Ownership map, assumptions taken, behavior deltas, filled checklist - in the PR or ledger |
 
 ## 1. Identify owners before touching hooks

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -98,6 +98,8 @@ class Inbox extends Component {
 
 Selection flags, per-row status, and row actions live on the member (`message.selected`, `message.archive()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows that own `render()` place directly - `{inbox.messages}` or a subset `{list}` - no `.map`. If two views compute the same expression over an entry, that expression is a getter on the entry's class.
 
+A row earns a pool when it has any of: mutable UI state (selection, expanded), an async lifecycle (upload, watch, progress), or actions (remove, retry) - one suffices. Demoting such a row to a plain DTO is not economy: its status then reads through lookups, and a method call on a raw instance creates no subscription - progress that only ever renders through `page.importFor(id)` never repaints. Tracked reads reach the member through the pool or its own `render()`.
+
 Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
 
 Behavior parity does not exempt this step - parity constrains observable behavior, not code shape. Entry ownership is an invariant, not a stylistic option a conversion may decline.
@@ -169,6 +171,43 @@ Mapping for what remains after ownership is settled:
 - `useCallback` handlers -> auto-bound class methods. Pass them directly to timers and listeners: `setInterval(this.tick, 1000)`, not `() => this.tick()`.
 - `useRef` handles - unsubscribe functions, snapshots, timer ids -> unmanaged fields ([state.md](../state/state.md#unmanaged-instance-data)), never reactive fields and never `#private`.
 - Route params -> props on the page owner. Keep working identity (current session, selection) as a separate field a reaction soft-syncs - never the URL param itself. The fused version announces itself as stale-prop workarounds: threading fresh ids through method arguments to outrun the route, or shadow fields remembering the last route seen. See the router recipe in [patterns.md](patterns.md).
+
+The route-identity split, concretely:
+
+```tsx
+// Wrong: the URL param is the working identity - fresh ids outrun the route
+class Workspace extends Component {
+  sessionId?: string;                 // route prop
+
+  async send() {
+    let sid = this.sessionId;
+    if (!sid) {
+      sid = createId();               // threaded through locals; the model
+      this.navigate(`/s/${sid}`);     // learns its own id via prop round-trip
+    }
+    await api.send(sid, this.body);
+  }
+}
+
+// Right: the working field leads; navigation confirms, never informs
+class Workspace extends Component {
+  sessionId?: string;                 // working identity
+  urlSessionId?: string;              // route prop
+
+  mount() {
+    return this.get(($) => {
+      void $.urlSessionId;
+      this.syncRoute();               // adopt or keep per policy - not 1:1
+    });
+  }
+
+  async send() {
+    const sid = this.sessionId ??= createId();
+    this.navigate(`/s/${sid}`, { replace: true });
+    await api.send(sid, this.body);
+  }
+}
+```
 
 Reactive fields are assigned directly - do not manufacture setters:
 

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -305,7 +305,7 @@ Pure presentation components (a `Metric`, a `StatusCallout`) may still take plai
 
 ## 10. Destructure an exact dependency snapshot
 
-Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place:
+Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place. These are React hooks: top of the component or `render()`, unconditionally - a `.get()` in an event handler or a conditionally-called helper builds green and crashes at runtime.
 
 ```tsx
 // Wrong: deep reads scattered through JSX, one hidden in a branch

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -60,6 +60,7 @@ If a property or action is *about* an entry in a collection, it lives on that en
 
 - a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures (`items` plus `selectedIds` - a second pool of the members themselves, `selected = has(Item)`, is the honest shape)
 - a method taking `(id, value)`: `setItemWeight(id, w)`, `toggle(id)`
+- a page method that re-finds a member by id (`pool.get((x) => x.id === id)`) - it is the member's method; behavior moves with the state
 - reassigning a collection to update one entry: `this.items = this.items.map(...)`, `this.jobs = { ...this.jobs, [id]: job }`
 
 Each tell is a missing class. Declare a `has` pool whose factory accepts the API payload, and move the state and actions onto the member:
@@ -99,6 +100,8 @@ Selection flags, per-row status, and row actions live on the member (`image.sele
 
 Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
 
+Behavior parity does not exempt this step - parity constrains observable behavior, not code shape. Entry ownership is an invariant, not a stylistic option a conversion may decline.
+
 ## 5. Split regions out of fat orchestrators
 
 When a page State still accumulates unrelated clusters after pools - form config plus catalog plus job plus navigation is the classic shape - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
@@ -128,7 +131,7 @@ const { is: recipe, prompt } = RecipePanel.get();
 const { canGenerate, generate } = GeneratePage.get();
 ```
 
-Split when the second cluster appears, not as a late cleanup.
+An owned region needs no cross-controller synchronization - the parent holds the instance and reads it directly; only views subscribe. Split when the second cluster appears, not as a late cleanup.
 
 ## 6. Provide classes directly
 
@@ -165,7 +168,7 @@ Mapping for what remains after ownership is settled:
 - Chains of `useEffect`s reacting to each other -> tracked reactions (`this.get($ => ...)`) registered in `new()`/`mount()`. Updates batch, so each flush re-runs a reaction once, however many trigger fields changed.
 - `useCallback` handlers -> auto-bound class methods. Pass them directly to timers and listeners: `setInterval(this.tick, 1000)`, not `() => this.tick()`.
 - `useRef` handles - unsubscribe functions, snapshots, timer ids -> unmanaged fields ([state.md](../state/state.md#unmanaged-instance-data)), never reactive fields and never `#private`.
-- Route params -> props on the page owner. Keep working identity (current session, selection) as separate fields a reaction soft-syncs - do not bind a field 1:1 to a URL param when leaving the route must not clear it. See the router recipe in [patterns.md](patterns.md).
+- Route params -> props on the page owner. Keep working identity (current session, selection) as a separate field a reaction soft-syncs - never the URL param itself. The fused version announces itself as stale-prop workarounds: threading fresh ids through method arguments to outrun the route, or shadow fields remembering the last route seen. See the router recipe in [patterns.md](patterns.md).
 
 Reactive fields are assigned directly - do not manufacture setters:
 
@@ -404,6 +407,7 @@ The checklist:
 - Are opaque handles (unsubscribe fns, timers, snapshots) unmanaged rather than reactive fields? *(invariant)*
 - Does every subscription consume what it declares - no `void x` reads to force tracking in a render? *(invariant)*
 - Is a page State with unrelated clusters split into owned region States? *(default)*
+- Is working identity (session, selection) a separate field from URL params, soft-synced by a reaction? *(default)*
 - Does every method do more than assign one field? *(invariant)*
 - Are contextual values still being drilled through props? *(invariant)*
 - Does every `.get()` / `.use()` show the exact nested dependency surface? *(invariant)*

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -102,7 +102,7 @@ A row earns a pool when it has any of: mutable UI state (selection, expanded), a
 
 Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
 
-Behavior parity does not exempt this step - parity constrains observable behavior, not code shape. Entry ownership is an invariant, not a stylistic option a conversion may decline.
+Behavior parity does not exempt this step - parity constrains observable behavior, not code shape, and a task scoped "no redesigns" means the UI and public contracts, not internal structure; this conversion restructures by definition. Entry ownership is an invariant, not a stylistic option a conversion may decline.
 
 ## 5. Split regions out of fat orchestrators
 

--- a/skills/react/refactor.md
+++ b/skills/react/refactor.md
@@ -4,6 +4,8 @@ Read this in full before converting hook-based React code. The most common failu
 
 Examples follow the conventions in [style.md](style.md).
 
+**Scope for large apps:** convert route/page controllers and their domain pools first; leave mature leaf widgets (inputs, menus) on hooks until their parent domain is stable. Coexistence is fine mid-migration.
+
 ## 1. Identify owners before touching hooks
 
 List the stateful concerns in the code being converted - not the hooks, the *concerns*: a multi-step workflow, a settings draft, a preview toggle, a network resource. Each concern gets exactly one owner. Only after the owner list is stable should any hook be touched.
@@ -52,7 +54,83 @@ export class ReviewStep extends Component {
 
 **Anti-pattern - subcomponent overuse.** The sections composed in `render()` above are freestanding FCs, not PascalCase methods on the class. Subcomponents (`<this.Header />`) are extension points - machinery for subclasses to replace or wrap. The test: **would a subclass reasonably replace or wrap this renderer?** For ordinary implementation scopes the answer is no, and a freestanding FC calling `ReviewStep.get()` is clearer. See [component.md](component.md).
 
-## 4. Provide classes directly
+## 4. Give repeated UI entries their own class
+
+If a property or action is *about* an entry in a collection, it lives on that entry's class - not on the page. The page-level tells are syntactic:
+
+- a field keyed by id: `Record<Id, T>`, `Map<Id, unknown>`, or parallel structures (`items` plus `selectedIds`)
+- a method taking `(id, value)`: `setItemWeight(id, w)`, `toggle(id)`
+- reassigning a collection to update one entry: `this.items = this.items.map(...)`, `this.jobs = { ...this.jobs, [id]: job }`
+
+Each tell is a missing class. Declare a `has` pool whose factory accepts the API payload, and move the state and actions onto the member:
+
+```tsx
+// Wrong: item state flattened onto the page
+class GalleryPage extends Component {
+  images: ImageMeta[] = [];
+  selectedNames = new Set<string>();
+  imports: Record<string, ImportJob> = {};
+
+  setWeight(name: string, weight: number) {
+    this.images = this.images.map((i) => i.name === name ? { ...i, weight } : i);
+  }
+}
+
+// Right: the entry is a class; the page keeps fetch, the pool, and policy
+class GalleryImage extends Component {
+  info = set<ImageMeta>();   // payload stays one subobject - not exploded per key
+  name = set<string>();
+  selected = false;
+  gallery = get(GalleryPage);
+
+  render() { /* the row paints itself */ }
+}
+
+class GalleryPage extends Component {
+  images = has((meta: ImageMeta) => new GalleryImage({ info: meta, name: meta.name }));
+
+  get selected() {
+    return this.images.filter((i) => i.selected);
+  }
+}
+```
+
+Selection flags, per-row status, and row actions live on the member (`image.selected`, `image.remove()`); the page keeps fetch, pool lifecycle, and multi-select *policy*. Rows that own `render()` place directly - `{page.images}` or a subset `{list}` - no `.map`. If two views compute the same expression over an entry, that expression is a getter on the entry's class.
+
+Keep members small: promote a payload key to its own reactive field only when views render it or it changes independently; the rest stays whole as one `info` field. Normalize API `null` to `undefined` at this boundary so presence fields stay optional. See [has.md](../field/has.md) for the pool surface and [patterns.md](patterns.md) for worked recipes.
+
+## 5. Split regions out of fat orchestrators
+
+When a page State still accumulates unrelated clusters after pools - form config plus catalog plus job plus navigation is the classic shape - each cluster becomes its own State owned as a field. Ownership provides implicitly; views bind the region directly:
+
+```tsx
+class RecipePanel extends State {      // headless region
+  page = get(GeneratePage);
+  prompt = '';
+  loras = has((dto: Lora) => new AppliedLora(dto));
+
+  get ready() { ... }
+}
+
+class GeneratePage extends Component { // orchestrator: route, session, job
+  recipe = new RecipePanel();
+  busy = false;
+
+  get canGenerate() {
+    return this.recipe.ready && !this.busy;
+  }
+
+  async generate() { /* recipe -> job -> session */ }
+}
+
+// Form sections bind the region; the footer mixes both
+const { is: recipe, prompt } = RecipePanel.get();
+const { canGenerate, generate } = GeneratePage.get();
+```
+
+Split when the second cluster appears, not as a late cleanup.
+
+## 6. Provide classes directly
 
 ```tsx
 // Wrong: instance created only to be provided
@@ -77,14 +155,17 @@ function App() {
 
 Provide an instance only when preconfiguration or external ownership genuinely requires it.
 
-## 5. Move source state and behavior; do not translate setters
+## 7. Move source state and behavior; do not translate setters
 
 Mapping for what remains after ownership is settled:
 
 - Values written by user input, browser events, timers, or network callbacks -> mutable class fields.
 - `useMemo` values and effects that only sync state -> class getters.
-- `useEffect` setup/teardown -> `protected new()` returning cleanup.
-- `useCallback` handlers -> auto-bound class methods.
+- `useEffect` setup/teardown -> `protected new()` returning cleanup; browser-only resources -> `mount()` on a `Component`.
+- Chains of `useEffect`s reacting to each other -> tracked reactions (`this.get($ => ...)`) registered in `new()`/`mount()`. Updates batch, so each flush re-runs a reaction once, however many trigger fields changed.
+- `useCallback` handlers -> auto-bound class methods. Pass them directly to timers and listeners: `setInterval(this.tick, 1000)`, not `() => this.tick()`.
+- `useRef` handles - unsubscribe functions, snapshots, timer ids -> unmanaged fields ([state.md](../state/state.md#unmanaged-instance-data)), never reactive fields and never `#private`.
+- Route params -> props on the page owner. Keep working identity (current session, selection) as separate fields a reaction soft-syncs - do not bind a field 1:1 to a URL param when leaving the route must not clear it. See the router recipe in [patterns.md](patterns.md).
 
 Reactive fields are assigned directly - do not manufacture setters:
 
@@ -117,7 +198,7 @@ setStartDate(startDate: string) {
 
 Audit rule: **delete any method whose body is only `this.field = value`.** It adds vocabulary without adding policy.
 
-## 6. Getters: shared and semantic only
+## 8. Getters: shared and semantic only
 
 A derived value earns a getter on shared state when it is read by multiple consumers, expresses domain or workflow meaning, is expensive enough to merit memoized tracking, is a deliberate part of the state's API, or makes the state usefully introspectable (debugging, devtools):
 
@@ -151,7 +232,7 @@ function StepIndicator() {
 
 Judge meaning, not reference counts. A getter with one JSX consumer today may still earn its place as a domain capability or an introspectable part of the state surface - a locality finding needs a semantic argument ("this is JSX formatting, not workflow meaning"), never a static count alone.
 
-## 7. Kill prop drilling
+## 9. Kill prop drilling
 
 Contextual children declare their own dependencies with `.get()`. Do not preserve the prop contracts the hook implementation needed:
 
@@ -180,7 +261,7 @@ function ReviewActions() {
 
 Pure presentation components (a `Metric`, a `StatusCallout`) may still take plain props - context replaces drilled *state*, not every value.
 
-## 8. Destructure an exact dependency snapshot
+## 10. Destructure an exact dependency snapshot
 
 Every `.get()` / `.use()` opens the component with the exact reactive values it renders, nested levels included, optional objects defaulted in place:
 
@@ -224,7 +305,7 @@ Three reasons this is the norm:
 
 The same applies to `this` inside `Component.render()` and subcomponents: destructure what the section reads at the top - the rendering shares its subscription plumbing with the hooks.
 
-## 9. Write through the proxy; use `is` sparingly
+## 11. Write through the proxy; use `is` sparingly
 
 Subscription proxies pass assignments through to the real instance. Three shapes cover every case:
 
@@ -240,7 +321,7 @@ const { is: review, confirmed } = ReviewStep.get(); // root object + sibling val
 
 **Anti-pattern:** aliasing `is` whenever anything will be written. Writes do not need the raw instance - unwrapping nested objects through `is` is noise.
 
-## 10. Put presence gates at the call site
+## 12. Put presence gates at the call site
 
 When content requires values that may not exist yet, the parent owns the render gate and the child asserts its invariant with `.get(true)`:
 
@@ -279,7 +360,7 @@ function SettingsEditor() {
 
 Declare gateable fields optional (`draft?: SettingsLocation`), not `| null` - `get(true)` rejects only `undefined`, and `Required<T>` does not strip `null` from unions.
 
-## 11. Extract, then consolidate
+## 13. Extract, then consolidate
 
 A conditional JSX branch above roughly ten lines or five component levels is a signal to give it its own named scope - a heuristic, not a mandate. Then apply the inverse: **recombine scopes that share the same dependencies, read locally, and contain no nested decision logic.** Splitting every fragment creates navigation overhead without clarifying ownership.
 
@@ -307,7 +388,7 @@ When an early return would skip most of a declared snapshot, that is a signal th
 
 The line/depth threshold is a signal, never grounds for a finding by itself. To fail a branch, name the concrete cost: a conditional subscription, multiple independent decisions in one branch, mixed ownership, a duplicated dependency snapshot, or navigation that a well-named scope would materially improve. "A separate component would be slightly nicer" is optional polish, not a defect.
 
-## 12. Audit with this checklist
+## 14. Audit with this checklist
 
 Rules carry different weights - classify every finding by severity:
 
@@ -319,6 +400,10 @@ Rules carry different weights - classify every finding by severity:
 The checklist:
 
 - Is each state field owned at the narrowest useful scope? *(invariant)*
+- Does state about a collection entry live on the entry's class - no id-keyed records, no `(id, value)` methods, no reassign-to-update-one-entry? *(invariant)*
+- Are opaque handles (unsubscribe fns, timers, snapshots) unmanaged rather than reactive fields? *(invariant)*
+- Does every subscription consume what it declares - no `void x` reads to force tracking in a render? *(invariant)*
+- Is a page State with unrelated clusters split into owned region States? *(default)*
 - Does every method do more than assign one field? *(invariant)*
 - Are contextual values still being drilled through props? *(invariant)*
 - Does every `.get()` / `.use()` show the exact nested dependency surface? *(invariant)*
@@ -328,9 +413,10 @@ The checklist:
 - Are Component subcomponents genuine extension points? *(invariant)*
 - Does every getter on shared state earn its place - multiple consumers, domain meaning, expensive computation, deliberate API, or introspection value? *(default - judge meaning, not reference counts)*
 - Are large JSX branches named without fragmenting trivial shared logic? *(heuristic - name the cost)*
-- Are nested destructures placed after direct properties? *(style)*
+- Are nested destructures placed after direct properties, with `is` first when retained? *(style)*
 
 Auditing notes:
 
 - Compare ownership, dependency surfaces, and write behavior - never filenames, file counts, or similarity to a particular reference implementation. File size and consolidation are project preferences: supplied by the project, scored separately.
 - Report two verdicts - architectural conformance and style-profile adherence - so a formatting miss cannot obscure correct structure, or vice versa.
+- Deliver the filled checklist with the change (PR description or ledger), not only a verdict.

--- a/skills/react/style.md
+++ b/skills/react/style.md
@@ -65,4 +65,4 @@ If a render guard would skip past most of an already-declared snapshot, the gate
 
 ## Layout
 
-Once a route has a model class, colocate the feature: `pages/gallery/` holding `index.tsx` (route shell), the page class, domain classes, and view slices - not a fat `Gallery.tsx` beside a partial folder. Project preference; never an audit finding.
+Once a route has a model class, colocate the feature: `pages/inbox/` holding `index.tsx` (route shell), the page class, domain classes, and view slices - not a fat `Inbox.tsx` beside a partial folder. Project preference; never an audit finding.

--- a/skills/react/style.md
+++ b/skills/react/style.md
@@ -5,6 +5,7 @@ These are conventions, not library semantics. They ship with the golden path bec
 ## Snapshot formatting
 
 - When a destructure contains multiple values, put every binding on its own line.
+- `is` (aliased) is the first binding when retained.
 - Direct properties come first; nested destructures go at the bottom.
 - Expand nested levels vertically - one key per line, closing braces aligned.
 - Optional nested objects take in-place defaults, not a separate unwrap:
@@ -60,4 +61,8 @@ downloadIif() {
 }
 ```
 
-If a render guard would skip past most of an already-declared snapshot, the gated content is a candidate for its own component - see step 11 of [refactor.md](refactor.md).
+If a render guard would skip past most of an already-declared snapshot, the gated content is a candidate for its own component - see step 13 of [refactor.md](refactor.md).
+
+## Layout
+
+Once a route has a model class, colocate the feature: `pages/gallery/` holding `index.tsx` (route shell), the page class, domain classes, and view slices - not a fat `Gallery.tsx` beside a partial folder. Project preference; never an audit finding.

--- a/skills/react/style.md
+++ b/skills/react/style.md
@@ -65,4 +65,4 @@ If a render guard would skip past most of an already-declared snapshot, the gate
 
 ## Layout
 
-Once a route has a model class, colocate the feature: `pages/inbox/` holding `index.tsx` (route shell), the page class, domain classes, and view slices - not a fat `Inbox.tsx` beside a partial folder. Project preference; never an audit finding.
+Once a route has a model class, colocate: `pages/inbox/` holding `index.tsx` (route shell), page class, domain classes, view slices - not a fat `Inbox.tsx` beside a partial folder. Project preference; never an audit finding.

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -17,8 +17,12 @@
 class Timer extends State {
   elapsed = 0;
 
+  tick() {
+    this.elapsed++;
+  }
+
   protected new() {
-    const id = setInterval(() => this.elapsed++, 1000);
+    const id = setInterval(this.tick, 1000);
     return () => clearInterval(id);
   }
 }

--- a/skills/state/state.md
+++ b/skills/state/state.md
@@ -69,7 +69,7 @@ for (const [key, value] of state) {
 
 ### Unmanaged Instance Data
 
-Opaque handles - unsubscribe functions, timers, snapshots - are not reactive state: their writes should not notify, nor throw through the managed setter after destroy. TypeScript `private` does not opt out (any enumerable own field is managed), and ES `#private` fields escape management but re-initialize unsafely on Components. Define the field non-enumerable via `def`:
+Opaque handles - unsubscribe functions, timers, snapshots - are not reactive state: writes should not notify, nor throw thru the managed setter after destroy. TypeScript `private` does not opt out (any enumerable own field is managed); ES `#private` escapes management but re-initializes unsafely on Components. Define the field non-enumerable via `def`:
 
 ```ts
 import State, { def } from '@expressive/mvc';
@@ -91,7 +91,7 @@ class Job extends State {
 }
 ```
 
-The `def` factory returns void, so no managed property is applied. A destroyed instance is frozen - run cleanup before then: `const stop = this.unwatch; this.unwatch = null; stop?.();`. A handle only lifecycle touches can stay simpler as a `new()` closure variable.
+The `def` factory returns void, so no managed property is applied. A destroyed instance is frozen - run cleanup before then: `const stop = this.unwatch; this.unwatch = null; stop?.();`. A handle only lifecycle touches stays simpler as a `new()` closure variable.
 
 ## The `is` Property
 

--- a/skills/state/state.md
+++ b/skills/state/state.md
@@ -67,6 +67,32 @@ for (const [key, value] of state) {
 }
 ```
 
+### Unmanaged Instance Data
+
+Opaque handles - unsubscribe functions, timers, snapshots - are not reactive state: their writes should not notify, nor throw through the managed setter after destroy. TypeScript `private` does not opt out (any enumerable own field is managed), and ES `#private` fields escape management but re-initialize unsafely on Components. Define the field non-enumerable via `def`:
+
+```ts
+import State, { def } from '@expressive/mvc';
+
+function put<T>(initial?: T): T {
+  return def((key, self) => {
+    Object.defineProperty(self, key, {
+      value: initial as T,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+  }) as T;
+}
+
+class Job extends State {
+  progress = 0;                              // reactive
+  unwatch = put<(() => void) | null>(null);  // unmanaged
+}
+```
+
+The `def` factory returns void, so no managed property is applied. A destroyed instance is frozen - run cleanup before then: `const stop = this.unwatch; this.unwatch = null; stop?.();`. A handle only lifecycle touches can stay simpler as a `new()` closure variable.
+
 ## The `is` Property
 
 Circular self-reference. Destructure first to retain instance access alongside values, and usually alias it to the state concept (`is: counter`, `is: form`) rather than keeping a local named `is`.


### PR DESCRIPTION
Closes the skill gaps surfaced by the Diffuser Studio dogfood refactor (the `refactor/expressive-mvc` ledger), then validates every change with blind one-shot reproductions across four agents. The original one-shot followed every rule the skill *states* and missed everything it only *implies* — domain sizing above all; six human feedback rounds (F1–F12) taught what these docs now say up front.

## Diagnosis → change map

| Gap (ledger ID) | Change |
|---|---|
| S8 domain sizing — item state flattened into id-keyed records, `(id, value)` methods | refactor.md **step 4** (syntactic tells, wrong/right pair, pool-earning criteria), ownership clause + rule row in SKILL.md, DTO boundary + selection-durability doctrine in has.md |
| S17 region controllers | refactor.md **step 5**, recipe in patterns.md |
| S12/S16 worked pool examples, `{list}` placement | patterns.md: domain-row + form-chip recipes (chip owns its async watch lifecycle) replace the plain-array "Nested / Child State"; basic.md Todo rewritten on `has()` |
| S18 unmanaged handles | state.md "Unmanaged Instance Data" (`def`+`defineProperty`); ChatRoom socket moved to `new()` closure. Shipping `put()` stays an open followup — documented, not added as API |
| S1/S2 router bridge, effect chains | Hook-mapping rows in step 7 **plus the route-identity split as a wrong/right pair in the golden path** (as recipe-only text it missed five one-shots out of five); recipe + `use()` pointer in patterns.md/react.md |
| S10/S15 pool-member re-rendering, `void x` | Render-strategy + untracked-method-read rule in has.md Reads ("a method call on a raw instance creates no subscription"); anti-pattern callouts + checklist |
| S13/S9/S6/S14/S3/S5/S7 | `is`-first, auto-bound timer callbacks, one-shot scope (audit.md's bottom-up scoped to coexistence), feature folders, `null`→`undefined` at the boundary, suspense opt-out, checklist-as-deliverable |
| New (found in validation) | **Static `.get()`/`.use()` are hooks — render scope only** (a small-model run shipped two build-green runtime crashes); "no redesigns" scopes behavior not structure; audit as a separate pass; **ambiguity-defaults table** for one-shot conversions (proceed + declare, don't ask) |

## Key decisions

- **P0 content lives in SKILL.md + refactor.md** — the only guaranteed-read files; leaf files carry mechanics. Steps renumbered 12 → 14.
- **All recipes anonymized** to a neutral mail domain (Inbox/Message, Composer/Attachment, ComposePage, threadId). The recipes originally carried this app's own class names, which contaminated blind testing and read as app-specific.
- Examples verified against source (`constructor(...args: State.Args)`, `get(effect)` stop fn, pool `add` forwarding); rebased on #319, whose pool-admit enables the second-pool subset shape now referenced in the tells.

## Empirical validation (blind one-shots, same app, gold branch invisible)

| Run | Skill rev | Score (9-criterion rubric) |
|---|---|---|
| grok r1 → r2 → r3 → r4 | main → +checklist → +anonymized → +criteria/route-pair | 6/3/0 → 7/2/0 → 6/2/1 → **8/1/0** |
| claude frontier r1 → r2 | main → final | 7/2/0 → **9/0/0** |
| codex r1 → r2 | main → final | 2/3/4 → 4/1/4 |
| codex D1 / D3 (diagnostics†) | final | D1 **8/1/0** · D3 recovered all invariants |
| sonnet | final | 3/4/2 |

† Not comparable to the blind rows: D1 reworded one prompt sentence ("no redesigns" → "restructuring is the task") — same skill, same workspace — and D3 ran a fresh audit pass over r2's own refusal. D1 was externally scored like every other run; D3 fixed every invariant-severity failure and correctly left the region split (severity: default).

Findings the later commits encode:

1. **Placement + concreteness beat volume.** Recipe-only guidance failed 5/5 runs; the identical content as a hot-path wrong/right pair landed first try.
2. **Anonymization deconfounded name-matching** (r3's regression): rules transfer, names don't — the form-chip shape reproduced with zero name overlap while name-carried parity collapsed, so r4's clean score is real rule transfer.
3. **Codex's architecture refusal was prompt-priming, not capability**: rewording "no redesigns" flipped it to the full pool+region architecture; a fresh audit pass over its own refusal recovered every invariant. Hence the interpretation rule, the separate-pass audit note, and the ambiguity-defaults table.
4. **Model floor:** mechanical rules survive a tier downshift (sonnet reproduced them faithfully); entry ownership and route identity still gate on frontier judgment. "Smallest model that scores clean" is the ongoing skill-quality metric.

Docs-only; no changeset. Full evidence trail (scorecards, workspaces, per-round notes) in the campaign notes; scoring was external per run — self-audits proved unreliable in three separate ways.

## Open threads (not this PR)

Library decisions: pool `replace`/reconcile (identity-preserving refill — would dissolve the one residual partial), shipping `put()`, assignable `Component.key` (all on the followups board with fresh evidence). Transfer test on an unrelated codebase. Luna runs pending API-key codex auth.

