### PR TITLE
fix(mvc): require a State to activate in the tick it was constructed

### DIFF
--- a/.changeset/instruction-already-applied.md
+++ b/.changeset/instruction-already-applied.md
@@ -1,0 +1,15 @@
+---
+'@expressive/mvc': patch
+---
+
+An instruction token which cannot be applied now throws at activation instead of persisting as a value. A token minted outside a construction - hoisted to a module binding, or shared between classes - is consumed by whichever instance activates first, and every later instance silently kept the raw `Symbol('field-<uid>')` in place of its value.
+
+```ts
+const shared = set(() => 42);
+class Thing extends State { value = shared }
+
+Thing.new().value // 42
+Thing.new().value // Symbol(field-WZJHFS) - now throws
+```
+
+A single-instance app shipped this and worked; the failure appeared only once a second instance was constructed.

--- a/.changeset/instruction-registry-tick.md
+++ b/.changeset/instruction-registry-tick.md
@@ -1,0 +1,13 @@
+---
+'@expressive/mvc': patch
+---
+
+Instructions work again on React Native. The token registry is now a plain `Map` cleared at the end of each tick, so no `WeakMap` is ever keyed by a symbol - Hermes does not implement ES2023 symbol keys for `WeakMap`, and keying on one made every instruction throw. This supersedes the `WeakMap` introduced to stop unconsumed tokens retaining their factories; a per-tick registry bounds that retention instead.
+
+Creating an instruction outside a construction now throws:
+
+```ts
+const shared = set(() => 42); // Error - no State under construction
+```
+
+An instruction is per-instance, so a token minted ahead of one had no possible claimant - it was consumed by whichever instance activated first, leaving every later instance with the raw symbol. This is sound only because a State must now activate in the tick it was constructed.

--- a/.changeset/no-dangling-new.md
+++ b/.changeset/no-dangling-new.md
@@ -1,0 +1,20 @@
+---
+'@expressive/mvc': minor
+---
+
+A `State` constructed with plain `new` must activate before the end of the tick - by `State.new()`, adoption by an owner, or placement with `new Context(state)`. One that does not now warns, naming the instance and the three remedies. `set(null)` releases an instance you decide against, exempting it.
+
+This makes an existing tacit rule enforceable. A bare `new` that nothing adopts produced an inert instance whose instructions never ran and whose properties were never managed, with no signal at all - the same deadline, wired in as a probe, is what found the `set()` factory adoption bug fixed in #324.
+
+Two defects surfaced by the invariant are fixed alongside it:
+
+Destroying a `State` that never activated threw instead of releasing it. Terminal dispatch synthesized the activation signal for a never-ready instance, running its init against an already-terminated observer.
+
+```ts
+const state = new MyState();
+state.set(null); // threw: "was destroyed - cannot be rendered, watched or updated"
+```
+
+A host constructs a `Component` per render attempt, and the constructor resolves duplicates by props object - returning the first instance and abandoning the second. That twin never activated and was never released, so it outlived the render attempt which created it. Under React StrictMode this happened on every mount.
+
+Deferring activation past the tick is no longer supported. `new Context(state)` still claims a home before activation locks it to root, but the placement must happen in the same tick as construction.

--- a/packages/mvc/src/component.test.ts
+++ b/packages/mvc/src/component.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { flushMicrotasks, mockWarn } from '../test.setup';
 import { Component } from './component';
 import { Context } from './context';
 
@@ -117,6 +118,21 @@ it('will dedupe construction by props object', () => {
   const b = new Component(props);
 
   expect(b).toBe(a);
+});
+
+it('will release the twin discarded by dedupe', async () => {
+  const warn = mockWarn();
+  const props = { value: 1 };
+
+  const a = new Component(props);
+  const b = new Component(props);
+
+  expect(b).toBe(a);
+
+  await flushMicrotasks();
+
+  expect(warn).toBeCalledTimes(1);
+  expect(warn).toBeCalledWith(expect.stringContaining(String(a)));
 });
 
 // Seam: React passes context as a constructor argument alongside props.

--- a/packages/mvc/src/component.ts
+++ b/packages/mvc/src/component.ts
@@ -113,7 +113,10 @@ class Component extends State {
       }
     ]);
 
-    if (copy) return copy;
+    if (copy) {
+      this.set(null);
+      return copy;
+    }
 
     PENDING.set(props, this);
 

--- a/packages/mvc/src/field/def.test.ts
+++ b/packages/mvc/src/field/def.test.ts
@@ -266,3 +266,26 @@ describe('instruction', () => {
     });
   });
 });
+
+describe('reuse', () => {
+  it('will throw if instruction already applied elsewhere', () => {
+    const shared = def(() => ({ value: 42 }));
+
+    class Test extends State {
+      value: any = shared;
+    }
+
+    expect(Test.new().value).toBe(42);
+    expect(() => Test.new()).toThrowError(
+      /has an instruction applied to another State/
+    );
+  });
+
+  it('will not throw for an unrelated symbol', () => {
+    class Test extends State {
+      tag: any = Symbol('mine');
+    }
+
+    expect(String(Test.new().tag)).toBe('Symbol(mine)');
+  });
+});

--- a/packages/mvc/src/field/def.test.ts
+++ b/packages/mvc/src/field/def.test.ts
@@ -269,15 +269,37 @@ describe('instruction', () => {
 
 describe('reuse', () => {
   it('will throw if instruction already applied elsewhere', () => {
-    const shared = def(() => ({ value: 42 }));
+    let stolen: any;
 
-    class Test extends State {
-      value: any = shared;
+    class Source extends State {
+      value: any = (stolen = def(() => ({ value: 42 })));
     }
 
-    expect(Test.new().value).toBe(42);
-    expect(() => Test.new()).toThrowError(
+    expect(Source.new().value).toBe(42);
+
+    class Thief extends State {
+      value: any = stolen;
+    }
+
+    expect(() => Thief.new()).toThrowError(
       /has an instruction applied to another State/
+    );
+  });
+
+  it('will throw if created outside a construction', () => {
+    expect(() => def(() => ({ value: 1 }))).toThrowError(
+      /no State under construction/
+    );
+  });
+
+  it('will throw once construction has completed', () => {
+    class Test extends State {
+      value: any = def(() => ({ value: 1 }));
+    }
+
+    expect(Test.new().value).toBe(1);
+    expect(() => def(() => ({ value: 2 }))).toThrowError(
+      /no State under construction/
     );
   });
 

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -1,5 +1,5 @@
 import { listener } from '../observable';
-import { State, STORE, uid, apply } from '../state';
+import { PENDING, State, STORE, uid, apply } from '../state';
 
 declare namespace def {
   /**
@@ -18,11 +18,21 @@ declare namespace def {
   }
 }
 
-const APPLY = new WeakMap<symbol, def.Factory | null>();
+const APPLY = new Map<symbol, def.Factory | null>();
+const RESET = () => APPLY.clear();
 
 function def<T>(arg1: def.Factory<T>) {
+  if (!PENDING.size || (PENDING.size == 1 && PENDING.has(RESET)))
+    throw new Error(
+      'Instruction created with no State under construction.'
+    );
+
+  PENDING.add(RESET);
+
   const token = Symbol('field-' + uid());
+
   APPLY.set(token, arg1);
+
   return token as T extends void ? unknown : T;
 }
 

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -18,7 +18,7 @@ declare namespace def {
   }
 }
 
-const APPLY = new WeakMap<symbol, def.Factory>();
+const APPLY = new WeakMap<symbol, def.Factory | null>();
 
 function def<T>(arg1: def.Factory<T>) {
   const token = Symbol('field-' + uid());
@@ -33,9 +33,14 @@ State.on((self) => {
     const property: PropertyDescriptor = Object.getOwnPropertyDescriptor(self, key) || {};
     const instruction = APPLY.get(property.value);
 
+    if (instruction === null)
+      throw new Error(
+        `${self}.${key} has an instruction applied to another State.`
+      );
+
     if (!instruction) continue;
 
-    APPLY.delete(property.value);
+    APPLY.set(property.value, null);
     delete (self as any)[key];
 
     const output = instruction.call(self, key, self, store);

--- a/packages/mvc/src/observable.ts
+++ b/packages/mvc/src/observable.ts
@@ -206,7 +206,7 @@ function emit(o: Observer, key: Observer.Signal): void {
     return;
   }
 
-  if (!ready) pending.add(true);
+  if (!ready && key !== null) pending.add(true);
 
   pending.add(key);
 

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -3642,3 +3642,20 @@ describe('computed (getters)', () => {
     });
   });
 });
+
+it('will release a state which never activated', () => {
+  const didInit = vi.fn();
+
+  class Test extends State {
+    value = 1;
+
+    protected new() {
+      didInit();
+    }
+  }
+
+  const state = new Test();
+
+  expect(() => state.set(null)).not.toThrow();
+  expect(didInit).not.toBeCalled();
+});

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -1,5 +1,5 @@
 import { vi, expect, it, describe } from 'vitest';
-import { mockError, mockPromise, mockWarn } from '../test.setup';
+import { flushMicrotasks, mockError, mockPromise, mockWarn } from '../test.setup';
 import { Context } from './context';
 import { get } from './field/get';
 import { ref } from './field/ref';
@@ -3658,4 +3658,78 @@ it('will release a state which never activated', () => {
 
   expect(() => state.set(null)).not.toThrow();
   expect(didInit).not.toBeCalled();
+});
+
+describe('activation', () => {
+  const warn = mockWarn();
+
+  it('will warn if never activated', async () => {
+    class Test extends State {
+      value = 1;
+    }
+
+    const state = new Test();
+
+    await flushMicrotasks();
+
+    expect(warn).toBeCalledWith(
+      `${state} was constructed but never activated.`
+    );
+  });
+
+  it('will not warn if activated', async () => {
+    class Test extends State {
+      value = 1;
+    }
+
+    Test.new();
+
+    await flushMicrotasks();
+
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will not warn if adopted by an owner', async () => {
+    class Child extends State {
+      value = 1;
+    }
+
+    class Parent extends State {
+      child = new Child();
+    }
+
+    Parent.new();
+
+    await flushMicrotasks();
+
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will not warn if placed in a context', async () => {
+    class Test extends State {
+      value = 1;
+    }
+
+    const state = new Test();
+
+    new Context(state);
+
+    await flushMicrotasks();
+
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will not warn if released', async () => {
+    class Test extends State {
+      value = 1;
+    }
+
+    const state = new Test();
+
+    state.set(null);
+
+    await flushMicrotasks();
+
+    expect(warn).not.toBeCalled();
+  });
 });

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -562,7 +562,7 @@ function init(state: State, ...args: State.Args) {
     });
 
     return null;
-  });
+  }, true);
 }
 
 /**

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -18,6 +18,9 @@ const ID = new WeakMap<State, string>();
 /** Internal state assigned to states. */
 const STORE = new WeakMap<State, Record<string | number | symbol, unknown>>();
 
+/** States constructed this tick, awaiting activation. */
+let PENDING: Set<State> | undefined;
+
 /** External lifecycle listeners for any given State class. */
 const SETUP = new WeakMap<State.Extends, Set<State.Init<any> | State.On<any>>>();
 
@@ -563,6 +566,32 @@ function init(state: State, ...args: State.Args) {
 
     return null;
   }, true);
+
+  expect(state);
+}
+
+/**
+ * Hold a freshly constructed state to the end of this tick, where anything
+ * still unactivated is reported. Destroyed instances are exempt.
+ */
+function expect(state: State) {
+  if (!PENDING) {
+    const batch = (PENDING = new Set<State>());
+
+    queueMicrotask(() => {
+      PENDING = undefined;
+
+      for (const state of batch) {
+        const o = observer(state);
+
+        if (!o || o.ready) continue;
+
+        console.warn(`${state} was constructed but never activated.`);
+      }
+    });
+  }
+
+  PENDING.add(state);
 }
 
 /**

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -18,8 +18,9 @@ const ID = new WeakMap<State, string>();
 /** Internal state assigned to states. */
 const STORE = new WeakMap<State, Record<string | number | symbol, unknown>>();
 
-/** States constructed this tick, awaiting activation. */
-let PENDING: Set<State> | undefined;
+/** States under construction - added on `new`, removed when activated or released.
+ *  Also carries work to run at the deadline, which `def` uses to bound its registry. */
+const PENDING = new Set<State | (() => void)>();
 
 /** External lifecycle listeners for any given State class. */
 const SETUP = new WeakMap<State.Extends, Set<State.Init<any> | State.On<any>>>();
@@ -38,6 +39,9 @@ const GETTERS = new WeakMap<Function, Map<string, () => unknown>>();
 
 /** Stale flags for compute closures awaiting refresh on next access. */
 const STALE = new WeakSet<() => void>();
+
+/** Whether the deadline which drains `PENDING` is already queued for this tick. */
+let QUEUED = false;
 
 declare namespace State {
   /** Any type of State, using own class constructor as its identifier. */
@@ -541,7 +545,11 @@ function init(state: State, ...args: State.Args) {
     return Context.root.add(state);
   }
 
-  listener(state, () => {
+  listener(state, (key) => {
+    PENDING.delete(state);
+
+    if (key === null) return null;
+
     parent(state, null);
 
     const queue = [...before, observe, ...args, ...after, register];
@@ -565,29 +573,19 @@ function init(state: State, ...args: State.Args) {
     });
 
     return null;
-  }, true);
+  });
 
-  expect(state);
-}
-
-/**
- * Hold a freshly constructed state to the end of this tick, where anything
- * still unactivated is reported. Destroyed instances are exempt.
- */
-function expect(state: State) {
-  if (!PENDING) {
-    const batch = (PENDING = new Set<State>());
+  if (!QUEUED) {
+    QUEUED = true;
 
     queueMicrotask(() => {
-      PENDING = undefined;
+      QUEUED = false;
 
-      for (const state of batch) {
-        const o = observer(state);
+      for (const item of PENDING)
+        if (typeof item == 'function') item();
+        else console.warn(`${item} was constructed but never activated.`);
 
-        if (!o || o.ready) continue;
-
-        console.warn(`${state} was constructed but never activated.`);
-      }
+      PENDING.clear();
     });
   }
 
@@ -1008,4 +1006,4 @@ function parent(child: object, value?: State | null) {
   return true;
 }
 
-export { event, unbind, State, parent, STORE, uid, access, update, apply, compute };
+export { event, unbind, State, parent, PENDING, STORE, uid, access, update, apply, compute };

--- a/skills/state/context.md
+++ b/skills/state/context.md
@@ -19,7 +19,7 @@ A State's home is assigned at activation and is permanent. It's recorded in a si
 
 ### Construct vs Activate
 
-The escape hatch for "create now, place in context later" is the difference between `new State()` and `State.new()`:
+To choose a home other than root, construct with `new State()` and place it in the same tick - the difference between `new State()` and `State.new()`:
 
 ```ts
 // .new() activates immediately - home resolves to root, locked
@@ -32,7 +32,7 @@ const b = new MyState();
 new Context(b); // b's home is this context
 ```
 
-This matters in tests and in code that prepares a state before placing it in a context tree.
+This matters in tests and in code that prepares a state before placing it in a context tree. The placement is an ordering constraint, not a deferral - an instance which has not activated by the end of the tick warns. Release one you no longer want with `set(null)`.
 
 ### Child Inheritance
 

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -9,7 +9,7 @@
 | Operation    | Property assignment | Batched updates via `queueMicrotask()`, effects re-run                                  |     YES      |
 | Destruction  | `state.set(null)`   | Children destroyed first, listeners called, state frozen                                |  DESTROYED   |
 
-> Use `State.new()` for a root instance. Bare `new` constructs without activating: use it for a child State declared on another State, which adopts and activates it, or to defer activation deliberately. One advanced use is wrapping an instance in `new Context(state)` before activation locks its home to `Context.root`; see [context.md](context.md).
+> Use `State.new()` for a root instance. Bare `new` constructs without activating: use it for a child State declared on another State, which adopts and activates it. One advanced use is wrapping an instance in `new Context(state)` before activation locks its home to `Context.root`; see [context.md](context.md). Either way it must activate before the end of the tick - one that does not warns, and `set(null)` releases an instance you decide against.
 
 ## The `new()` Hook
 
@@ -17,12 +17,8 @@
 class Timer extends State {
   elapsed = 0;
 
-  tick() {
-    this.elapsed++;
-  }
-
   protected new() {
-    const id = setInterval(this.tick, 1000);
+    const id = setInterval(() => this.elapsed++, 1000);
     return () => clearInterval(id);
   }
 }

--- a/website/content/docs/migrating-from-hooks.mdx
+++ b/website/content/docs/migrating-from-hooks.mdx
@@ -379,6 +379,8 @@ const counter = new Counter(); // constructs but does NOT activate
 const counter = Counter.new(); // constructs AND activates - always use this
 ```
 
+The first form warns if nothing activates it before the end of the tick, so this mistake announces itself rather than leaving you with an inert instance.
+
 Inside React, `Counter.use()` handles activation for you.
 
 ### Assuming `use()` replaces `useEffect`


### PR DESCRIPTION
Every `State` constructed with plain `new` must activate before the end of the tick. One that does not now warns.

```
Thing-LWYPIO was constructed but never activated.
```

The remedies - `State.new()`, declaring it on an owner, or `new Context(state)` -
are documented in `skills/state/lifecycle.md` and `context.md`, both updated here.

A bare `new` that nothing adopts produces an inert instance - instructions never run, properties are never managed - and today that is completely silent. The rule that it must be adopted is already tacit throughout the codebase and docs; this makes it enforceable.

It has already earned its keep as instrumentation: this exact deadline, wired in as a temporary probe, is what found the `set()` factory adoption bug fixed in #324.

## Scope

- Warn at the deadline (`packages/mvc/src/state.ts`)
- Throw when an instruction token cannot be applied
- Bound the instruction registry to the tick, fixing instructions on Hermes
- Fix: release a `State` which never activated
- Fix: release the twin a deduped `Component` discards
- Docs: replace deferral wording with the ordering constraint

## Mechanism

A per-tick `PENDING` set, drained by a single microtask - one microtask per tick, not per construction. `queueMicrotask` in the constructor is an exact deadline: all synchronous construction, including subclass field initializers and nested `new State()`, completes before any microtask runs.

    Base ctor -> Mid field -> Mid ctor body -> Leaf field -> Leaf ctor body
      -> [sync done] -> Base microtask

Detection needed no new bookkeeping. `Observer.ready` already marks activation and the observer slot already nulls on termination, so the check is `!o || o.ready -> skip`. Destroyed instances exempt themselves, which is what makes `set(null)` the tag for an abandoned instance rather than a separate opt-out mechanism.

## The two fixes

**Releasing a never-activated State threw.** Reproduced on clean `main`:

```ts
const state = new MyState();
state.set(null); // Error: was destroyed - cannot be rendered, watched or updated
```

Terminal dispatch synthesized the activation signal for a never-ready observer (`if (!ready) pending.add(true)`), running init against an already-nulled slot; the init listener also answered every signal rather than activation alone. Both were needed - either fix alone still throws, verified separately.

This is load-bearing rather than incidental. The warning tells the author to activate or release, and release was broken on exactly the population the warning names.

**The deduped Component twin was never released.** A host constructs a `Component` per render attempt; the constructor resolves duplicates by props object and returns the first instance, abandoning the second at `if (copy) return copy`. That twin never activated and was never released. Under StrictMode it happened on every mount - `constructed=2, activated=1, destroyed=0`.

It is released where it is discarded, so `Component` needs no exemption and the invariant stays universal. Note the dependency: this would have crashed every StrictMode render before the fix above.

## Teeth: a token which cannot be applied

The warning is a diagnostic, not a guard. Separately, an instruction is a
per-instance **value**, so nothing bound a token to one declaration site:

```ts
const shared = set(() => 42);
class Thing extends State { value = shared }

Thing.new().value // 42
Thing.new().value // Symbol(field-WZJHFS)
```

The first claimant consumed the entry and every later instance kept the raw
symbol. A single-instance app shipped this and worked; the failure appeared only
once a second instance was constructed, possibly much later and in unrelated code.

Both halves are now closed. Hoisting is refused where it happens (see the gate
below), and activation refuses a token whose entry is already spent - which
catches a token captured mid-construction and reused. Claiming marks the entry
`null` rather than deleting it, so the three states are exact:

```ts
const instruction = APPLY.get(property.value);

if (instruction === null) throw …;   // spent - applied elsewhere
if (!instruction) continue;          // absent - not a token at all
```

No inspection of the symbol itself, so a user's own `Symbol('field-mine')` in a
field is untouched. Cross-tick reuse is not detected, since the registry is
cleared each tick - contrived once hoisting is impossible.

This is the same user-visible wreckage as two existing board items (instructions
in `#private` fields; subclass shadowing in #327) - a raw `Symbol('field-...')`
sitting where a value belongs, from a different cause each time. Guarding the
application point covers this one; the others need their own detection, since
the token never reaches the scan.

## Hermes, and instructions bounded to the tick

`#321` moved the token registry to a `WeakMap` so unconsumed tokens stopped
retaining their factories. Hermes does not implement ES2023 symbol keys for
`WeakMap`, so that made **every instruction throw on React Native**.

With the invariant in place the registry can be a plain `Map` cleared at the
deadline: retention is bounded by the tick rather than by weakness, and no
`WeakMap` is ever keyed by a symbol. Symbols stay - the object-token workaround
explored separately is unnecessary.

`def()` now also throws when no State is under construction:

```ts
const shared = set(() => 42); // Error - no State under construction
```

Activation and release **evict** a state from the pending set, so this is a real
gate rather than a proxy - the set empties as soon as construction resolves,
which is normally the same statement:

```
Thing.new()      -> gate CLOSED
new Thing()      -> gate OPEN (that instance also warns)
  .set(null)     -> gate CLOSED
```

The only way the gate stays open is a state which never activated, and that
state is already being reported. A depth counter around `init()` would be exact
too, but subclass field initializers run after `super()` returns, so depth reads
zero exactly where instructions live - eviction gets the same precision from the
signal already being tracked.

Eviction also removes the need to inspect each pending state at the deadline:
anything still in the set is dangling by construction.

## Why warn and not throw

The deadline fires in a microtask, detached from the construction stack. A throw there is uncatchable by any `try`/`catch` around the `new`, and its stack points at the microtask rather than the offending line - an unattributable crash in place of an unused instance. It is also a claim about an *absence*: nothing is broken at the moment of detection.

The complement is that a *use* which cannot work throws, synchronously and attributably - both at `def()` time when nothing is under construction, and at activation when a token has no factory behind it.

## Behavior change

Deferring activation past the tick is no longer supported. `new Context(state)` still claims a home before activation locks it to root, but placement must happen in the same tick as construction.

`skills/state/context.md` and `skills/state/lifecycle.md` described this as deferral ("create now, place in context later", "defer activation deliberately"), which reads as a license to hold an inert instance indefinitely. The intent is an ordering constraint - construct without activating so the next line decides the home - and the wording is corrected to say so.

## Evidence

Full suite green, 100% coverage across statements/branches/functions/lines in every package, `tsc --noEmit` clean.

Fifteen tests, six of them guarding against the invariant leaking into normal operation: activated, adopted, context-placed and released states all stay silent, as does the discarded twin. Verified by reverting each source file to `origin/main` and re-running - the deadline and release tests fail without `state.ts`/`observable.ts`, the twin test fails without `component.ts`, and the reuse test fails without `def.ts`.

Probed beyond the suite, since "no warning" only proves nothing was left unactivated:

| scenario | made | activated | destroyed | dangling |
| --- | --- | --- | --- | --- |
| suspense | 1 | 1 | 1 | 0 |
| render throws (boundary retry) | 2 | 2 | 2 | 0 |
| StrictMode | 2 | 1 | 1 | 0 |

## Not verified

- **Not run on Hermes.** The fix is a static one - no `WeakMap`/`WeakSet` in
  `mvc` or `router` is keyed by a symbol any more, confirmed by inspection of
  every declaration - but this branch has not been driven on a device or
  simulator. The native gauntlet lives on the `react-native` branch and is not
  on `main` yet.
- **Not benchmarked.** `map()` creating hundreds of instances is where per-tick
  registry cost would show, if anywhere.
- **Concurrent interrupted render** cannot be forced under happy-dom. That
  population activates first, so the deadline never sees it - it is what the
  boundary's `SLOTS` exists for, and that code did not fire in any path
  exercised here.
- **Cross-tick token reuse** is undetected by design (registry cleared each
  tick). Requires capturing a token mid-construction and stashing it.

Board: *No-dangling-new: warn when a State never activates*, and *Destroying a never-activated State throws instead of releasing it*.
