### PR TITLE
feat(mvc): add put instruction for unmanaged storage

### DIFF
--- a/.changeset/put-instruction.md
+++ b/.changeset/put-instruction.md
@@ -1,0 +1,8 @@
+---
+"@expressive/mvc": minor
+"@expressive/react": minor
+---
+
+Add `put` - an instruction for unmanaged instance storage. The property is a plain writable own value: reads and writes use normal property syntax, never notify subscribers, and never throw after destroy. Excluded from snapshots, iteration, and `ref(this)`, but assignable from an overlay (constructor argument, `set({ ... })`, or Component props).
+
+For subscription handles, side-pocket data, and comparison tokens - state the UI observes stays in a managed field.

--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { flushMicrotasks, mockWarn } from '../test.setup';
 import { Component } from './component';
 import { Context } from './context';
+import { put } from './field/put';
 
 it('will default fallback to null', () => {
   const foo = Component.new({});
@@ -92,6 +93,22 @@ it('will merge state when props reassigned', async () => {
   await foo.set();
 
   expect(foo.value).toBe(7);
+});
+
+it('will apply props to unmanaged field', async () => {
+  class Foo extends Component {
+    value = put<number>();
+  }
+
+  const foo = Foo.new({ value: 5 });
+
+  expect(foo.value).toBe(5);
+
+  (foo as any).props = { value: 7 };
+  await foo.set();
+
+  expect(foo.value).toBe(7);
+  await expect(foo).not.toHaveUpdated('value');
 });
 
 it('will reset omitted props on reassignment', async () => {

--- a/packages/mvc/src/field/put.test.ts
+++ b/packages/mvc/src/field/put.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { State } from '../state';
+import { put } from './put';
+import { ref } from './ref';
+
+describe('put', () => {
+  it('will store value on instance', () => {
+    class Test extends State {
+      value = put('foo');
+    }
+
+    const test = Test.new();
+
+    expect(test.value).toBe('foo');
+
+    test.value = 'bar';
+
+    expect(test.value).toBe('bar');
+  });
+
+  it('will be undefined without initial value', () => {
+    class Test extends State {
+      value = put<string>();
+    }
+
+    const test = Test.new();
+
+    expect(test.value).toBeUndefined();
+  });
+
+  it('will not trigger update', async () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put(1);
+    }
+
+    const test = Test.new();
+
+    test.opaque = 2;
+
+    await expect(test).not.toHaveUpdated();
+
+    test.managed = 2;
+
+    await expect(test).toHaveUpdated('managed');
+  });
+
+  it('will not notify effect on write', async () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put(1);
+    }
+
+    const test = Test.new();
+    const effect = vi.fn((self: Test) => void [self.managed, self.opaque]);
+
+    test.get(effect);
+    expect(effect).toBeCalledTimes(1);
+
+    test.opaque = 2;
+    await test.set();
+
+    expect(effect).toBeCalledTimes(1);
+
+    test.managed = 2;
+    await test.set();
+
+    expect(effect).toBeCalledTimes(2);
+  });
+
+  it('will exclude from snapshot and iteration', () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put(2);
+    }
+
+    const test = Test.new();
+
+    expect(test.get()).toEqual({ managed: 1 });
+    expect([...test]).toEqual([['managed', 1]]);
+    expect(Object.keys(test)).not.toContain('opaque');
+  });
+
+  it('will exclude from ref proxy', () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put(2);
+    }
+
+    const test = Test.new();
+
+    class Refs extends State {
+      to = ref(test);
+    }
+
+    const refs = Refs.new().to as Record<string, unknown>;
+
+    expect(refs.managed).toBeInstanceOf(Function);
+    expect(refs.opaque).toBeUndefined();
+  });
+
+  it('will write after destroy', () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put<number>();
+    }
+
+    const test = Test.new();
+
+    test.set(null);
+
+    expect(() => (test.managed = 2)).toThrowError(
+      `Tried to update ${test}.managed but state is destroyed.`
+    );
+
+    test.opaque = 2;
+
+    expect(test.opaque).toBe(2);
+  });
+
+  it('will apply from constructor argument', () => {
+    class Test extends State {
+      opaque = put('foo');
+    }
+
+    const test = Test.new({ opaque: 'bar' });
+
+    expect(test.opaque).toBe('bar');
+  });
+
+  it('will apply from set overlay', async () => {
+    class Test extends State {
+      managed = 1;
+      opaque = put('foo');
+    }
+
+    const test = Test.new();
+
+    test.set({ opaque: 'bar' });
+
+    expect(test.opaque).toBe('bar');
+    await expect(test).not.toHaveUpdated();
+  });
+
+  it('will not be reactive if subclass overrides', async () => {
+    class Test extends State {
+      value = put(1);
+    }
+
+    class Subclass extends Test {
+      value = 2;
+    }
+
+    const test = Subclass.new();
+
+    test.value = 3;
+
+    await expect(test).toHaveUpdated('value');
+  });
+});

--- a/packages/mvc/src/field/put.ts
+++ b/packages/mvc/src/field/put.ts
@@ -1,0 +1,54 @@
+import { def } from './def';
+
+/**
+ * Store a value on the instance without managing it.
+ *
+ * The property is a plain, writable own value - reads and writes use normal
+ * property syntax, never notify subscribers, and never throw after destroy.
+ * Excluded from snapshots, iteration, and `ref(this)`.
+ *
+ * Use for mechanism and memory - subscription handles, side-pocket data,
+ * comparison tokens. State the UI observes belongs in a managed field.
+ *
+ * An overlay (constructor argument, `set({ ... })`, or Component props) may
+ * assign one, same as a managed field.
+ *
+ * Note instructions are values, not declarations - a subclass which overrides
+ * this field with a plain value gets an ordinary managed property instead.
+ * Restate the instruction to keep it.
+ *
+ * @param value - Starting value for property.
+ */
+function put<T>(value: T): T;
+
+/**
+ * Store a value on the instance without managing it. Initially `undefined`.
+ *
+ * The property is a plain, writable own value - reads and writes use normal
+ * property syntax, never notify subscribers, and never throw after destroy.
+ * Excluded from snapshots, iteration, and `ref(this)`. Access never suspends.
+ *
+ * Use for mechanism and memory - subscription handles, side-pocket data,
+ * comparison tokens. State the UI observes belongs in a managed field.
+ *
+ * An overlay (constructor argument, `set({ ... })`, or Component props) may
+ * assign one, same as a managed field.
+ *
+ * Note instructions are values, not declarations - a subclass which overrides
+ * this field with a plain value gets an ordinary managed property instead.
+ * Restate the instruction to keep it.
+ */
+function put<T>(): T | undefined;
+
+function put<T>(value?: T): any {
+  return def<T>((key, subject) => {
+    Object.defineProperty(subject, key, {
+      value,
+      writable: true,
+      enumerable: false,
+      configurable: true
+    });
+  });
+}
+
+export { put };

--- a/packages/mvc/src/index.ts
+++ b/packages/mvc/src/index.ts
@@ -2,6 +2,7 @@ export { def } from './field/def';
 export { get } from './field/get';
 export { has } from './field/has';
 export { map } from './field/map';
+export { put } from './field/put';
 export { set } from './field/set';
 export { ref } from './field/ref';
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -40,6 +40,6 @@ Object.assign(Runtime, {
 });
 
 export { State, State as default, Consumer, Provider } from './adapter';
-export { Component, Context, def, get, ref, set, transition } from '@expressive/mvc';
+export { Component, Context, def, get, put, ref, set, transition } from '@expressive/mvc';
 export { has } from './has';
 export { map } from './map';

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -120,6 +120,7 @@ Field initializers that configure reactive behavior. Each has multiple overloads
 | `ref()` | Mutable refs (`.current`), ref callbacks with cleanup, ref proxies                                      | [field/ref.md](field/ref.md) |
 | `map()` | Reactive `Map` field - keyed entries or a keyed spawner, with owned `State` members and direct render    | [field/map.md](field/map.md) |
 | `has()` | Owned collections - an ordered list of values, or a pool of spawned members. Pools are for per-item UI state (selection, progress, row actions). Class first (`has(Row)`); factory when the seed isn't the init | [field/has.md](field/has.md) |
+| `put()` | Unmanaged storage - subscription handles, side-pocket data, comparison tokens | [field/put.md](field/put.md) |
 | `def()` | Low-level custom property behavior                                                                      | [field/def.md](field/def.md) |
 
 For **computed values**, declare a normal class getter - getters on a State subclass are auto-promoted to memoized, dependency-tracked properties. See [state/computed.md](state/computed.md) for tracking rules and when a derivation should *not* be a getter.
@@ -355,6 +356,7 @@ Fetch these for detailed documentation when the task requires deeper knowledge. 
 - [field/ref.md](field/ref.md) - Mutable refs, ref proxy, callbacks
 - [field/map.md](field/map.md) - Reactive `Map`: keyed entries, keyed spawner, owned members, direct render
 - [field/has.md](field/has.md) - Owned collections: reactive lists and spawned pools
+- [field/put.md](field/put.md) - Unmanaged storage: handles, side-pocket data, storage classes
 - [field/def.md](field/def.md) - Low-level custom property behavior
 
 ### React

--- a/skills/field/def.md
+++ b/skills/field/def.md
@@ -10,6 +10,8 @@ import { def } from '@expressive/mvc';
 
 Low-level primitive for defining custom property behavior during initialization. All other instructions (`get`, `set`, `ref`) are built on `def`.
 
+Reach for it when writing your own instruction. For unmanaged storage use [`put`](put.md) - a factory returning void defines an own property the store never sees, but an enumerable one is captured as managed state.
+
 ## Usage
 
 ```ts

--- a/skills/field/put.md
+++ b/skills/field/put.md
@@ -1,0 +1,101 @@
+# `put` - Unmanaged Storage
+
+```ts
+import { put } from '@expressive/mvc';
+```
+
+> React apps import these from `@expressive/react` - the adapter re-exports every instruction. Examples below show the core import; do not add `@expressive/mvc` to a React app's `package.json`.
+
+Stores a value on the instance without managing it. Reads and writes use plain property syntax, never notify subscribers, and never throw after destroy.
+
+For mechanism and memory - subscription handles, side-pocket data, comparison tokens. Facts the UI observes belong in a managed field.
+
+## Usage
+
+```ts
+class JobRunner extends State {
+  progress = 0;                              // managed - UI observes
+  unwatch = put<(() => void) | null>(null);  // opaque - mechanism
+
+  start(id: string) {
+    this.stop();
+    this.unwatch = watchJob(id, {
+      onProgress: (p) => {
+        if (this.get(null)) return;
+        this.progress = p.percent;
+      }
+    });
+  }
+
+  stop() {
+    const stop = this.unwatch;
+    this.unwatch = null;
+    stop?.();
+  }
+
+  protected new() {
+    return () => this.stop();
+  }
+}
+```
+
+Without an initial value the property is `undefined` and typed `T | undefined`. Access never suspends.
+
+```ts
+class Form extends State {
+  draft = put<Snapshot>();
+}
+```
+
+## Storage Classes
+
+| Need | Use |
+| --- | --- |
+| UI-observed state | plain field, `set()` |
+| DOM or callback ref | `ref()` |
+| Opaque instance memory | `put()` |
+| Custom descriptor | `def()` |
+
+Three recurring cases for `put`:
+
+- **Subscription handles** - an unsubscribe function swapped on every restart. A managed field would notify on each swap and throw when a late callback nulls it after destroy.
+- **Side-pocket data** - a snapshot held while the user is elsewhere. Nothing should re-render because the pocket was written; restoring writes managed fields explicitly.
+- **Comparison tokens** - "what did we last process?" bookkeeping for edge detection.
+
+## Anti-Patterns
+
+- **Don't** store an unsubscribe handle in a managed field - swaps notify, and a null-out after destroy throws.
+- **Don't** reach for `#private` for non-reactive storage. Tracked contexts (effects, computed getters, render) receive a derived object, and private-field access from one throws.
+- **Don't** use TypeScript `private` to opt out of reactivity - it is compile-time only; the field stays managed.
+- **Don't** put form fields, progress, or anything a dependency snapshot lists in `put`.
+
+## Behavior
+
+- Excluded from `state.get()` snapshots, iteration, `Object.keys`, and `ref(this)`.
+- Writable after destroy - a late callback may null a handle. Managed fields throw there.
+- Assign from methods, where `this` is the instance. A write through the tracking proxy shadows rather than assigns.
+- An overlay may assign one - constructor argument, `set({ ... })`, or Component props - with no event dispatched for the key.
+- `readonly x = put(...)` blocks authored writes at compile time; overlays still apply.
+
+## Inheritance
+
+Instructions are values, not declarations. A subclass which overrides the field with a plain value gets an ordinary managed property - reactive, and throwing on post-destroy writes. Restate the instruction to keep it:
+
+```ts
+class Base extends State {
+  handle = put<Socket>();
+}
+
+class Sub extends Base {
+  handle = put<Socket>();  // not `= someSocket`
+}
+```
+
+This holds for every instruction; `put` is called out because the silent result is a different storage class.
+
+## Type Signatures
+
+```ts
+function put<T>(value: T): T;
+function put<T>(): T | undefined;
+```


### PR DESCRIPTION
## Scope

Adds `put`, an instruction for instance-owned storage the reactive system never sees. Motivated by a usage report from Diffuser Studio (six production fields across three patterns, behind a 15-line app-local polyfill).

```ts
class JobRunner extends State {
  progress = 0;                              // managed - UI observes
  unwatch = put<(() => void) | null>(null);  // opaque - mechanism
}
```

The gap it fills: values that live for the model's lifetime, are read and written with plain property syntax, must not notify, and must not go through the managed setter after teardown. Today the only correct path is a void-returning `def` that `defineProperty`s the key — sharp, undocumented, and easy to get wrong in a way that fails silently.

## Why this needs to be first-party

Three near-misses that look right and are not:

- **`#private`** — the tracking subject is `Object.create(instance)`, and computed getters run with it as `this`. Private-field brand checks do not traverse prototypes, so `this.#x` throws in any tracked context. Docs cannot fix this; only an alternative storage class can.
- **TypeScript `private`** — compile-time only, field stays managed.
- **A managed field** — swaps notify, and `update()` throws unconditionally once the observer is nulled, so a late callback nulling a handle after destroy throws.

The polyfill also balances on a detail apps get wrong when they fork it: what keeps the re-defined property out of the store is `enumerable: false`, because the activation sweep promotes any enumerable own data property into managed state. A fork that flips enumerability is silently captured.

## Overlay integration

`assign()` gates overlay keys on `key in state`. The `def` sweep runs in the `before` phase, so a `put` field is already an own property when the args overlay lands — it takes a plain silent assignment. This covers all three overlay entry points: constructor arguments, `set({ ... })`, and Component props (initial and every reassignment).

This is the capability that separates `put` from the zero-export alternative of `declare` + assign-in-`new()`: at overlay time a declared key does not exist on the instance, so `State.new({ draftSnap })` silently drops it. Covered by a `Component` test since it falls out of `assign()`'s fallthrough rather than anything `put` does.

## Surface

```ts
function put<T>(value: T): T;
function put<T>(): T | undefined;
```

Two type overloads, one runtime path. Considered and rejected:

- **Factory form** — class-field initializers already run per instance, so `put(new Map())` is fresh per instance. Lazy init would need a getter, which breaks the plain-data-property contract.
- **Write callback** — that is a reactive seam; it is `set(value, callback)`.
- **`enumerable` option** — impossible, not declined: an enumerable put field is adopted by the activation sweep. Non-enumerable by mechanism.
- **Read-only** — already `readonly x = put(...)`; runtime enforcement would break overlay assignment.
- **Auto-dispose on reassign** — guessing which stored functions are cleanups is a footgun. Callers do stop-and-swap explicitly.

Also resolves the open TODO in `set.ts` in the negative: bare `set(value)` stays reactive rather than forking into a silent-assign mode that would have been a worse `put`.

## Inheritance footgun

A subclass overriding the field with a plain value gets an ordinary managed property — reactive again, and throwing on post-destroy writes. Not guardable: the shadowed token leaves no trace to detect, and branding the return type would break ordinary writes. Documented instead, as a general instruction rule with a `put`-specific callout, since the silent result here is a change of storage class. Test pins the current behavior.

This is the same class of issue as the board item *"Instruction fields are not inherited"*; `put` neither worsens nor fixes it.

## Verification

- 10 new `put` tests plus one `Component` props test; full mvc suite 658 passed, coverage 100% across all four metrics.
- Runtime probe against built `dist` (not just `tsc`): overlay seeding applies, effect does not re-run on opaque write but does on managed write, snapshot and `Object.keys` exclude the field, post-destroy opaque write succeeds where the managed write throws.

## Docs

New `skills/field/put.md` (storage-class table, three patterns, anti-patterns, inheritance rule), indexed in `SKILL.md`, and a pointer from `def.md` scoping hand-rolled storage to custom-instruction authoring.