### PR TITLE
fix(mvc): end the bootstrap chain walk on State, not on a class name

### DIFF
--- a/.changeset/chain-walk-anonymous.md
+++ b/.changeset/chain-walk-anonymous.md
@@ -1,0 +1,17 @@
+---
+'@expressive/mvc': patch
+---
+
+Fix `State.on()` handlers being silently skipped when an anonymous class sits in the prototype chain.
+
+Bootstrap walked the chain until it hit a class with a falsy `name`, which terminated correctly only because `Object.getPrototypeOf(State)` is `Function.prototype`. Any intermediate class with an empty `name` ended the walk early and every ancestor above it was dropped - their per-class `type` hooks, per-instance `before`/`after` setup, and the teardowns those return never ran, with no error.
+
+The ordinary mixin idiom produces exactly that: a class expression which is returned or passed rather than assigned gets no inferred name.
+
+```ts
+const Timestamped = (Base) => class extends Base { stamp = Date.now() };
+
+class Doc extends Timestamped(State) {}   // handlers on State were lost
+```
+
+The walk now ends on `State` itself rather than on a name check.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -2832,6 +2832,29 @@ describe('on method (static)', () => {
     expect(order).toEqual(['A', 'B', 'C']);
   });
 
+  it('will run handlers above an anonymous class', () => {
+    const order: string[] = [];
+
+    class A extends State {}
+
+    A.on(() => void order.push('A'));
+
+    const attach = <T extends typeof A>(type: T) => {
+      type.on(() => void order.push('anonymous'));
+      return type;
+    };
+
+    class C extends attach(class extends A {}) {}
+
+    C.on(() => void order.push('C'));
+
+    expect(Object.getPrototypeOf(C).name).toBe('');
+
+    C.new();
+
+    expect(order).toEqual(['A', 'anonymous', 'C']);
+  });
+
   it('will squash same callback for multiple classes', () => {
     class Test extends State {}
     class Test2 extends Test {}

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -581,9 +581,7 @@ function bootstrap(T: State.Extends) {
 
   while (true) {
     chain.unshift(T);
-
     if (T === State) break;
-
     T = Object.getPrototypeOf(T);
   }
 

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -579,10 +579,13 @@ function bootstrap(T: State.Extends) {
   let keys = new Map<string, (value: any) => void>();
   let getters = new Map<string, () => unknown>();
 
-  do {
+  while (true) {
     chain.unshift(T);
+
+    if (T === State) break;
+
     T = Object.getPrototypeOf(T);
-  } while (T.name);
+  }
 
   for (const type of chain) {
     for (const handler of SETUP.get(type) || [])


### PR DESCRIPTION
## What was wrong

`bootstrap` walked the prototype chain until it reached a class with a falsy `name`:

```ts
do {
  chain.unshift(T);
  T = Object.getPrototypeOf(T);
} while (T.name);
```

That terminated correctly only by accident - `State` extends nothing, so `Object.getPrototypeOf(State)` is `Function.prototype`, whose `name` is `""`. Any *intermediate* class with an empty name ended the walk there, and every ancestor above it was dropped from `chain`. Those classes' `State.on()` registrations never ran: per-class `type` hooks, per-instance `before`/`after` setup, and the teardown functions those return. Silently - no error, no warning.

## How it is reached

The ordinary mixin idiom. A class expression that is **returned or passed** rather than assigned gets no inferred name:

```ts
const Timestamped = (Base) => class extends Base { stamp = Date.now() };

class Doc extends Timestamped(State) {}   // chain: Doc -> (anonymous) -> State
```

Reproduced against the built dist of `@expressive/mvc` 0.83.0 - a handler on `State` and a handler on the mixin class both vanish, while the same test through a named subclass runs both.

Fields, computed getters and reactive dispatch are **not** affected; they resolve by a different path. The damage is scoped to the `SETUP` registry.

## The fix

```ts
while (true) {
  chain.unshift(T);

  if (T === State) break;

  T = Object.getPrototypeOf(T);
}
```

`State` is the semantic boundary the walk always meant, so it terminates on that rather than on a proxy for it. `State` stays in the chain, so `SETUP.get(State)` handlers still run ahead of the `if (type === State) continue` below.

Two alternatives were tried and rejected:

- **`while (T !== State)`** as a drop-in condition drops `State` from the chain, since the loop unshifts before advancing - trading one silent skip for another.
- **A derived `ROOT = Object.getPrototypeOf(State)`** works, but is just `Function.prototype` spelled indirectly, and introduces an evaluation-order dependency on `class State` being defined first (it throws on TDZ if declared above the class).

The chosen form needs no module-level state. One behavior change worth noting: a class that does *not* descend from `State` now walks to `null` and throws, where the old code exited quietly and built a wrong-but-plausible chain. `bootstrap` is typed `State.Extends`, so that input is already a programming error, and failing loudly is the better outcome.

## Test

`state.test.ts`, in the existing `on method (static)` block. It asserts `Object.getPrototypeOf(C).name` is `''` before asserting handler order - **without that guard the test is vacuous**, because `const Anon = class extends A {}` infers the name "Anon" and passes against the broken code. The class is therefore built as a call argument.

Fails on `main`, passes here. Full suite green (1307), `tsc --noEmit` clean, `@expressive/mvc` coverage still 100% on all four metrics.

## Provenance

Found while auditing React Native support in #297 - the `.name` dependency turned up when checking whether minification could break the chain walk. Minification remains an unconfirmed second path to the same failure (nothing in CI executes a minified bundle); the mixin case is confirmed and is what this fixes. The sentinel guard closes both.
