### PR TITLE
test(mvc): pin and document that `this` is the instance

### DIFF
--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -301,6 +301,42 @@ describe('methods', () => {
     expect(foo1).not.toBe(foo2);
   });
 
+  it('will bind to the instance, not a proxy', () => {
+    class Test extends State {
+      value = 0;
+
+      whoami() {
+        return this;
+      }
+    }
+
+    const test = Test.new();
+    let proxy!: Test;
+    let inside!: Test;
+
+    test.get((current) => {
+      proxy = current;
+      inside = current.whoami();
+    });
+
+    expect(proxy).not.toBe(test.is);
+    expect(inside).toBe(test.is);
+  });
+
+  it('will call new() with the instance', () => {
+    let inside!: Test;
+
+    class Test extends State {
+      protected new() {
+        inside = this;
+      }
+    }
+
+    const test = Test.new();
+
+    expect(inside).toBe(test.is);
+  });
+
   it('will allow overwrite', () => {
     class Test extends State {
       foo = 'foo';

--- a/skills/state/lifecycle.md
+++ b/skills/state/lifecycle.md
@@ -27,6 +27,7 @@ class Timer extends State {
 - Runs once after all properties are initialized and child states are set up.
 - Return `void` if no cleanup needed.
 - Return `() => void` for a cleanup function called on destruction.
+- `this` is the instance, not a tracking proxy - closures made here (a listener, an interval) capture it and may use it as a `Map`/`Set` key.
 
 `new()` is a typed optional member of `State` (`protected new?(): void | (() => void)`), not name-based detection - editors autocomplete it, its signature is checked, and TypeScript's `override` keyword catches a misspelled override. The same holds for `catch()` and `mount()` on `Component`. Adapter hooks reached
 only through `State.use()` - `use()` and `mount()` on a plain `State` - are

--- a/skills/state/state.md
+++ b/skills/state/state.md
@@ -141,6 +141,7 @@ increment(); // `this` is correctly bound
 - Overwriting methods works: `test.method = () => 'bar'`.
 - `super` calls work across inheritance chains.
 - Methods called inside effects do NOT create subscriptions for properties they access.
+- `this` inside a method is the instance, never a tracking proxy - so `this === this.is`, and it is safe as a `Map`/`Set` key or for identity comparison. True however the method was reached, including off a proxy handed to an effect or render. The `new()` hook has the same guarantee (see [lifecycle.md](lifecycle.md#the-new-hook)).
 
 ## Static Methods
 


### PR DESCRIPTION
`this` inside a State method is the instance, never a tracking proxy — so `this === this.is`, and it is safe as a `Map`/`Set` key or for identity comparison. The `new()` hook has the same guarantee. Neither was tested or documented.

## Two mechanisms, not one

- **`state.ts:659`** — auto-binding binds to `is`, so a method reached through a tracking proxy still runs with `this` as the instance.
- **`state.ts:562`** — the constructor queue invokes hooks as `arg.call(state, state)`, supplying the instance directly.

The second matters because `init(this, args, this.new)` reads `this.new` *before* `bootstrap` installs the binding getters, so the `new()` hook may well arrive unbound. It doesn't matter — the call site supplies the receiver. The source reads like a problem that a second, unrelated mechanism quietly covers, which is why this is worth pinning rather than inferring.

## Verified by mutation

Each test fails for its own mechanism and passes under the other's, so neither is vacuous:

| mutation | `will bind to the instance, not a proxy` | `will call new() with the instance` |
| --- | --- | --- |
| `fn.bind(is)` → `fn` | **fails** | passes |
| hook receiver → a different object | passes | **fails** |

The first test also asserts the proxy is *not* the instance, so it cannot pass by the two being the same object.

## Documented, not just tested

`skills/state/state.md` said methods are auto-bound but never what they are bound *to* — the half that makes identity comparison and `WeakMap` keying safe. That section and the `new()` hook in `lifecycle.md` now say it.

Surfaced while reviewing `@expressive/router`, which keys a `WeakMap` on `this` from inside its own methods — sound, but resting on an invariant nothing stated.

No changeset — no observable change.
