### PR TITLE
feat: report when deferred work has been presented

### DIFF
--- a/.changeset/transition-settlement.md
+++ b/.changeset/transition-settlement.md
@@ -1,0 +1,8 @@
+---
+"@expressive/mvc": minor
+"@expressive/react": minor
+---
+
+`transition()` now returns a promise settling once the deferred updates have been presented, so callers can hold a pending flag for the span - progress bars, `aria-busy`, disabled controls. Under React this covers a suspended replacement: the promise settles when the new content commits, not when the write lands.
+
+Hosts report presentation by returning a promise from `HostRuntime.transition`; those that return nothing settle on dispatch, unchanged. The React adapter observes through a `useTransition` hosted by `Provider` - without one, work still defers and the promise settles on dispatch.

--- a/packages/mvc/src/dispatch.test.ts
+++ b/packages/mvc/src/dispatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { flushMicrotasks, mockError } from '../test.setup';
+import { flushMicrotasks, mockError, mockPromise } from '../test.setup';
 import { watch } from './observable';
 import { enqueue, schedule } from './dispatch';
 import { State } from './state';
@@ -165,5 +165,49 @@ describe('dispatch', () => {
 
     expect(error).toHaveBeenCalledWith(expected);
     expect(after).toHaveBeenCalledOnce();
+  });
+
+  it('will settle when the host reports the replay presented', async () => {
+    const presented = mockPromise<void>();
+    const log: string[] = [];
+
+    const settled = schedule(() => {
+      enqueue(() => log.push('dispatch'));
+    }, (work) => {
+      work();
+      return presented;
+    });
+
+    let done = false;
+    settled.then(() => (done = true));
+
+    await flushMicrotasks();
+
+    expect(log).toEqual(['dispatch']);
+    expect(done).toBe(false);
+
+    presented.resolve();
+    await flushMicrotasks();
+
+    expect(done).toBe(true);
+  });
+
+  it('will settle when the host reports a failed replay', async () => {
+    const presented = mockPromise<void>();
+
+    const settled = schedule(() => {
+      enqueue(() => {});
+    }, (work) => {
+      work();
+      return presented;
+    });
+
+    let done = false;
+    settled.then(() => (done = true));
+
+    presented.reject(new Error('abandoned'));
+    await flushMicrotasks();
+
+    expect(done).toBe(true);
   });
 });

--- a/packages/mvc/src/dispatch.ts
+++ b/packages/mvc/src/dispatch.ts
@@ -1,52 +1,108 @@
 type Handler = () => void;
-type Transition = (work: Handler) => void;
+type Settle = void | Promise<void>;
+type Transition = (work: Handler) => Settle;
+
+interface Pending {
+  count: number;
+  done(): void;
+}
 
 interface Scheduled {
   transition?: Transition;
+  pending?: Pending;
 }
 
 const DISPATCH = new Map<Handler, Scheduled>();
-let active: Transition | undefined;
+const RESOLVED = Promise.resolve();
 
-function execute(work: Handler, transition?: Transition) {
+let active: Transition | undefined;
+let current: Pending | undefined;
+
+function execute(work: Handler, transition?: Transition): Settle {
   if (!transition) return work();
 
   const parent = active;
   active = transition;
 
   try {
-    transition(work);
+    return transition(work);
   } finally {
     active = parent;
   }
 }
 
-function enqueue(handler: Handler) {
-  if (!DISPATCH.size)
-    queueMicrotask(() => {
-      for (const [handler, scheduled] of DISPATCH) {
-        DISPATCH.delete(handler);
+function drop(scheduled: Scheduled) {
+  const { pending } = scheduled;
 
-        try {
-          execute(handler, scheduled.transition);
-        } catch (err) {
-          console.error(err);
-        }
-      }
-    });
+  if (!pending) return;
+
+  scheduled.pending = undefined;
+
+  if (!--pending.count) pending.done();
+}
+
+function flush() {
+  for (const [handler, scheduled] of DISPATCH) {
+    DISPATCH.delete(handler);
+
+    let settled: Settle = undefined;
+
+    try {
+      settled = execute(handler, scheduled.transition);
+    } catch (err) {
+      console.error(err);
+    }
+
+    if (settled instanceof Promise) {
+      const release = () => drop(scheduled);
+      settled.then(release, release);
+    } else drop(scheduled);
+  }
+}
+
+function enqueue(handler: Handler) {
+  if (!DISPATCH.size) queueMicrotask(flush);
 
   const scheduled = DISPATCH.get(handler);
 
   if (scheduled) {
-    if (!active) scheduled.transition = undefined;
+    if (!active) {
+      scheduled.transition = undefined;
+      drop(scheduled);
+    }
   } else {
-    DISPATCH.set(handler, { transition: active });
+    if (current) current.count++;
+
+    DISPATCH.set(handler, { transition: active, pending: current });
   }
 }
 
-function schedule(work: Handler, transition?: Transition) {
-  if (!transition || transition === active) return work();
-  execute(work, transition);
+/**
+ * Run `work` under `transition`, resolving once every subscriber update it
+ * queued has replayed through that transition and the host has reported the
+ * replay settled. A host which reports nothing resolves on replay.
+ */
+function schedule(work: Handler, transition?: Transition): Promise<void> {
+  if (!transition || transition === active) {
+    work();
+    return RESOLVED;
+  }
+
+  const parent = current;
+  const scheduled: Scheduled = {};
+  const promise = new Promise<void>((resolve) => {
+    scheduled.pending = current = { count: 1, done: resolve };
+  });
+
+  try {
+    execute(work, transition);
+  } finally {
+    current = parent;
+  }
+
+  drop(scheduled);
+
+  return promise;
 }
 
 export { enqueue, schedule };

--- a/packages/mvc/src/runtime.ts
+++ b/packages/mvc/src/runtime.ts
@@ -39,8 +39,10 @@ export interface HostRuntime {
   jsxs(type: unknown, props: object, key?: unknown): Component.Node;
   propsOf(node: unknown): Record<string, unknown>;
   typeOf(node: unknown): unknown;
-  /** Non-urgent update bracket (e.g. React `startTransition`). Optional - see {@link transition}. */
-  transition?(work: () => void): void;
+  /** Non-urgent update bracket (e.g. React `startTransition`). Optional - see
+   * {@link transition}. Return a promise settling when the bracketed work has
+   * been presented to report progress; return nothing to opt out. */
+  transition?(work: () => void): void | Promise<void>;
   Fragment: unknown;
 }
 
@@ -145,7 +147,11 @@ export function propsOf(node: unknown): Record<string, unknown> {
  * Mark synchronous work as non-urgent. `work` runs inline through the host
  * scheduler; queued subscriber updates inherit the designation and replay it
  * after dispatch. Without a host scheduler, normal timing is retained.
+ *
+ * Resolves once those updates have been presented, so a caller can hold a
+ * pending flag for the span. Hosts that do not report presentation resolve on
+ * replay instead.
  */
-export function transition(work: () => void): void {
-  schedule(work, HOST.transition);
+export function transition(work: () => void): Promise<void> {
+  return schedule(work, HOST.transition);
 }

--- a/packages/react/src/context.ts
+++ b/packages/react/src/context.ts
@@ -1,6 +1,7 @@
 import { State, Context, Component } from '@expressive/mvc';
 import type { UseState } from '@expressive/mvc';
 import { Runtime, useHook } from './runtime';
+import { useDriver } from './transition';
 
 let shared: any;
 
@@ -102,6 +103,9 @@ function Provider<T extends State>({
   ...props
 }: Provider.Props<T>) {
   const ambient = useAmbient();
+
+  useDriver();
+
   const digest: Digest<T> = useHook((returns) => {
     const context = new Context(ambient);
     const fresh: State[] = [];

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ Object.assign(Runtime, {
   useState,
   useRef,
   useSyncExternalStore: React.useSyncExternalStore,
+  useTransition: React.useTransition,
   Suspense,
   ignore: [
     'updater',

--- a/packages/react/src/jsx-runtime.ts
+++ b/packages/react/src/jsx-runtime.ts
@@ -2,6 +2,8 @@ import React, { Children, isValidElement } from 'react';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import { host } from '@expressive/mvc/runtime';
 
+import { drive } from './transition';
+
 import type { JSX as ReactJSX, ReactNode } from 'react';
 
 declare module '@expressive/mvc/runtime' {
@@ -15,7 +17,7 @@ host({
   jsx,
   jsxs,
   Fragment,
-  transition: React.startTransition,
+  transition: (work) => drive(work, React.startTransition),
   isElement: isValidElement,
   childrenOf: Children.toArray,
   typeOf(node){

--- a/packages/react/src/runtime.ts
+++ b/packages/react/src/runtime.ts
@@ -11,6 +11,8 @@ export const Runtime = {} as {
   useState<S>(initial: S | (() => S)): [S, (next: (previous: S) => S) => void];
   useEffect(effect: () => (() => void) | void, deps?: any[]): void;
   useRef<T>(initial: T): { current: T };
+  /** Consumed to observe deferred work; absent where the host cannot report it. */
+  useTransition?(): [boolean, (work: () => void) => void];
   /** Consumed for pre-commit revision validation; absent where commits
    *  cannot interleave with writes. */
   useSyncExternalStore?(

--- a/packages/react/src/transition.test.tsx
+++ b/packages/react/src/transition.test.tsx
@@ -1,0 +1,110 @@
+import { act, render } from '@testing-library/react';
+import { Suspense } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Provider, State, transition } from '.';
+import { Runtime } from './adapter';
+import { mockPromise } from '../test.setup';
+
+describe('transition', () => {
+  class Test extends State {
+    value = 'a';
+    busy = false;
+  }
+
+  function scenario() {
+    const test = Test.new();
+    const gate = mockPromise<void>();
+    let ready = false;
+
+    gate.then(() => {
+      ready = true;
+    });
+
+    const Page = () => {
+      const { value } = Test.get();
+
+      if (value === 'b' && !ready) throw gate;
+
+      return <span>{value}</span>;
+    };
+
+    const Status = () => <b>{Test.get().busy ? 'busy' : 'idle'}</b>;
+
+    const view = render(
+      <Provider for={test}>
+        <Status />
+        <Suspense fallback={<i>fallback</i>}>
+          <Page />
+        </Suspense>
+      </Provider>
+    );
+
+    return { test, gate, text: () => view.container.textContent };
+  }
+
+  it('will resolve once deferred work is presented', async () => {
+    const { test, gate, text } = scenario();
+
+    expect(text()).toBe('idlea');
+
+    await act(async () => {
+      test.busy = true;
+      transition(() => {
+        test.value = 'b';
+      }).then(() => {
+        test.busy = false;
+      });
+      await Promise.resolve();
+    });
+
+    expect(text()).toBe('busya');
+
+    await act(async () => {
+      gate.resolve();
+      await gate;
+    });
+
+    expect(text()).toBe('idleb');
+  });
+
+  it('will defer without observing where the host cannot report', async () => {
+    const { useTransition } = Runtime;
+    delete Runtime.useTransition;
+
+    try {
+      const { test, gate, text } = scenario();
+
+      expect(text()).toBe('idlea');
+
+      await act(async () => {
+        transition(() => {
+          test.value = 'b';
+        });
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        gate.resolve();
+        await gate;
+      });
+
+      expect(text()).toBe('idleb');
+    } finally {
+      Runtime.useTransition = useTransition;
+    }
+  });
+
+  it('will resolve without a mounted driver', async () => {
+    const test = Test.new();
+    let done = false;
+
+    await transition(() => {
+      test.value = 'b';
+    }).then(() => {
+      done = true;
+    });
+
+    expect(done).toBe(true);
+  });
+});

--- a/packages/react/src/transition.test.tsx
+++ b/packages/react/src/transition.test.tsx
@@ -95,6 +95,104 @@ describe('transition', () => {
     }
   });
 
+  describe('pending', () => {
+    class App extends State {
+      page = 'a';
+      busy = false;
+
+      go(to: string) {
+        this.busy = true;
+        transition(() => {
+          this.page = to;
+        }).then(() => {
+          this.busy = false;
+        });
+      }
+    }
+
+    function gated() {
+      const app = App.new();
+      const gate = mockPromise<void>();
+      let ready = false;
+
+      gate.then(() => {
+        ready = true;
+      });
+
+      return {
+        app,
+        gate,
+        suspend: (page: string) => {
+          if (page === 'b' && !ready) throw gate;
+        }
+      };
+    }
+
+    it('will hold the previous screen where read above deferred content', async () => {
+      const { app, gate, suspend } = gated();
+
+      const Frame = (props: { children?: unknown }) => (
+        <div>{App.get().busy ? 'dim:' : 'live:'}{props.children as any}</div>
+      );
+
+      const Screen = () => {
+        const { page } = App.get();
+        suspend(page);
+        return <span>{page}</span>;
+      };
+
+      const view = render(
+        <Provider for={app}>
+          <Frame>
+            <Suspense fallback={<i>fallback</i>}>
+              <Screen />
+            </Suspense>
+          </Frame>
+        </Provider>
+      );
+
+      await act(async () => {
+        app.go('b');
+        await Promise.resolve();
+      });
+
+      expect(view.container.querySelector('i')).toBeNull();
+      expect(view.container.textContent).toBe('dim:a');
+
+      await act(async () => {
+        gate.resolve();
+        await gate;
+      });
+
+      expect(view.container.textContent).toBe('live:b');
+    });
+
+    it('will not hold where one component reads both', async () => {
+      const { app, suspend } = gated();
+
+      const Screen = () => {
+        const { page, busy } = App.get();
+        suspend(page);
+        return <span>{busy ? 'dim:' : 'live:'}{page}</span>;
+      };
+
+      const view = render(
+        <Provider for={app}>
+          <Suspense fallback={<i>fallback</i>}>
+            <Screen />
+          </Suspense>
+        </Provider>
+      );
+
+      await act(async () => {
+        app.go('b');
+        await Promise.resolve();
+      });
+
+      expect(view.container.querySelector('i')).not.toBeNull();
+    });
+  });
+
   it('will resolve without a mounted driver', async () => {
     const test = Test.new();
     let done = false;

--- a/packages/react/src/transition.ts
+++ b/packages/react/src/transition.ts
@@ -1,0 +1,60 @@
+import { Runtime } from './runtime';
+
+type Start = (work: () => void) => void;
+
+interface Driver {
+  start: Start;
+  waiting: (() => void)[];
+}
+
+const DRIVERS = new Set<Driver>();
+
+function settle(driver: Driver) {
+  for (const resolve of driver.waiting.splice(0)) resolve();
+}
+
+/**
+ * Bracket `work` through a mounted driver, reporting when React has presented
+ * it. Falls back to the ambient scheduler when nothing is mounted to observe -
+ * the work still defers, it just reports nothing.
+ */
+export function drive(work: () => void, ambient: Start): void | Promise<void> {
+  const [driver] = DRIVERS;
+
+  if (!driver) return ambient(work);
+
+  return new Promise<void>((resolve) => {
+    driver.waiting.push(resolve);
+    driver.start(work);
+  });
+}
+
+/**
+ * Hosts the host-side transition scheduler. React reports a transition as
+ * pending only through the hook that started it, so an update deferred from
+ * outside render needs a mounted hook to schedule through and to observe.
+ */
+export function useDriver() {
+  const hook = Runtime.useTransition;
+
+  if (!hook) return;
+
+  const [pending, start] = hook();
+  const ref = Runtime.useRef<Driver | null>(null);
+  const driver = ref.current || (ref.current = { start, waiting: [] });
+
+  driver.start = start;
+
+  Runtime.useEffect(() => {
+    DRIVERS.add(driver);
+
+    return () => {
+      DRIVERS.delete(driver);
+      settle(driver);
+    };
+  }, []);
+
+  Runtime.useEffect(() => {
+    if (!pending) settle(driver);
+  }, [pending]);
+}

--- a/skills/state/state.md
+++ b/skills/state/state.md
@@ -73,7 +73,19 @@ class App extends State {
 }
 ```
 
-`busy` is an urgent write, so an indicator reading it paints immediately while the page defers. Under React this spans a suspended replacement - the promise settles when the new page commits, not when the write lands. Reporting requires a mounted `Provider`; without one (or on a host that cannot report) the work still defers and the promise settles on dispatch.
+Under React the promise spans a suspended replacement - it settles when the new page commits, not when the write lands.
+
+**Read the flag above the deferred content, never beside it.** A component is one watcher carrying one update at one priority, so a component reading both `busy` and `page` takes the urgent priority of `busy` for the whole update - it re-renders at once, suspends, and the fallback appears instead of the previous screen holding.
+
+```tsx
+const Frame = (props) => (             // pending only - paints at once
+  <div aria-busy={App.get().busy}>{props.children}</div>
+);
+
+const Screen = () => <Page page={App.get().page} />;   // deferred value only - holds
+```
+
+Reporting requires a mounted `Provider`; without one (or on a host that cannot report) the work still defers and the promise settles on dispatch.
 
 ### Value Equality
 

--- a/skills/state/state.md
+++ b/skills/state/state.md
@@ -55,6 +55,26 @@ transition(() => {
 
 The callback runs synchronously. Its queued subscriber callbacks retain transition priority through MVC's microtask dispatch; React interprets that priority with `startTransition`. Writes after an `await` are outside the scope and need another `transition()` call. Normal batching still applies, and urgent invalidation wins when the same watcher is already pending at transition priority.
 
+`transition()` returns a promise settling once those updates are on screen - hold a flag across it for progress UI:
+
+```ts
+class App extends State {
+  page = 'home';
+  busy = false;
+
+  go(to: string) {
+    this.busy = true;
+    transition(() => {
+      this.page = to;
+    }).then(() => {
+      this.busy = false;
+    });
+  }
+}
+```
+
+`busy` is an urgent write, so an indicator reading it paints immediately while the page defers. Under React this spans a suspended replacement - the promise settles when the new page commits, not when the write lands. Reporting requires a mounted `Provider`; without one (or on a host that cannot report) the work still defers and the promise settles on dispatch.
+
 ### Value Equality
 
 Updates are skipped when new value `===` previous value. No event is emitted.


### PR DESCRIPTION
## Scope

Infrastructure for a navigation/transition **pending** signal. Prerequisite for #318 (router deferred presentation), which will rebase onto this and consume it as a pure consumer.

Why this lands first: #318 as it stands defers navigation with **no feedback at all** during the hold — dead air for the duration of a slow guard or chunk. That's arguably a worse UX than the fallback flash it replaces, so the pending story needs to exist before either ships.

## The constraint

React reports a transition as pending only through the `useTransition` hook **that started it**. Verified by probe:

| scheduled via | a hook's `isPending` |
| --- | --- |
| global `React.startTransition` | never flips |
| that hook's own `start` | flips, and stays true while suspended |
| that hook's `start`, called from a later microtask | flips, and stays true while suspended |
| mvc `transition()` (today) | never flips |

The third row is the load-bearing one: it's the exact shape of mvc's batched dispatch **replay**, which is where the real `setState` lands. So settlement has to be wired to the replay, not to the `transition()` call site — the call site only mutates state and queues watchers.

## Public surface (two widened return types, no new exports)

```ts
// @expressive/mvc
transition(work: () => void): Promise<void>          // was void

// HostRuntime
transition?(work: () => void): void | Promise<void>  // was void
```

A host reports presentation by returning a promise; one that returns nothing settles on replay, exactly as today. That's the whole contract a custom reconciler implements.

Internally `dispatch.ts` tracks outstanding replays per transition: each watcher queued under a transition claims it, each replay releases on settle, and the promise resolves at zero. An urgent write that strips a queued handler's deferral also releases its claim, so the promise can't hang.

## React adapter

`Provider` hosts the `useTransition` (zero new public surface — apps already wrap in it) and registers its `start`; `transition()` schedules through it and resolves when React reports the transition settled. No Provider mounted, or a host with no `useTransition` (preact): work still defers, promise settles on dispatch.

Usage the docs now show:

```ts
go(to: string) {
  this.busy = true;                                  // urgent - indicator paints now
  transition(() => { this.page = to })               // deferred - page holds
    .then(() => { this.busy = false });              // settles when the new page commits
}
```

## Tests

`packages/react/src/transition.test.tsx` asserts the full span: `busy` true **while the previous page is still on screen**, then clears when the suspended replacement commits (`busya` → `idleb`). Plus the no-driver and no-`useTransition`-host degradation paths, and two mvc dispatch tests covering host-reported settle and a rejected replay.

Full workspace suite green; mvc and react both back at 100% on all four coverage metrics. Exercised through real `react-dom` under happy-dom; no browser pass on this PR (the #318 rebase carries the example that gets one).

## Placement rule (added after review question)

The pending flag must be read **above** the deferred content, never beside it — and this is the one thing to know about the seam.

A component is one watcher carrying one queued update at one priority. Reading the flag beside the deferred value takes the flag's *urgent* priority for the whole update, so the component re-renders at once, suspends, and the fallback replaces the screen. The hold — the entire feature — is destroyed:

| arrangement | during transition |
| --- | --- |
| one component reads `page` + `busy` | `live:a` **`FALLBACK`** — fallback rendered, previous content only survives as `display:none` |
| pending read above the deferred content | `dim:a` — previous screen visible and marked pending |

```tsx
const Frame = (props) => (                            // pending only - paints at once
  <div aria-busy={App.get().busy}>{props.children}</div>
);

const Screen = () => <Page page={App.get().page} />;  // deferred value only - holds
```

This is intrinsic to the dispatch model rather than the seam: React can give one component urgent `isPending` alongside deferred content because those are separate state cells, while mvc has one update channel per watcher. It mirrors React's own constraint that `useTransition` sits above the suspending content, so the convention should be familiar rather than surprising.

Both arrangements are now pinned in `transition.test.tsx` (fallback element present/absent is the discriminator), and `skills/state/state.md` states the rule. Follow-up filed (P1): the failure is silent today and reads as "deferral doesn't work" — a dev warning when a watcher holding a transition claim is re-enqueued urgently would catch it at the point of the mistake.
