### PR TITLE
fix(mvc): resolve upstream get() between siblings regardless of field order

### DIFF
--- a/.changeset/sibling-upstream-get.md
+++ b/.changeset/sibling-upstream-get.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Resolve upstream `get()` between siblings regardless of field order. A child's `get(Type)` no longer throws when the matching sibling is declared after it on the same parent, and `get(Type, false)` and the callback form backfill when the sibling arrives. States added to a context now notify upstream consumers registered in that same context.

--- a/packages/mvc/src/context.test.ts
+++ b/packages/mvc/src/context.test.ts
@@ -1178,6 +1178,18 @@ it('will traverse deeply nested contexts', () => {
   expect(cb).toBeCalledWith(foo, true);
 });
 
+it('will notify upstream consumer when type is added to same context', () => {
+  const context = new Context();
+  const cb = vi.fn();
+
+  context.get(Example, cb, false);
+
+  const foo = Example.new();
+  context.add(foo);
+
+  expect(cb).toBeCalledWith(foo, false);
+});
+
 it('will skip consumer if filter does not match downstream', () => {
   const parent = new Context();
   const child = parent.push();

--- a/packages/mvc/src/context.ts
+++ b/packages/mvc/src/context.ts
@@ -257,23 +257,24 @@ class Context {
 
     for (const T of TT) onDone.add(this.register(T, [I, explicit]));
 
-    function queue(ctx: Context, downstream: boolean) {
+    function queue(ctx: Context, downstream: boolean, same?: boolean) {
       let found = false;
       for (const T of TT) {
         const list = ctx.consume.get(T);
         if (list !== undefined) found = true;
         if (list)
           for (const [cb, filter] of list)
-            if (filter === downstream || filter == null)
+            if (same || filter == null || filter === downstream)
               expects.set(cb, () => {
-                const r = cb(I, downstream);
+                const r = cb(I, filter ?? downstream);
                 if (r) onDone.add(r);
               });
       }
       return found;
     }
 
-    for (let ctx: Context | undefined = this; ctx; ctx = ctx.parent) queue(ctx, true);
+    queue(this, true, true);
+    for (let ctx = this.parent; ctx; ctx = ctx.parent) queue(ctx, true);
     this.traverse((ctx) => queue(ctx, false));
 
     if (!LOOKUP.has(I)) LOOKUP.set(I, this);

--- a/packages/mvc/src/field/get.test.ts
+++ b/packages/mvc/src/field/get.test.ts
@@ -261,6 +261,105 @@ describe('fetch mode', () => {
     expect(Object.keys(test)).toMatchObject(['foo']);
   });
 
+  describe('siblings', () => {
+    class Peer extends State {}
+    class Required extends State {
+      peer = get(Peer);
+    }
+    class Optional extends State {
+      peer = get(Peer, false);
+    }
+
+    it('will resolve optional sibling declared earlier', () => {
+      class Parent extends State {
+        peer = new Peer();
+        child = new Optional();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.child.peer).toBe(parent.peer);
+    });
+
+    it('will resolve optional sibling declared later', () => {
+      class Parent extends State {
+        child = new Optional();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.child.peer).toBe(parent.peer);
+    });
+
+    it('will resolve required sibling declared later', () => {
+      class Parent extends State {
+        child = new Required();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.child.peer).toBe(parent.peer);
+    });
+
+    it('will run callback for sibling declared later', () => {
+      const callback = vi.fn();
+
+      class Child extends State {
+        peer = get(Peer, callback);
+      }
+      class Parent extends State {
+        child = new Child();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+
+      expect(callback).toBeCalledTimes(1);
+      expect(callback).toBeCalledWith(parent.peer, parent.child);
+      expect(parent.child.peer).toBe(parent.peer);
+    });
+
+    it('will resolve siblings within explicit context', () => {
+      class Parent extends State {
+        child = new Required();
+        peer = new Peer();
+      }
+
+      const context = new Context(Parent);
+      const parent = context.get(Parent);
+
+      expect(parent.child.peer).toBe(parent.peer);
+      expect(context.get(Peer)).toBe(parent.peer);
+    });
+
+    it('will resolve through an activating grandparent', () => {
+      class Middle extends State {
+        child = new Required();
+      }
+      class Parent extends State {
+        middle = new Middle();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.middle.child.peer).toBe(parent.peer);
+    });
+
+    it('will throw if sibling never arrives', () => {
+      class Parent extends State {
+        child = new Required();
+        other = new Optional();
+      }
+
+      expect(() => Parent.new()).toThrow(
+        /Required Peer not found in context for Required-[\w-]+\./
+      );
+    });
+  });
+
   describe('subscription', () => {
     it('will update when implicit upstream is replaced', async () => {
       class Peer extends State {}

--- a/packages/mvc/src/field/get.ts
+++ b/packages/mvc/src/field/get.ts
@@ -1,4 +1,4 @@
-import { capture } from '../observable';
+import { capture, listener, observer } from '../observable';
 import { Context } from '../context';
 import { State, parent, update } from '../state';
 import { def } from './def';
@@ -121,8 +121,26 @@ function above<T extends State>(
       assign(state);
     }, false, subject);
 
-    if (!found && argument !== false)
-      throw new Error(`Required ${Type} not found in context for ${subject}.`);
+    if (!found && argument !== false) {
+      const missing = () =>
+        new Error(`Required ${Type} not found in context for ${subject}.`);
+
+      let activating: State | undefined;
+
+      for (
+        let p: State | null | undefined = hasParent;
+        p && !observer(p)!.ready;
+        p = parent(p)
+      )
+        activating = p;
+
+      if (!activating) throw missing();
+
+      listener(activating, () => {
+        if (!found) throw missing();
+        return null;
+      }, true);
+    }
 
     return {
       get: argument !== false,

--- a/packages/react/src/context.test.tsx
+++ b/packages/react/src/context.test.tsx
@@ -268,6 +268,36 @@ describe('Provider', () => {
     );
   });
 
+  it('will resolve siblings regardless of declaration order', () => {
+    const didRender = vi.fn();
+
+    class Peer extends State {}
+    class Child extends State {
+      peer = get(Peer);
+    }
+    class Parent extends State {
+      child = new Child();
+      peer = new Peer();
+    }
+
+    render(
+      <Provider for={Parent}>
+        <Consumer for={Parent}>
+          {(parent) => {
+            didRender(parent.child.peer.is, parent.peer.is);
+          }}
+        </Consumer>
+      </Provider>
+    );
+
+    expect(didRender).toBeCalledTimes(1);
+
+    const [peer, sibling] = didRender.mock.calls[0];
+
+    expect(peer).toBeInstanceOf(Peer);
+    expect(peer).toBe(sibling);
+  });
+
   it('will destroy created model on unmount', async () => {
     const willDestroy = vi.fn();
 

--- a/skills/field/get.md
+++ b/skills/field/get.md
@@ -104,6 +104,7 @@ type get.Callback<T> = (state: T, subject: State) => void | boolean | (() => voi
 
 - All `get()` properties are **non-enumerable** (hidden from `Object.keys()`, spread, and `ref(this)`).
 - Upstream lookups check direct parent first, then context hierarchy.
+- Siblings under one parent resolve regardless of field order - a required lookup waits for the parent to finish activating before throwing.
 - Will not resolve self as own instance.
 - Upstream callback is not reactive - it runs once per mount, not on value changes.
 - Downstream callbacks run cleanup before both target and recipient are destroyed.

--- a/skills/state/context.md
+++ b/skills/state/context.md
@@ -47,7 +47,7 @@ const ctx = new Context(Parent);
 ctx.get(Child); // child instance - registered in ctx, not root
 ```
 
-Recursive: grandchildren inherit through their immediate parent. Reassigning a child field destroys the old child (if owned via `new Child()` syntax) and adds the replacement to the same context. Externally-assigned children are not destroyed on replacement.
+Recursive: grandchildren inherit through their immediate parent. Siblings resolve each other through this context regardless of field order. Reassigning a child field destroys the old child (if owned via `new Child()` syntax) and adds the replacement to the same context. Externally-assigned children are not destroyed on replacement.
 
 ## Root Context
 

--- a/website/content/docs/api/instructions.mdx
+++ b/website/content/docs/api/instructions.mdx
@@ -224,6 +224,7 @@ form = get(FormState, true, false); // T | undefined
 
 - All `get()` properties are **non-enumerable** - hidden from `Object.keys()`, spread, and `ref(this)`.
 - Upstream lookups check the direct parent first, then walk the context hierarchy.
+- Siblings under one parent resolve each other regardless of field order - a required lookup waits for the parent to finish activating before throwing.
 - A state does not resolve itself.
 - Upstream callbacks are not reactive - they fire once per mount.
 - Downstream collections ignore redundant registrations of the same instance.


### PR DESCRIPTION
## Problem

A child's upstream `get(Type)` runs during that child's activation, before the parent has adopted fields declared after it. Two symptoms:

```ts
class B extends State { n = 1; }
class Req extends State { b = get(B); }
class Opt extends State { b = get(B, false); }

class P2 extends State { b = new B(); opt = new Opt(); }
class P3 extends State { req = new Req(); b = new B(); }

P2.new().opt.b   // undefined, never fills in
P3.new()         // throws "Required B not found in context for Req"
```

The context itself ends up correct (`new Context(P3).get(B)` finds it), so the lookup was simply running too early and never re-checking.

## Fix

Two small changes in `@expressive/mvc`:

- **`Context.add`** now notifies upstream consumers (`filter: false`) registered in the *same* context the state lands in. Previously only consumers in descendant contexts were told; same-context consumers were treated as downstream-only. This makes `get(B, false)` and `get(B, callback)` backfill when a later sibling arrives - the same subscription path the downstream collection form already used.
- **`get()` upstream, required form** defers its "not found" throw while an ancestor is still activating. It walks `parent()` up to the outermost not-ready ancestor and checks again on that ancestor's ready event. Nothing found by then still throws the same `Required X not found in context for Y.` error, from the same `Parent.new()` call. A required lookup on an already-active parent (child assigned later) still throws immediately.

## Tests

- `field/get.test.ts` - new `siblings` block: optional earlier/later, required later, callback later, under `new Context(Parent)`, through an activating grandparent, and the still-throws case.
- `context.test.ts` - same-context addition notifies an upstream consumer with `downstream: false`.
- `react/context.test.tsx` - siblings resolve under `<Provider for={Parent}>`.

All new resolution tests fail on `main`. Coverage gates hold at 100% for mvc and react.

## Docs

One line each in `skills/field/get.md`, `skills/state/context.md`, and the website `instructions.mdx` behavior notes.

## Out of scope, worth knowing

Children of a bare `Parent.new()` register into `Context.root`, where root's contest rule evicts same-type implicit entries. So a **second** `P1.new()` in the same process still throws - its `B` evicts the first parent's `B` and is itself not registered. That is existing root semantics, not this ordering bug, and fixing it means resolving siblings through the parent rather than the shared context. Worth a follow-up; not folded in here.
