### PR TITLE
feat(mvc): shape or decline what pool add produces

### DIFF
--- a/.changeset/lucky-pans-invite.md
+++ b/.changeset/lucky-pans-invite.md
@@ -1,0 +1,9 @@
+---
+'@expressive/mvc': minor
+---
+
+Pools can shape or decline what `add` produces.
+
+`has(Player, 'id')` names a field to receive `add`'s argument, covering the common transposition without a function. A lone instance is still admitted rather than constructed.
+
+A factory returning `undefined` now adds nothing and `add` yields `undefined` - so a factory may look a member up, filter one out, or build it. Member type excludes `undefined`, so only `add` widens.

--- a/.changeset/lucky-pans-invite.md
+++ b/.changeset/lucky-pans-invite.md
@@ -6,4 +6,4 @@ Pools can shape or decline what `add` produces.
 
 `has(Player, 'id')` names a field to receive `add`'s argument, covering the common transposition without a function. A lone instance is still admitted rather than constructed.
 
-A factory returning `undefined` now adds nothing and `add` yields `undefined` - so a factory may look a member up, filter one out, or build it. Member type excludes `undefined`, so only `add` widens.
+A factory returning `undefined` or `null` now adds nothing and `add` yields it back - so a factory may look a member up, filter one out, or build it. Member type excludes nullish, so only `add` widens.

--- a/packages/mvc/src/field/has.test.ts
+++ b/packages/mvc/src/field/has.test.ts
@@ -18,7 +18,7 @@ function reactive<T extends State, K extends State.Field<T>>(
 
 function reactive<R, A extends unknown[]>(
   make: (...args: A) => R
-): has.Pool<Exclude<R, undefined>, A, R>;
+): has.Pool<Exclude<R, null | undefined>, A, R>;
 
 function reactive(...args: any[]): any {
   const arg = args[0];
@@ -852,9 +852,27 @@ describe('pool lookup', () => {
     expect(pool.size).toBe(0);
   });
 
-  it('will exclude undefined from member type', () => {
+  it('will not add if factory returns null', async () => {
     const known = new Map([['abc', Item.new({ id: 'abc' })]]);
-    const pool = reactive((id: string) => known.get(id));
+    const pool = reactive((id: string) => known.get(id) || null);
+    const fn = vi.fn();
+
+    watch(pool, ($) => {
+      void $.size;
+      fn();
+    });
+    fn.mockClear();
+
+    expect(pool.add('nope')).toBeNull();
+    await flush();
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(pool.size).toBe(0);
+  });
+
+  it('will exclude nullish from member type', () => {
+    const known = new Map([['abc', Item.new({ id: 'abc' })]]);
+    const pool = reactive((id: string) => known.get(id) || null);
 
     pool.add('abc');
 

--- a/packages/mvc/src/field/has.test.ts
+++ b/packages/mvc/src/field/has.test.ts
@@ -11,15 +11,20 @@ function reactive<T extends State>(
   Type: new (...args: State.Args<T>) => T
 ): has.Pool<T, State.Args<T> | [T]>;
 
-function reactive<T, A extends unknown[]>(
-  make: (...args: A) => T
-): has.Pool<T, A>;
+function reactive<T extends State, K extends State.Field<T>>(
+  Type: new (...args: State.Args<T>) => T,
+  key: K
+): has.Pool<T, [T[K]] | [T]>;
+
+function reactive<R, A extends unknown[]>(
+  make: (...args: A) => R
+): has.Pool<Exclude<R, undefined>, A, R>;
 
 function reactive(...args: any[]): any {
   const arg = args[0];
 
   return typeof arg == 'function'
-    ? new has.Pool(arg)
+    ? new has.Pool(arg, args[1])
     : new has.List(arg);
 }
 
@@ -564,6 +569,14 @@ describe('pool', () => {
     expect(pool.size).toBe(0);
   });
 
+  it('will create pool for class without keys', () => {
+    const pool = new has.Pool<Item>(Item);
+    const item = pool.add({ value: 3 });
+
+    expect(item.value).toBe(3);
+    expect(pool.size).toBe(1);
+  });
+
   it('will create pool for factory', () => {
     const pool = reactive(() => ({ value: 0 }));
 
@@ -612,6 +625,14 @@ describe('pool', () => {
     const item = pool.add(3);
 
     expect(item.n).toBe(3);
+  });
+
+  it('will not add if factory returns nothing', () => {
+    const pool = reactive((n: number) => (n > 0 ? { n } : undefined));
+
+    expect(pool.add(1)).toEqual({ n: 1 });
+    expect(pool.add(0)).toBeUndefined();
+    expect(pool.size).toBe(1);
   });
 
   it('will pass through guest from factory', () => {
@@ -776,6 +797,108 @@ describe('pool', () => {
     await flush();
 
     expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe('pool lookup', () => {
+  class Item extends State {
+    id = '';
+  }
+
+  it('will adopt instance returned by factory', () => {
+    const known = new Map([['abc', Item.new({ id: 'abc' })]]);
+    const pool = reactive((id: string) => known.get(id) || new Item({ id }));
+
+    expect(pool.add('abc')).toBe(known.get('abc'));
+    expect(pool.add('xyz')).not.toBe(known.get('abc'));
+    expect(pool.size).toBe(2);
+  });
+
+  it('will not add member returned twice', async () => {
+    const known = new Map([['abc', Item.new({ id: 'abc' })]]);
+    const pool = reactive((id: string) => known.get(id));
+    const fn = vi.fn();
+
+    pool.add('abc');
+
+    watch(pool, ($) => {
+      void $.size;
+      fn();
+    });
+    fn.mockClear();
+
+    expect(pool.add('abc')).toBe(known.get('abc'));
+    await flush();
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(pool.size).toBe(1);
+  });
+
+  it('will not add if factory declines', async () => {
+    const known = new Map([['abc', Item.new({ id: 'abc' })]]);
+    const pool = reactive((id: string) => known.get(id));
+    const fn = vi.fn();
+
+    watch(pool, ($) => {
+      void $.size;
+      fn();
+    });
+    fn.mockClear();
+
+    expect(pool.add('nope')).toBeUndefined();
+    await flush();
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(pool.size).toBe(0);
+  });
+
+  it('will exclude undefined from member type', () => {
+    const known = new Map([['abc', Item.new({ id: 'abc' })]]);
+    const pool = reactive((id: string) => known.get(id));
+
+    pool.add('abc');
+
+    expect(pool.map((item) => item.id)).toEqual(['abc']);
+  });
+});
+
+describe('pool key', () => {
+  class Cell extends State {
+    at = '';
+    color = 'white';
+  }
+
+  it('will assign argument to named property', () => {
+    const pool = reactive(Cell, 'at');
+    const cell = pool.add('a1');
+
+    expect(cell.at).toBe('a1');
+    expect(cell.color).toBe('white');
+  });
+
+  it('will still admit instance of class', () => {
+    const pool = reactive(Cell, 'at');
+    const guest = Cell.new({ at: 'b2' });
+
+    expect(pool.add(guest)).toBe(guest);
+    expect(pool.size).toBe(1);
+  });
+
+  it('will own member spawned through key', () => {
+    class Member extends State {
+      id = '';
+      owner = get(Owner);
+    }
+
+    class Owner extends State {
+      members = has(Member, 'id');
+    }
+
+    const owner = Owner.new();
+    const member = owner.members.add('abc');
+
+    expect(member.owner).toBe(owner);
+    expect(member.id).toBe('abc');
   });
 });
 

--- a/packages/mvc/src/field/has.test.ts
+++ b/packages/mvc/src/field/has.test.ts
@@ -13,7 +13,7 @@ function reactive<T extends State>(
 
 function reactive<T extends State, K extends State.Field<T>>(
   Type: new (...args: State.Args<T>) => T,
-  key: K
+  fromKey: K
 ): has.Pool<T, [T[K]] | [T]>;
 
 function reactive<R, A extends unknown[]>(

--- a/packages/mvc/src/field/has.ts
+++ b/packages/mvc/src/field/has.ts
@@ -32,7 +32,7 @@ function has<T extends State, K extends State.Field<T>>(
 
 function has<R, A extends unknown[]>(
   make: (...args: A) => R
-): Pool<Exclude<R, undefined>, A, R>;
+): Pool<Exclude<R, null | undefined>, A, R>;
 
 function has(
   arg?: Iterable<unknown> | Function | false | null,
@@ -196,9 +196,9 @@ class Pool<T, A extends unknown[] = unknown[], R = T> {
 
   add(...args: A): R {
     const target = source(this);
-    const made = MAKE.get(target)!(...args) as T | undefined;
+    const made = MAKE.get(target)!(...args) as T | null | undefined;
 
-    if (made === undefined) return undefined as R;
+    if (made == null) return made as R;
 
     const values = MEMBERS.get(target) as Set<T>;
 

--- a/packages/mvc/src/field/has.ts
+++ b/packages/mvc/src/field/has.ts
@@ -8,9 +8,10 @@ const SHAPE = Symbol('shape');
 
 const ITEMS = new WeakMap<object, unknown[]>();
 const MEMBERS = new WeakMap<object, Set<unknown>>();
-const MAKE = new WeakMap<object, Function>();
 const OWNED = new WeakMap<object, Map<unknown, () => void>>();
+const MAKE = new WeakMap<object, Make>();
 
+type Make = (...args: unknown[]) => unknown;
 type Predicate<T> = (value: T, index: number, self: unknown) => boolean;
 type Mapper<T, U> = (value: T, index: number, self: unknown) => U;
 
@@ -81,7 +82,7 @@ class List<T> {
 
   set(index: number, value: T) {
     const target = source(this);
-    const values = ITEMS.get(target)! as T[];
+    const values = ITEMS.get(target) as T[];
     const at = index < 0 ? values.length + index : index;
 
     if (at < 0 || at >= values.length || values[at] === value) return;
@@ -94,7 +95,7 @@ class List<T> {
     if (!values.length) return;
 
     const target = source(this);
-    const arr = ITEMS.get(target)! as T[];
+    const arr = ITEMS.get(target) as T[];
     const at =
       index < 0
         ? Math.max(arr.length + index, 0)
@@ -116,7 +117,7 @@ class List<T> {
   pop(index: number, count: number): T[];
   pop(index = -1, count?: number): T | T[] | undefined {
     const target = source(this);
-    const values = ITEMS.get(target)! as T[];
+    const values = ITEMS.get(target) as T[];
     const before = values.length;
     const start =
       index < 0 ? Math.max(before + index, 0) : Math.min(index, before);
@@ -164,8 +165,17 @@ class List<T> {
 
 class Pool<T, A extends unknown[] = unknown[]> {
   constructor(make: Function) {
+    if (State.is(make)) {
+      const Type = make as unknown as State.Type;
+
+      make = (...args: State.Args) =>
+        args.length == 1 && args[0] instanceof Type
+          ? args[0]
+          : new Type(...args);
+    }
+
     MEMBERS.set(this, new Set());
-    MAKE.set(this, make);
+    MAKE.set(this, make as Make);
     OWNED.set(this, new Map());
 
     event(this);
@@ -177,26 +187,17 @@ class Pool<T, A extends unknown[] = unknown[]> {
 
   add(...args: A): T {
     const target = source(this);
-    const values = MEMBERS.get(target)! as Set<T>;
-    const make = MAKE.get(target)!;
+    const made = MAKE.get(target)!(...args) as T;
+    const values = MEMBERS.get(target) as Set<T>;
 
-    const value = (
-      !State.is(make)
-        ? make(...args)
-        : args.length == 1 && args[0] instanceof make
-          ? args[0]
-          : new (make as State.Type)(...(args as State.Args))
-    ) as T;
-
-    if (!values.has(value)) {
-      values.add(value);
-      adopt(target, value, value);
-
-      event(target, value as never);
+    if (!values.has(made)) {
+      values.add(made);
+      adopt(target, made, made);
+      event(target, made as never);
       event(target, SHAPE);
     }
 
-    return value;
+    return made;
   }
 
   get(): State.Export<T>[];
@@ -213,7 +214,7 @@ class Pool<T, A extends unknown[] = unknown[]> {
 
   delete(value: T): boolean {
     const target = source(this);
-    const values = MEMBERS.get(target)! as Set<T>;
+    const values = MEMBERS.get(target) as Set<T>;
 
     if (!values.has(value)) return false;
 
@@ -228,7 +229,7 @@ class Pool<T, A extends unknown[] = unknown[]> {
 
   clear() {
     const target = source(this);
-    const values = MEMBERS.get(target)! as Set<T>;
+    const values = MEMBERS.get(target) as Set<T>;
 
     if (!values.size) return;
 

--- a/packages/mvc/src/field/has.ts
+++ b/packages/mvc/src/field/has.ts
@@ -25,13 +25,22 @@ function has<T extends State>(
   Type: new (...args: State.Args<T>) => T
 ): Pool<T, State.Args<T> | [T]>;
 
-function has<T, A extends unknown[]>(
-  make: (...args: A) => T
-): Pool<T, A>;
+function has<T extends State, K extends State.Field<T>>(
+  Type: new (...args: State.Args<T>) => T,
+  key: K
+): Pool<T, [T[K]] | [T]>;
 
-function has(arg?: Iterable<unknown> | Function | false | null): unknown {
+function has<R, A extends unknown[]>(
+  make: (...args: A) => R
+): Pool<Exclude<R, undefined>, A, R>;
+
+function has(
+  arg?: Iterable<unknown> | Function | false | null,
+  key?: string
+): unknown {
   return def((_key, subject) => {
-    const value = typeof arg == 'function' ? new Pool(arg) : new List(arg);
+    const value =
+      typeof arg == 'function' ? new Pool(arg, key) : new List(arg);
 
     parent(value, subject);
     listener(subject, () => value.clear(), null);
@@ -163,15 +172,15 @@ class List<T> {
   }
 }
 
-class Pool<T, A extends unknown[] = unknown[]> {
-  constructor(make: Function) {
+class Pool<T, A extends unknown[] = unknown[], R = T> {
+  constructor(make: Function, key?: string) {
     if (State.is(make)) {
       const Type = make as unknown as State.Type;
 
       make = (...args: State.Args) =>
-        args.length == 1 && args[0] instanceof Type
-          ? args[0]
-          : new Type(...args);
+        args.length == 1 && args[0] instanceof Type ? args[0] :
+        key ? new Type({ [key]: args[0] }) :
+        new Type(...args);
     }
 
     MEMBERS.set(this, new Set());
@@ -185,9 +194,12 @@ class Pool<T, A extends unknown[] = unknown[]> {
     return touch(this, SHAPE, members<T>(this).size);
   }
 
-  add(...args: A): T {
+  add(...args: A): R {
     const target = source(this);
-    const made = MAKE.get(target)!(...args) as T;
+    const made = MAKE.get(target)!(...args) as T | undefined;
+
+    if (made === undefined) return undefined as R;
+
     const values = MEMBERS.get(target) as Set<T>;
 
     if (!values.has(made)) {
@@ -197,7 +209,7 @@ class Pool<T, A extends unknown[] = unknown[]> {
       event(target, SHAPE);
     }
 
-    return made;
+    return made as R;
   }
 
   get(): State.Export<T>[];

--- a/packages/mvc/src/field/has.ts
+++ b/packages/mvc/src/field/has.ts
@@ -27,7 +27,7 @@ function has<T extends State>(
 
 function has<T extends State, K extends State.Field<T>>(
   Type: new (...args: State.Args<T>) => T,
-  key: K
+  fromKey: K
 ): Pool<T, [T[K]] | [T]>;
 
 function has<R, A extends unknown[]>(
@@ -36,11 +36,11 @@ function has<R, A extends unknown[]>(
 
 function has(
   arg?: Iterable<unknown> | Function | false | null,
-  key?: string
+  fromKey?: string
 ): unknown {
   return def((_key, subject) => {
     const value =
-      typeof arg == 'function' ? new Pool(arg, key) : new List(arg);
+      typeof arg == 'function' ? new Pool(arg, fromKey) : new List(arg);
 
     parent(value, subject);
     listener(subject, () => value.clear(), null);
@@ -173,13 +173,13 @@ class List<T> {
 }
 
 class Pool<T, A extends unknown[] = unknown[], R = T> {
-  constructor(make: Function, key?: string) {
+  constructor(make: Function, fromKey?: string) {
     if (State.is(make)) {
       const Type = make as unknown as State.Type;
 
       make = (...args: State.Args) =>
         args.length == 1 && args[0] instanceof Type ? args[0] :
-        key ? new Type({ [key]: args[0] }) :
+        fromKey ? new Type({ [fromKey]: args[0] }) :
         new Type(...args);
     }
 

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -18,7 +18,7 @@ The argument selects the mode:
 | call | interface | insert | identity |
 | --- | --- | --- | --- |
 | `has<T>()` / `has(values)` | `has.List<T>` | `push` / `put` / `set(index)` | position |
-| `has(StateClass)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns, `add(value)` admits | the value itself |
+| `has(StateClass)` / `has(StateClass, key)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns, `add(value)` admits | the value itself |
 
 A list stores values you give it, in order, addressed by index. A pool spawns its members - `add` returns the member, the call site holds the reference, and the value is its own identity for `has`, `delete`, and eviction. A class-mode pool also takes a ready-made instance.
 
@@ -78,6 +78,44 @@ store.selected.add(item);                // holds an active member - guest
 ```
 
 Only a single argument is treated this way; `add(a, b)` always constructs, so multi-argument constructors are unaffected. A factory pool never admits - its arguments are its own, so route instances through the factory body (`has((item?: Item) => item || new Item())`).
+
+### Argument key
+
+A field name after the class assigns `add`'s argument to it - the common case, without writing a function.
+
+```ts
+class Roster extends State {
+  players = has(Player, 'id');
+}
+
+const player = roster.players.add('abc');   // new Player({ id: 'abc' })
+```
+
+The key is a `State.Field<T>` - an own field, not a base `State` member - and `add` takes its value type. One key only; transposing more than one value is a factory.
+
+### Declining to add
+
+A factory returning `undefined` adds nothing and `add` yields `undefined` - so it decides *which* member, not just how to build one. Return an existing instance and the pool holds that, making `add` a lookup-or-create; a member already present is returned untouched.
+
+```ts
+const USERS = new Map<string, User>();
+
+class Store extends State {
+  active = has((id: string) => USERS.get(id) || new User({ id }));
+  online = has((id: string) => USERS.get(id));
+}
+
+store.active.add('abc');         // known user, else spawns one
+store.online.add('nope');        // undefined - nothing added
+```
+
+Members stay `T` - only `add` widens - so reads are not infected by the miss case. The same applies to filtering at construction:
+
+```ts
+messages = has((dto: MessageDto) =>
+  dto.deleted ? undefined : new Message({ info: dto, id: dto.id })
+);
+```
 
 A pool has no initial argument: it spawns, so seed it imperatively from the `new()` hook, which runs once the field has resolved. This is the single seeding seam - it also covers conditional, ordered, and derived members, which a static initializer could not.
 
@@ -186,7 +224,13 @@ Member fields read thru a subscribed context track deeply - a parent rendering `
 ```ts
 function has<T>(initial?: Iterable<T> | false | null): has.List<T>;
 function has<T extends State>(Type: new (...args: State.Args<T>) => T): has.Pool<T, State.Args<T> | [T]>;
-function has<T, A extends unknown[]>(make: (...args: A) => T): has.Pool<T, A>;
+function has<T extends State, K extends State.Field<T>>(
+  Type: new (...args: State.Args<T>) => T,
+  key: K
+): has.Pool<T, [T[K]] | [T]>;
+function has<R, A extends unknown[]>(
+  make: (...args: A) => R
+): has.Pool<Exclude<R, undefined>, A, R>;
 
 class has.List<T> {
   readonly size: number;
@@ -202,9 +246,9 @@ class has.List<T> {
   // map / filter / any / all / [Symbol.iterator]
 }
 
-class has.Pool<T, A extends unknown[] = unknown[]> {
+class has.Pool<T, A extends unknown[] = unknown[], R = T> {
   readonly size: number;
-  add(...args: A): T;                          // constructor's or factory's own signature; class mode also takes [T]
+  add(...args: A): R;                          // constructor's or factory's own signature; class mode also takes [T]
   get(): State.Export<T>[];                    // snapshot
   get(predicate): T | undefined;
   has(value: T): boolean;
@@ -221,6 +265,6 @@ class has.Pool<T, A extends unknown[] = unknown[]> {
 - Mode follows the argument: iterable/none is a list, any function (class or factory, any arity) is a pool.
 - List events are positional: `set(index)` notifies that index; `put`/`pop` notify shifted indices plus length.
 - Pool events are by value: `add`/`delete` notify the member plus shape; `has(value)` tracks that member only.
-- Repeat `add` of a value already present is a no-op.
+- `add` is a no-op for a value already present, and for `undefined` from a factory - which it returns.
 - `get()` with no arguments returns a snapshot array in both modes.
 - Reactivity is shallow. Nested State, `map()`, and `has()` values keep their own reactivity when accessed through the collection.

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -95,7 +95,7 @@ The key is a `State.Field<T>` - an own field, not a base `State` member - and `a
 
 ### Declining to add
 
-A factory returning `undefined` adds nothing and `add` yields `undefined` - so it decides *which* member, not just how to build one. Return an existing instance and the pool holds that, making `add` a lookup-or-create; a member already present is returned untouched.
+A factory returning `undefined` or `null` adds nothing and `add` yields it back - so a factory decides *which* member, not just how to build one. Return an existing instance and the pool holds that, making `add` a lookup-or-create; a member already present is returned untouched.
 
 ```ts
 const USERS = new Map<string, User>();
@@ -180,7 +180,7 @@ Ownership follows freshness, not how the member arrived: a fresh (never-activate
 
 Every collection is adopted by its hosting state at activation. Fresh `State` members are parented to the owner and activate inside its context: `get(Owner)` resolves directly and providers above the owner resolve from members.
 
-Death also flows the other way: a `State` member that dies evicts itself from the pool - owned or guest - so a pool never serves destroyed members. Destroying a member (`member.set(null)`) is a complete removal gesture on its own. Lists do not adopt, destroy, or evict on death - they store values by position; use a pool (`has(Item)`) when members are owned `State`s.
+Death also flows the other way: a `State` member that dies evicts itself from the pool - owned or guest - so a pool never serves destroyed members. Adding one already destroyed throws. Destroying a member (`member.set(null)`) is a complete removal gesture on its own. Lists do not adopt, destroy, or evict on death - they store values by position; use a pool (`has(Item)`) when members are owned `State`s.
 
 Destruction is an eviction concern, separate from context, so the underlying `has.Pool` and `has.List` can be constructed directly without an owner (`new has.Pool(Item)`, chiefly for testing) - fresh members are still owned and destroyed on eviction, just not parented into a context.
 
@@ -230,7 +230,7 @@ function has<T extends State, K extends State.Field<T>>(
 ): has.Pool<T, [T[K]] | [T]>;
 function has<R, A extends unknown[]>(
   make: (...args: A) => R
-): has.Pool<Exclude<R, undefined>, A, R>;
+): has.Pool<Exclude<R, null | undefined>, A, R>;
 
 class has.List<T> {
   readonly size: number;
@@ -265,6 +265,6 @@ class has.Pool<T, A extends unknown[] = unknown[], R = T> {
 - Mode follows the argument: iterable/none is a list, any function (class or factory, any arity) is a pool.
 - List events are positional: `set(index)` notifies that index; `put`/`pop` notify shifted indices plus length.
 - Pool events are by value: `add`/`delete` notify the member plus shape; `has(value)` tracks that member only.
-- `add` is a no-op for a value already present, and for `undefined` from a factory - which it returns.
+- `add` is a no-op for a value already present, and for nullish from a factory - which it returns.
 - `get()` with no arguments returns a snapshot array in both modes.
 - Reactivity is shallow. Nested State, `map()`, and `has()` values keep their own reactivity when accessed through the collection.

--- a/skills/field/has.md
+++ b/skills/field/has.md
@@ -18,7 +18,7 @@ The argument selects the mode:
 | call | interface | insert | identity |
 | --- | --- | --- | --- |
 | `has<T>()` / `has(values)` | `has.List<T>` | `push` / `put` / `set(index)` | position |
-| `has(StateClass)` / `has(StateClass, key)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns, `add(value)` admits | the value itself |
+| `has(StateClass)` / `has(StateClass, fromKey)` / `has(factory)` | `has.Pool<T, A>` | `add(...args)` spawns, `add(value)` admits | the value itself |
 
 A list stores values you give it, in order, addressed by index. A pool spawns its members - `add` returns the member, the call site holds the reference, and the value is its own identity for `has`, `delete`, and eviction. A class-mode pool also takes a ready-made instance.
 
@@ -226,7 +226,7 @@ function has<T>(initial?: Iterable<T> | false | null): has.List<T>;
 function has<T extends State>(Type: new (...args: State.Args<T>) => T): has.Pool<T, State.Args<T> | [T]>;
 function has<T extends State, K extends State.Field<T>>(
   Type: new (...args: State.Args<T>) => T,
-  key: K
+  fromKey: K
 ): has.Pool<T, [T[K]] | [T]>;
 function has<R, A extends unknown[]>(
   make: (...args: A) => R


### PR DESCRIPTION
Class-mode pools can name a field to receive `add`'s argument, and any factory may decline to produce a member.

```ts
class Board extends State {
  rows = has(StepRow, 'section');            // new StepRow({ section })
  online = has((id: string) => USERS.get(id)); // lookup - miss adds nothing
}
```

## Motivation

Pools in real use are full of factories that exist only to transpose one value:

```ts
rows = has((section: LayerSection) => new StepRow({ section }));
```

The class is the interesting part and it's buried behind a lambda whose entire job is to move one argument into one field.

## What landed

Three pool forms, each with one job:

| form | job |
| --- | --- |
| `has(Type)` | construct from constructor args; admit a lone instance |
| `has(Type, 'key')` | put `add`'s argument in that field |
| `has(factory)` | decide the member - build it, find it, or skip it |

`add` still admits a ready-made instance in every class mode, checked before the key is applied.

## Decisions along the way

**The mapper overload we started with is not in this PR.** The first design was `has(Type, map)` - a function converting `add` arguments into constructor assignment, with a returned instance meaning "adopt this one". It was built, tested and documented, then removed once the pieces around it made it redundant. The string key took the one-value case, and typed factories took the lookup case. What remained unique to it was pairing mapped arguments with instance admission, which is one `instanceof` line inside a factory.

**Adoption stayed, and takes precedence.** Early on the question was whether a mapper should displace `add(instance)`. Keeping both costs one branch, and losing it would have been awkward for moving a member between pools - so admission is checked first in every class mode, and that survived into the key form.

**Keys are singular, deliberately.** Varargs (`has(Cell, 'at', 'color')`) were implemented and then dropped. Positional arguments stop being self-evident past the first one, and a multi-field transposition is exactly where naming the fields at the definition site earns its keep. Varargs remain available later as a purely additive widening.

**Nullish means "no member", everywhere.** Originally a symbol sentinel carried the mapper's no-op decision. Collapsing it to `undefined` widened the rule to factories, which turned out to be the more useful contract - a factory can now look a member up, filter one out, or build it. `null` joined it late: `Map.get` yields `undefined`, but plenty of lookup APIs return `null`, and a `null` seated in a pool as a member is junk. Both decline, and both are excluded from the member type. The check is `== null`, so a factory returning `0` or `''` still adds. This is a behavior change - a factory returning nullish previously added it to the pool as a member.

**No validation beyond that.** Whether `add` should throw on a bad factory return was considered and declined. `T` is unconstrained, so primitives, plain objects and `State`s are all legitimate members - the library has no definition of "bad" to check against. The one case with teeth already throws: `adopt` runs `observer()` on a `State` member, so adding a destroyed instance fails loudly (`Item-... was destroyed - cannot be rendered, watched or updated`) rather than seating a dead member that would never evict.

**Typing the decline without taxing everyone.** The obvious signature - `make: (...args: A) => T | undefined` - widens `add` to `T | undefined` for *every* factory pool, including ones that always produce a member. Inferring the raw return instead and deriving the member type keeps the cost where the behavior is:

```ts
function has<R, A extends unknown[]>(
  make: (...args: A) => R
): Pool<Exclude<R, undefined>, A, R>;
```

```ts
has((id: string) => USERS.get(id))   // Pool<User, [string], User | undefined>
has((n: number) => ({ n }))          // Pool<{n: number}, [number], {n: number}>
```

Absorbing `| undefined | void` in the parameter position was checked as an alternative and rejected: it produces the same member type but destroys the information `add` needs, so every factory's `add` widens. Both variants were verified against `tsc` with exact-type assertions before choosing.

**Strategy resolves once, at construction.** `add` used to re-derive its mode on every call. `MAKE` now holds a maker settled when the pool is built - a `State` class is wrapped once, a factory is stored as-is with zero indirection - leaving `add` to forward arguments and derive a value. Split out as its own commit and verified as a pure refactor: `main`'s tests pass against it with the test file untouched.

## Notes

- One test's value is compile-time: `pool.map((item) => item.id)` only typechecks if `Exclude` kept `undefined` out of the member type.
- The refactor commit also drops non-null assertions made redundant by the casts beside them, including three in `List` that predate this branch.
- `skills/field/has.md` gains *Argument key* and *Declining to add*; `website/content/docs` still describes the old signature, deferred with the existing `map`+`has` website pass.

## Verification

35 test files / 1338 tests passing, `tsc --noEmit` clean in all four packages, `@expressive/mvc` at 100% statements, branches, functions and lines.

