### PR TITLE
fix(mvc): adopt State stored by any writer, not just direct assignment

### DIFF
--- a/.changeset/adopt-managed-state.md
+++ b/.changeset/adopt-managed-state.md
@@ -1,0 +1,10 @@
+---
+"@expressive/mvc": patch
+"@expressive/router": patch
+---
+
+A `State` landing in a managed property is now adopted by whichever path stores it, not only by direct assignment. A child produced by a `set()` factory, or assigned to a property which started empty, is parented, registered in its owner's context, activated, and destroyed with its owner.
+
+Values derived by a getter or computed are unaffected - derivation reads a reference and does not confer ownership.
+
+Fixes the `Route.router` fallback in `@expressive/router`, where a `Router` constructed for a route with none in context was never activated.

--- a/.changeset/adopt-managed-state.md
+++ b/.changeset/adopt-managed-state.md
@@ -3,8 +3,8 @@
 "@expressive/router": patch
 ---
 
-A `State` landing in a managed property is now adopted by whichever path stores it, not only by direct assignment. A child produced by a `set()` factory, or assigned to a property which started empty, is parented, registered in its owner's context, activated, and destroyed with its owner.
+A `State` stored by an owning writer is now adopted regardless of how it arrives, not only by direct assignment at define time. A child produced by a `set()` factory, or assigned to a property which started empty - including a `Component` prop - is parented, registered in its owner's context, activated, and destroyed with its owner.
 
-Values derived by a getter or computed are unaffected - derivation reads a reference and does not confer ownership.
+Ownership still follows freshness: an already-active `State` is registered as a guest and outlives the property, matching `map()`. Values a state only reads - a getter, a computed, or a type resolved from context by `get(Type)` - are not adopted; reading a reference does not confer ownership.
 
 Fixes the `Route.router` fallback in `@expressive/router`, where a `Router` constructed for a route with none in context was never activated.

--- a/packages/mvc/src/field/get.test.ts
+++ b/packages/mvc/src/field/get.test.ts
@@ -360,6 +360,23 @@ describe('fetch mode', () => {
     });
   });
 
+  it('will not register upstream into own context', () => {
+    class Parent extends State {
+      child = new Child();
+    }
+    class Child extends State {
+      parent = get(Parent);
+    }
+    class Stranger extends State {
+      parent = get(Parent, false);
+    }
+
+    const parent = Parent.new();
+
+    expect(parent.child.parent).toBe(parent);
+    expect(Stranger.new().parent).toBeUndefined();
+  });
+
   describe('subscription', () => {
     it('will update when implicit upstream is replaced', async () => {
       class Peer extends State {}
@@ -483,6 +500,21 @@ describe('fetch mode', () => {
         new Context(parent).push({ child1, child2 });
 
         expect(parent.children).toEqual([child1, child2]);
+      });
+
+      it('will not collect self through a consumer', () => {
+        class Node extends State {
+          peers = get(Node, true);
+          up = get(Node, false);
+        }
+
+        const parent = new Node();
+        const child = new Node();
+
+        new Context(parent).push(child);
+
+        expect(child.up).toBe(parent);
+        expect(parent.peers).toEqual([child]);
       });
 
       it('will not be enumerable', () => {

--- a/packages/mvc/src/field/set.ts
+++ b/packages/mvc/src/field/set.ts
@@ -132,7 +132,7 @@ function set<T = any>(value?: unknown, argument?: unknown): any {
 
         function assign(next: any, silent?: boolean) {
           if (typeof argument == 'function') subject[key] = next;
-          else update(subject, key, next, silent);
+          else update(subject, key, next, silent, true);
         }
 
         if (output instanceof Promise)

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -178,6 +178,75 @@ it('will destroy owned child when replaced', () => {
   expect(parent.child.get(null)).toBe(false);
 });
 
+it('will adopt child from set factory', () => {
+  const created = vi.fn();
+
+  class Child extends State {
+    value = 1;
+    protected new() {
+      created();
+    }
+  }
+
+  class Parent extends State {
+    child = set(() => new Child());
+  }
+
+  const parent = Parent.new();
+  const { child } = parent;
+
+  expect(created).toBeCalledTimes(1);
+  expect(child.get(null)).toBe(false);
+
+  parent.set(null);
+
+  expect(child.get(null)).toBe(true);
+});
+
+it('will adopt child assigned after undefined', () => {
+  class Child extends State {
+    value = 1;
+  }
+
+  class Parent extends State {
+    child?: Child = undefined;
+  }
+
+  const parent = Parent.new();
+
+  parent.child = new Child();
+
+  const { child } = parent;
+
+  expect(child!.get(null)).toBe(false);
+
+  parent.set(null);
+
+  expect(child!.get(null)).toBe(true);
+});
+
+it('will not adopt child derived by getter', () => {
+  class Child extends State {
+    value = 1;
+  }
+
+  const held = Child.new();
+
+  class Parent extends State {
+    get child() {
+      return held;
+    }
+  }
+
+  const parent = Parent.new();
+
+  expect(parent.child).toBe(held);
+
+  parent.set(null);
+
+  expect(held.get(null)).toBe(false);
+});
+
 it('will not destroy non-owned child when replaced', () => {
   class Child extends State {
     value = 1;

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -225,6 +225,45 @@ it('will adopt child assigned after undefined', () => {
   expect(child!.get(null)).toBe(true);
 });
 
+it('will destroy owned child when replaced', () => {
+  class Child extends State {}
+
+  class Parent extends State {
+    child?: Child = undefined;
+  }
+
+  const parent = Parent.new();
+  const first = new Child();
+
+  parent.child = first;
+
+  const second = new Child();
+
+  parent.child = second;
+
+  expect(first.get(null)).toBe(true);
+  expect(second.get(null)).toBe(false);
+});
+
+it('will not own active child from set factory', () => {
+  class Child extends State {}
+
+  const held = Child.new();
+
+  class Parent extends State {
+    child = set(() => held);
+  }
+
+  const parent = Parent.new();
+
+  expect(parent.child).toBe(held);
+  expect(Context.get(parent).get(Child)).toBe(held);
+
+  parent.set(null);
+
+  expect(held.get(null)).toBe(false);
+});
+
 it('will not adopt child derived by getter', () => {
   class Child extends State {
     value = 1;

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -729,7 +729,7 @@ function compute(this: State, getter: (self: any) => unknown, key: string) {
       console.error(err);
     }
 
-    update(this, key, next, !isAsync, true);
+    update(this, key, next, !isAsync);
   };
 
   apply(
@@ -781,7 +781,7 @@ function apply(
   }
 
   function set(value: unknown, silent?: boolean) {
-    update(state, key, value, silent);
+    update(state, key, value, silent, true);
   }
 
   define(state, key, {
@@ -956,7 +956,7 @@ function update<T>(
   key: State.Event<T>,
   value: T,
   silent?: boolean,
-  derived?: boolean
+  own?: boolean
 ) {
   if (observer(state) === null) {
     if (silent) return false;
@@ -975,13 +975,13 @@ function update<T>(
 
   if (!silent) event(state, key);
 
-  if (!derived) adopt(state, key, value);
+  if (own) adopt(state, key, value);
 
   return true;
 }
 
 /**
- * Hand a value landing in a managed property to that property's adopter,
+ * Hand a value stored by an owning writer to that property's adopter,
  * creating one the first time a State is stored there. A property which has
  * held a State keeps its adopter, so a later non-State value releases the
  * previous child.

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -43,6 +43,9 @@ const STALE = new WeakSet<() => void>();
 /** Whether the deadline which drains `PENDING` is already queued for this tick. */
 let QUEUED = false;
 
+/** Adopters for managed properties which have held a child State. */
+const ADOPT = new WeakMap<State, Map<unknown, (value: unknown) => void>>();
+
 declare namespace State {
   /** Any type of State, using own class constructor as its identifier. */
   type Extends<T extends State = State> = (abstract new (...args: any[]) => T) &
@@ -726,7 +729,7 @@ function compute(this: State, getter: (self: any) => unknown, key: string) {
       console.error(err);
     }
 
-    update(this, key, next, !isAsync);
+    update(this, key, next, !isAsync, true);
   };
 
   apply(
@@ -777,11 +780,8 @@ function apply(
     return;
   }
 
-  const adopt = config.value instanceof State && child(state);
-
   function set(value: unknown, silent?: boolean) {
-    if (!update(state, key, value, silent)) return;
-    if (adopt) adopt(STORE.get(state)![key]);
+    update(state, key, value, silent);
   }
 
   define(state, key, {
@@ -955,7 +955,8 @@ function update<T>(
   state: State,
   key: State.Event<T>,
   value: T,
-  silent?: boolean
+  silent?: boolean,
+  derived?: boolean
 ) {
   if (observer(state) === null) {
     if (silent) return false;
@@ -974,7 +975,33 @@ function update<T>(
 
   if (!silent) event(state, key);
 
+  if (!derived) adopt(state, key, value);
+
   return true;
+}
+
+/**
+ * Hand a value landing in a managed property to that property's adopter,
+ * creating one the first time a State is stored there. A property which has
+ * held a State keeps its adopter, so a later non-State value releases the
+ * previous child.
+ */
+function adopt(state: State, key: unknown, value: unknown) {
+  let keys = ADOPT.get(state);
+
+  if (!keys) {
+    if (!(value instanceof State)) return;
+    ADOPT.set(state, (keys = new Map()));
+  }
+
+  let claim = keys.get(key);
+
+  if (!claim) {
+    if (!(value instanceof State)) return;
+    keys.set(key, (claim = child(state)));
+  }
+
+  claim(value);
 }
 
 /** Random alphanumberic of length 6; always starts with a letter. */

--- a/packages/react/src/component.test.tsx
+++ b/packages/react/src/component.test.tsx
@@ -4,7 +4,7 @@ import { renderToString } from 'react-dom/server';
 import React, { Suspense } from 'react';
 
 import { mockError, mockPromise, flushMicrotasks } from '../test.setup';
-import { Component, Consumer, set } from '.';
+import { Component, Consumer, State, set } from '.';
 import { transition } from '@expressive/mvc/runtime';
 
 it('will create and provide instance', () => {
@@ -876,6 +876,51 @@ describe('state props on rerender', () => {
     expect(screen).toHaveText('bar');
   });
 
+  it('will own a fresh state passed as prop', () => {
+    class Thing extends State {
+      value = 'foo';
+    }
+
+    class Control extends Component {
+      thing?: Thing = undefined;
+
+      render() {
+        return <span>{this.thing!.value}</span>;
+      }
+    }
+
+    const thing = new Thing();
+    const view = render(<Control thing={thing} />);
+
+    expect(screen).toHaveText('foo');
+
+    view.unmount();
+
+    expect(thing.get(null)).toBe(true);
+  });
+
+  it('will not own an active state passed as prop', () => {
+    class Thing extends State {
+      value = 'foo';
+    }
+
+    class Control extends Component {
+      thing?: Thing = undefined;
+
+      render() {
+        return <span>{this.thing!.value}</span>;
+      }
+    }
+
+    const thing = Thing.new();
+    const view = render(<Control thing={thing} />);
+
+    expect(screen).toHaveText('foo');
+
+    view.unmount();
+
+    expect(thing.get(null)).toBe(false);
+  });
 });
 
 describe('default render', () => {

--- a/packages/router/src/route.test.tsx
+++ b/packages/router/src/route.test.tsx
@@ -50,6 +50,21 @@ describe('Route', () => {
     expect(view.container.textContent).toBe('id: foo');
   });
 
+  it('will own a fallback router when none is in context', () => {
+    router.current.set(null);
+
+    const route = Route.new();
+    const fallback = route.router;
+
+    expect(fallback).toBeInstanceOf(Router);
+    expect(fallback).not.toBe(router.current);
+    expect(fallback.get(null)).toBe(false);
+
+    route.set(null);
+
+    expect(fallback.get(null)).toBe(true);
+  });
+
   it('exposes the router query', () => {
     const route = Route.new();
     route.router.goto('/posts?q=hi&page=2');


### PR DESCRIPTION
## Problem

A `State` assigned directly to a field is adopted — parented, registered in the owner's context, activated, and destroyed with the owner. A `State` arriving by any other route was not. It was stored as a plain value and never activated: no `new()` hook, no listeners, no context registration, no destroy propagation.

```ts
class Parent extends State { child = new Child() }              // adopted
class Parent extends State { child = set(() => new Child()) }   // inert forever
```

Adoption was wired into `apply()` as `config.value instanceof State && child(state)` — evaluated once, from the value present at define time. Two paths miss it: a `set()` factory (which calls `update()` directly, since the property is read-only and cannot be assigned through its own setter), and any property that starts empty and receives a `State` later.

Reachable in shipped code as `Route.router = set(() => this.get(Router, false) || new Router())` — the fallback when no `Router` is in context. It produced 11 dangling `Router` instances in one router suite run.

## Fix

Adoption moves into `update()`, the single funnel every managed-store write passes through, and is **opt-in** there. Two writers opt in, both meaning *the owner is storing this as the property's content*:

- the property setter in `apply()` — covers direct assignment, assignment after empty, and `Component` props
- the read-only factory in `set()` — which cannot reach that setter

Adopters are created per property, lazily, on the first `State` stored there, and retained after: a later non-`State` value still runs the adopter so the previous child is released. `child()` already discriminates correctly via `parent()`, which reports whether it *freshly* claimed — so `this.get(Router, false) || new Router()` behaves right in both branches, adopting a newly constructed `Router` while merely registering one borrowed from context.

## Opt-in, not opt-out

The first cut of this adopted on *every* `update()` and carved exceptions out with a `derived` flag. That is the wrong default: the failure mode of a missing carve-out is a silent context leak, and two showed up.

`get(Type)` stores its resolved ancestor with `update()`. Adopting there ran `Context.get(subject).add(value)`, publishing the ancestor into the consumer's own context:

- a `get(Node, true)` downstream collection then included the collector itself
- a root-homed consumer published its ancestor into `Context.root`, where an unrelated `get(Type, false)` resolved it — a global without `static global`, which is exactly what `Context.add`'s guard exists to prevent

Both are pinned by regression tests in `get.test.ts`; both fail under the opt-out version. Inverting the flag also removes the need for `compute()` to opt out — derivation simply never opts in — so the derivation carve-out costs nothing and the getter test still passes.

## Ownership rule

**Freshness decides ownership; the writer decides whether ownership is on the table at all.** A fresh (never-activated) `State` stored by an owning writer is adopted. An already-active one is a guest, held but never destroyed. A value the state only *reads* — a getter, a computed, a type resolved from context — is never adopted. This matches what `map()` already documents.

One visible consequence: a fresh `State` passed as a `Component` prop is now owned and destroyed on unmount (`Thing.new()` instances are unaffected). Both directions have tests.

## Verification

- 3 tests in `state.test.ts` (factory child, assign-after-empty, derivation boundary), 2 in `get.test.ts` (no upstream registration, no self-collection), 2 in `component.test.tsx` (fresh prop owned, active prop not). Each fails without its change.
- Full workspace suite: 1313 passed across 35 files. 100% coverage on all four metrics in all four packages.
- Re-ran the dangling-instance instrumentation against the router suite: 11 → 0.
- Runtime probe against built `dist`: factory child activates, is alive, and is destroyed with its parent.

## Notes

- No new public surface. `child` stays module-private; `update`'s new parameter is internal (`update` is not exported from the package entry).
- `@expressive/router` gets a patch changeset — its behavior changes even though no router source did.
- This does **not** fix the board item about `new Router()` + `goto()` throwing in `locate`. That repro is a bare `new Router()`, which never reaches a managed property; it still throws `query.keys is not a function` on this branch. The `Route.router` fallback would have hit the same latent throw, which is how the two got connected.
