### PR TITLE
fix(website): stop Safari entrance animations from hanging invisible

### DIFF
--- a/website/app/app.css
+++ b/website/app/app.css
@@ -47,19 +47,23 @@ figure[data-rehype-pretty-code-figure] pre code,
   transform: translateX(-0.5rem);
 }
 
-.snippet-entrance[data-visible]:not([data-animate]) > .shiki > [role='region'] {
+.snippet-entrance[data-visible] > .shiki > [role='region'] {
   opacity: 1;
   transform: none;
 }
 
-.snippet-entrance[data-animate] > .shiki > [role='region'] {
-  animation: snippet-entrance 400ms ease-out both;
+.snippet-entrance[data-visible][data-animate] > .shiki > [role='region'] {
+  animation: snippet-entrance 400ms ease-out;
 }
 
 @keyframes snippet-entrance {
+  from {
+    opacity: 0;
+    transform: translateX(-0.5rem);
+  }
   to {
     opacity: 1;
-    transform: translateX(0);
+    transform: none;
   }
 }
 
@@ -501,7 +505,7 @@ figure[data-rehype-pretty-code-figure] pre code,
   [class*='tip-trace-'],
   .trace-pulse,
   .live-counter-pulse,
-  .snippet-entrance[data-animate] > .shiki > [role='region'] {
+  .snippet-entrance[data-visible][data-animate] > .shiki > [role='region'] {
     animation: none !important;
   }
 

--- a/website/app/components/Reveal.tsx
+++ b/website/app/components/Reveal.tsx
@@ -18,18 +18,37 @@ class Visibility extends State {
   shown = false;
 
   element = ref<HTMLDivElement>((el) => {
+    const show = () => {
+      if (this.shown) return;
+      this.shown = true;
+      io.disconnect();
+    };
+
     const io = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
-          this.shown = true;
-          io.disconnect();
-        }
+        if (entry.isIntersecting) show();
       },
-      { threshold: 0.25 },
+      { threshold: 0, rootMargin: '0px 0px -8% 0px' },
     );
 
     io.observe(el);
-    return () => io.disconnect();
+
+    const frames: number[] = [];
+    frames.push(requestAnimationFrame(() => {
+      frames.push(requestAnimationFrame(() => {
+        if (this.shown) return;
+        const rect = el.getBoundingClientRect();
+        const vh = window.innerHeight;
+        const vw = window.innerWidth;
+        if (rect.bottom > 0 && rect.top < vh * 0.92 && rect.right > 0 && rect.left < vw)
+          show();
+      }));
+    }));
+
+    return () => {
+      io.disconnect();
+      for (const id of frames) cancelAnimationFrame(id);
+    };
   });
 }
 
@@ -40,7 +59,7 @@ export default function Reveal({ children, className, delay, from = 'up' }: Reve
     <div
       ref={element}
       style={delay ? { transitionDelay: `${delay}ms` } : undefined}
-      className={`transition-all duration-700 ease-out motion-reduce:transition-none motion-reduce:opacity-100 motion-reduce:translate-x-0 motion-reduce:translate-y-0 ${
+      className={`transition-[opacity,transform] duration-700 ease-out motion-reduce:transition-none motion-reduce:opacity-100 motion-reduce:translate-x-0 motion-reduce:translate-y-0 ${
         shown ? 'opacity-100 translate-x-0 translate-y-0' : `opacity-0 ${OFFSET[from]}`
       } ${className || ''}`}>
       {children}

--- a/website/app/components/Snippet.tsx
+++ b/website/app/components/Snippet.tsx
@@ -64,7 +64,12 @@ class SnippetEntrance extends Component {
       if (highlighted()) reveal(true);
     });
 
-    observer.observe(element, { childList: true, subtree: true });
+    observer.observe(element, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+    });
     timeout = window.setTimeout(() => reveal(false), 1750);
     if (highlighted()) reveal(true);
 

--- a/website/app/routes/home/Benefits.tsx
+++ b/website/app/routes/home/Benefits.tsx
@@ -19,15 +19,15 @@ export function Benefits() {
             No big-bang rewrite. Adopt it one feature at a time and leave simple
             useState calls alone. A tool for complexity, not a replacement.
           </Benefit>
-          <Benefit title="Keep what works" delay={100}>
+          <Benefit title="Keep what works" delay={50}>
             MVC doesn't need to replace every hook or specialist library. Keep
             the tools that still earn their place.
           </Benefit>
-          <Benefit title="Portable state" delay={200}>
+          <Benefit title="Portable state" delay={100}>
             Headless State classes don't depend on a component tree. Move them,
             test them, or use the framework-agnostic core.
           </Benefit>
-          <Benefit title="No build-time magic" delay={300}>
+          <Benefit title="No build-time magic" delay={150}>
             MVC adds no compiler, code generation, or custom syntax. What you
             write is what runs.
           </Benefit>

--- a/website/app/routes/home/Product.tsx
+++ b/website/app/routes/home/Product.tsx
@@ -24,14 +24,14 @@ export function Product() {
           <Point title="Smaller components" illustration={<SmallerComponents />} delay={0}>
             Focus on the display logic, not coordinating features.
           </Point>
-          <Point title="Separated concerns" illustration={<BuiltInSeparation />} delay={300}>
+          <Point title="Separated concerns" illustration={<BuiltInSeparation />} delay={50}>
             Break up features so
             growth isn't tech debt.
           </Point>
           <Point title="Less Ceremony" illustration={<MinimalBoilerplate />} delay={100}>
             Normal logic, without the factories and wrappers.
           </Point>
-          <Point title="Higher Clarity" illustration={<ReadableOutput />} delay={200}>
+          <Point title="Higher Clarity" illustration={<ReadableOutput />} delay={150}>
             Review agent output with confidence, not gymnastics.
           </Point>
         </div>

--- a/website/app/routes/home/Vibe.tsx
+++ b/website/app/routes/home/Vibe.tsx
@@ -22,7 +22,7 @@ export function Vibe() {
             State, derived values, async, and lifecycle live together.
             Composition helps separate concerns into readable chunks.
           </Point>
-          <Point title="Logic and state are addressable" delay={200}>
+          <Point title="Logic and state are addressable" delay={50}>
             Every behavior has a name and a home you can point at.
             A fix starts at the class, not a hunt through wiring.
           </Point>
@@ -30,7 +30,7 @@ export function Vibe() {
             Classes pair naturally with TypeScript and JSDocs, to
             surface types and intent where the work is.
           </Point>
-          <Point title="Class instances are just objects" delay={300}>
+          <Point title="Class instances are just objects" delay={150}>
             The instance is the source of truth. Log it, assert on it, or bind
             it to <code>window</code> to inspect directly.
           </Point>


### PR DESCRIPTION
## Summary

Safari (especially) was leaving homepage animated-in content stuck at `opacity: 0` indefinitely. Two separate entrance systems:

- **SnippetEntrance** — first-load code blocks set both `data-visible` and `data-animate`, but CSS only reached `opacity: 1` via `animation-fill-mode: both`. If Safari skipped/cancelled the animation, the base rule kept the region invisible forever (empty hero code frame).
- **Reveal** — IntersectionObserver used `threshold: 0.25` with no fallback. A missed initial callback left Product/Vibe/Benefits cards invisible forever.

## Changes

- Make `data-visible` the durable end state for snippets; animation is progressive enhancement only (explicit `from`/`to`, no fill-mode dependency).
- Reveal: `threshold: 0`, slight bottom `rootMargin`, double-rAF geometry fallback, `transition-[opacity,transform]` instead of `transition-all`.
- Snippet MutationObserver also watches `style`/`class` so Shiki token style updates still trigger reveal on Safari.

No package/API change; no changeset.

## Test plan

- [ ] Homepage hard-reload in Safari: hero code block appears (not empty frame)
- [ ] Scroll Product / Vibe / Benefits: cards fade in and never stay blank
- [ ] Chrome/Firefox: entrance animations still look normal
- [ ] Cloudflare Pages preview picks up the branch automatically