### PR TITLE
fix(mvc): resolve upstream get() siblings through the parent, not the context

### DIFF
--- a/.changeset/sibling-get-parent-scope.md
+++ b/.changeset/sibling-get-parent-scope.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+Resolve upstream `get()` siblings through the parent rather than the shared context. Two `Parent.new()` instances in one process no longer cross-resolve each other's children through root, and a destroyed child's pending lookup is unregistered so a later `Parent.new()` does not throw.

--- a/packages/mvc/src/field/get.test.ts
+++ b/packages/mvc/src/field/get.test.ts
@@ -3,6 +3,7 @@ import { mockPromise } from '../../test.setup';
 import { Context } from '../context';
 import { State } from '../state';
 import { get } from './get';
+import { has } from './has';
 import { set } from './set';
 
 // is this desirable?
@@ -357,6 +358,123 @@ describe('fetch mode', () => {
       expect(() => Parent.new()).toThrow(
         /Required Peer not found in context for Required-[\w-]+\./
       );
+    });
+
+    it('will resolve within own parent when several exist', () => {
+      class Parent extends State {
+        child = new Required();
+        peer = new Peer();
+      }
+
+      const p1 = Parent.new();
+      const p2 = Parent.new();
+      const p3 = Parent.new();
+
+      expect(p1.child.peer).toBe(p1.peer);
+      expect(p2.child.peer).toBe(p2.peer);
+      expect(p3.child.peer).toBe(p3.peer);
+    });
+
+    it('will resolve own sibling declared earlier when another parent exists', () => {
+      class Parent extends State {
+        peer = new Peer();
+        child = new Required();
+      }
+
+      const p1 = Parent.new();
+      const p2 = Parent.new();
+
+      expect(p1.child.peer).toBe(p1.peer);
+      expect(p2.child.peer).toBe(p2.peer);
+    });
+
+    it('will not notify a destroyed child when a later parent activates', () => {
+      class Parent extends State {
+        child = new Required();
+        peer = new Peer();
+      }
+
+      const p1 = Parent.new();
+      p1.set(null);
+
+      const p2 = Parent.new();
+
+      expect(p2.child.peer).toBe(p2.peer);
+    });
+
+    it('will not notify a replaced child when sibling is reassigned', () => {
+      class Parent extends State {
+        child = new Optional();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+      const { child, peer } = parent;
+
+      parent.child = new Optional();
+      parent.peer = new Peer();
+
+      expect(child.peer).toBe(peer);
+      expect(parent.child.peer).toBe(parent.peer);
+    });
+
+    it('will prefer sibling over grandparent sibling', () => {
+      class Middle extends State {
+        child = new Required();
+        peer = new Peer();
+      }
+      class Parent extends State {
+        middle = new Middle();
+        peer = new Peer();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.middle.child.peer).toBe(parent.middle.peer);
+    });
+
+    it('will not resolve a sibling that was cleared', () => {
+      class Parent extends State {
+        peer: Peer | null = new Peer();
+        child?: Optional = undefined;
+      }
+
+      const parent = Parent.new();
+
+      parent.peer = null;
+      parent.child = new Optional();
+
+      expect(parent.child.peer).toBeUndefined();
+    });
+
+    it('will resolve through context for a pool member', () => {
+      class Theme extends State {}
+      class Item extends State {
+        theme = get(Theme);
+      }
+      class Store extends State {
+        items = has(Item);
+      }
+
+      const context = new Context({ Theme, Store });
+      const item = context.get(Store).items.add();
+
+      expect(item.theme).toBe(context.get(Theme));
+    });
+
+    it('will not resolve to itself', () => {
+      class Node extends State {
+        peer = get(Node, false);
+      }
+      class Parent extends State {
+        a = new Node();
+        b = new Node();
+      }
+
+      const parent = Parent.new();
+
+      expect(parent.a.peer).toBe(parent.b);
+      expect(parent.b.peer).toBe(parent.a);
     });
   });
 

--- a/packages/mvc/src/field/get.ts
+++ b/packages/mvc/src/field/get.ts
@@ -1,6 +1,6 @@
 import { capture, listener, observer } from '../observable';
 import { Context } from '../context';
-import { State, parent, update } from '../state';
+import { State, children, parent, STORE, update } from '../state';
 import { def } from './def';
 
 declare namespace get {
@@ -101,6 +101,8 @@ function above<T extends State>(
         : undefined;
 
     function assign(value: T) {
+      if (STORE.get(subject)![key] === value) return;
+
       if (callback) {
         const result = callback(value, subject);
         if (typeof result === 'function') subject.set(null, result);
@@ -113,13 +115,33 @@ function above<T extends State>(
       return {};
     }
 
-    const ctx = Context.get(subject);
     let found = false;
+    let depth = Infinity;
+    let level = 0;
 
-    ctx.get(Type, (state) => {
-      found = true;
-      assign(state);
-    }, false, subject);
+    for (let p: State | null | undefined = hasParent; p; p = parent(p), level++) {
+      const at = level;
+
+      const remove = children(p, (child) => {
+        if (child !== subject && child instanceof Type && at <= depth) {
+          found = true;
+          depth = at;
+          assign(child as T);
+        }
+      });
+
+      subject.set(null, () => { remove(); });
+    }
+
+    if (!found) {
+      const remove = Context.get(subject).get(Type, (state) => {
+        if (depth !== Infinity) return;
+        found = true;
+        assign(state);
+      }, false, subject) as () => void;
+
+      subject.set(null, () => { remove(); });
+    }
 
     if (!found && argument !== false) {
       const missing = () =>

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -45,6 +45,7 @@ let QUEUED = false;
 
 /** Adopters for managed properties which have held a child State. */
 const ADOPT = new WeakMap<State, Map<unknown, (value: unknown) => void>>();
+const CHILDREN = new WeakMap<State, Set<(child: State) => void>>();
 
 declare namespace State {
   /** Any type of State, using own class constructor as its identifier. */
@@ -849,7 +850,32 @@ function child(state: State) {
     }
 
     event(value);
+
+    CHILDREN.get(state)?.forEach((cb) => cb(value));
   };
+}
+
+/**
+ * Report States adopted by a parent - those already held, then each one
+ * claimed later. Returns a callback to stop watching.
+ */
+function children(state: State, callback: (child: State) => void) {
+  const store = STORE.get(state)!;
+  const keys = ADOPT.get(state);
+
+  if (keys)
+    for (const key of keys.keys()) {
+      const value = store[key as string];
+      if (value instanceof State) callback(value);
+    }
+
+  let set = CHILDREN.get(state);
+
+  if (!set) CHILDREN.set(state, (set = new Set()));
+
+  set.add(callback);
+
+  return () => set!.delete(callback);
 }
 
 /** Currently accumulating export. Stores real values of placeholder properties such as ref() or child states. */
@@ -1033,4 +1059,4 @@ function parent(child: object, value?: State | null) {
   return true;
 }
 
-export { event, unbind, State, parent, PENDING, STORE, uid, access, update, apply, compute };
+export { event, unbind, State, parent, children, PENDING, STORE, uid, access, update, apply, compute };

--- a/skills/field/get.md
+++ b/skills/field/get.md
@@ -103,7 +103,7 @@ type get.Callback<T> = (state: T, subject: State) => void | boolean | (() => voi
 ## Behavior
 
 - All `get()` properties are **non-enumerable** (hidden from `Object.keys()`, spread, and `ref(this)`).
-- Upstream lookups check direct parent first, then context hierarchy.
+- Upstream lookups check direct parent first, then siblings under each ancestor (nearest wins), then context hierarchy.
 - Siblings under one parent resolve regardless of field order - a required lookup waits for the parent to finish activating before throwing.
 - Will not resolve self as own instance.
 - Upstream callback is not reactive - it runs once per mount, not on value changes.

--- a/skills/state/context.md
+++ b/skills/state/context.md
@@ -47,7 +47,7 @@ const ctx = new Context(Parent);
 ctx.get(Child); // child instance - registered in ctx, not root
 ```
 
-Recursive: grandchildren inherit through their immediate parent. Siblings resolve each other through this context regardless of field order. Reassigning a child field destroys the old child (if owned via `new Child()` syntax) and adds the replacement to the same context. Externally-assigned children are not destroyed on replacement.
+Recursive: grandchildren inherit through their immediate parent. Siblings resolve each other through their parent regardless of field order, so two parents never cross-resolve. Reassigning a child field destroys the old child (if owned via `new Child()` syntax) and adds the replacement to the same context. Externally-assigned children are not destroyed on replacement.
 
 ## Root Context
 

--- a/website/content/docs/api/instructions.mdx
+++ b/website/content/docs/api/instructions.mdx
@@ -223,7 +223,7 @@ form = get(FormState, true, false); // T | undefined
 ### Behavior notes
 
 - All `get()` properties are **non-enumerable** - hidden from `Object.keys()`, spread, and `ref(this)`.
-- Upstream lookups check the direct parent first, then walk the context hierarchy.
+- Upstream lookups check the direct parent first, then siblings under each ancestor (nearest wins), then walk the context hierarchy.
 - Siblings under one parent resolve each other regardless of field order - a required lookup waits for the parent to finish activating before throwing.
 - A state does not resolve itself.
 - Upstream callbacks are not reactive - they fire once per mount.


### PR DESCRIPTION
## Problem

Reported from downstream (agent-focus, `@expressive/mvc` 0.84.0):

```ts
class B extends State { n = 1 }
class A extends State { b = get(B) }
class P extends State { a = new A(); b = new B() }

const p1 = P.new(); const p2 = P.new();
p2.a.b === p2.b // false - resolved p1.b

const p3 = P.new(); p3.set(null);
const p4 = P.new(); // throws: Tried to update A-xxxx.b but state is destroyed.
```

Two defects, both remaining after #335:

- Children of a bare `Parent.new()` register into `Context.root`, whose contest rule evicts same-type implicit entries. A second parent's child either found the first parent's sibling (still registered) or nothing at all (both evicted), so it cross-resolved or threw.
- The upstream consumer a child's `get()` registered in context was never removed when the child was destroyed. The next parent's sibling notified the dead child, which threw, and the stale registration made every later `Parent.new()` in the process throw too.

## Fix

- `above()` in `field/get.ts` now scans each ancestor's adopted children first (nearest ancestor wins) and watches each ancestor for later adoptions via a new internal `children()` helper in `state.ts`. Context is consulted only if no sibling was found, and a context notification no longer overrides a value that came from a sibling.
- Both the ancestor watchers and the context consumer are unregistered on the subject's destroy.
- `assign()` skips re-notification of the same instance, so a sibling reported by both the parent and the same-context notification from #335 runs the callback form once.

Not changed: `has()`/`map()` pool members still resolve their `get()` through context as before. A parent whose only children are pool members has no adopted-children map, which is covered by a test.

## Tests

Added under `siblings` in `field/get.test.ts`: several live parents, earlier-declared sibling with another parent present, destroyed child then new parent, replaced child then reassigned sibling, nearer sibling preferred over grandparent's, self exclusion, cleared sibling, pool member via context. Five of these fail on `main`. mvc coverage stays at 100%; full workspace suite passes.

## Docs

`skills/state/context.md`, `skills/field/get.md`, and the instructions page now say siblings resolve through their parent, then context. Changeset: patch for `@expressive/mvc`.
