### PR TITLE
fix(mvc): do not warn for a base child a subclass initializer overwrote

### DIFF
--- a/.changeset/subclass-orphan-child.md
+++ b/.changeset/subclass-orphan-child.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+A child State constructed by a base-class field initializer and overwritten by a subclass initializer no longer warns that it was constructed but never activated. Activation drops pending States constructed between a parent and the last child it adopted.

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -3849,6 +3849,70 @@ describe('activation', () => {
     expect(warn).not.toBeCalled();
   });
 
+  it('will not warn for base child a subclass overwrote', async () => {
+    class Child extends State {
+      value = 1;
+    }
+
+    class Base extends State {
+      child = new Child();
+    }
+
+    class Sub extends Base {
+      child = new Child();
+    }
+
+    const sub = Sub.new();
+
+    await flushMicrotasks();
+
+    expect(sub.child).toBeInstanceOf(Child);
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will not warn for overwritten child of an adopted child', async () => {
+    class Leaf extends State {}
+
+    class Base extends State {
+      leaf = new Leaf();
+    }
+
+    class Sub extends Base {
+      leaf = new Leaf();
+    }
+
+    class Parent extends State {
+      child = new Sub();
+    }
+
+    Parent.new();
+
+    await flushMicrotasks();
+
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will still warn for unrelated state constructed alongside', async () => {
+    class Child extends State {}
+    class Other extends State {}
+
+    class Parent extends State {
+      child = new Child();
+    }
+
+    const parent = new Parent();
+    const other = new Other();
+
+    event(parent);
+
+    await flushMicrotasks();
+
+    expect(warn).toBeCalledTimes(1);
+    expect(warn).toBeCalledWith(
+      `${other} was constructed but never activated.`
+    );
+  });
+
   it('will not warn if placed in a context', async () => {
     class Test extends State {
       value = 1;

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -46,8 +46,6 @@ let QUEUED = false;
 /** Adopters for managed properties which have held a child State. */
 const ADOPT = new WeakMap<State, Map<unknown, (value: unknown) => void>>();
 const CHILDREN = new WeakMap<State, Set<(child: State) => void>>();
-const ORDER = new WeakMap<State, number>();
-let SERIAL = 0;
 
 declare namespace State {
   /** Any type of State, using own class constructor as its identifier. */
@@ -526,7 +524,6 @@ function init(state: State, ...args: State.Args) {
 
   ID.set(state, `${T}-${uid()}`);
   STORE.set(state, {});
-  ORDER.set(state, ++SERIAL);
 
   function observe() {
     for (const key in state) {
@@ -553,6 +550,8 @@ function init(state: State, ...args: State.Args) {
   }
 
   listener(state, (key) => {
+    const rest = queued(state);
+
     PENDING.delete(state);
 
     if (key === null) return null;
@@ -579,7 +578,11 @@ function init(state: State, ...args: State.Args) {
       }
     });
 
-    orphans(state);
+    let end = rest.length;
+
+    while (end-- > 0 && PENDING.has(rest[end]));
+
+    for (let i = 0; i < end; i++) PENDING.delete(rest[i]);
 
     return null;
   });
@@ -861,23 +864,18 @@ function child(state: State) {
 }
 
 /**
- * Drop pending States constructed between a parent and the latest State it
- * holds - initializers a subclass overwrote before activation.
+ * Pending States constructed after this one - in a parent, the products of
+ * its own initializers, until the last one it kept.
  */
-function orphans(state: State) {
-  const own = ORDER.get(state)!;
-  const store = STORE.get(state)!;
-  let last = own;
+function queued(state: State) {
+  const rest: State[] = [];
+  let seen = false;
 
-  for (const key in store) {
-    const value = store[key];
-    if (value instanceof State) last = Math.max(last, ORDER.get(value)!);
-  }
+  for (const item of PENDING)
+    if (!seen) seen = item === state;
+    else if (item instanceof State) rest.push(item);
 
-  for (const item of PENDING) {
-    const at = item instanceof State ? ORDER.get(item)! : 0;
-    if (at > own && at < last) PENDING.delete(item);
-  }
+  return rest;
 }
 
 /**

--- a/packages/mvc/src/state.ts
+++ b/packages/mvc/src/state.ts
@@ -46,6 +46,8 @@ let QUEUED = false;
 /** Adopters for managed properties which have held a child State. */
 const ADOPT = new WeakMap<State, Map<unknown, (value: unknown) => void>>();
 const CHILDREN = new WeakMap<State, Set<(child: State) => void>>();
+const ORDER = new WeakMap<State, number>();
+let SERIAL = 0;
 
 declare namespace State {
   /** Any type of State, using own class constructor as its identifier. */
@@ -524,6 +526,7 @@ function init(state: State, ...args: State.Args) {
 
   ID.set(state, `${T}-${uid()}`);
   STORE.set(state, {});
+  ORDER.set(state, ++SERIAL);
 
   function observe() {
     for (const key in state) {
@@ -575,6 +578,8 @@ function init(state: State, ...args: State.Args) {
         else if (typeof out == 'object') assign(state, out, true);
       }
     });
+
+    orphans(state);
 
     return null;
   });
@@ -853,6 +858,26 @@ function child(state: State) {
 
     CHILDREN.get(state)?.forEach((cb) => cb(value));
   };
+}
+
+/**
+ * Drop pending States constructed between a parent and the latest State it
+ * holds - initializers a subclass overwrote before activation.
+ */
+function orphans(state: State) {
+  const own = ORDER.get(state)!;
+  const store = STORE.get(state)!;
+  let last = own;
+
+  for (const key in store) {
+    const value = store[key];
+    if (value instanceof State) last = Math.max(last, ORDER.get(value)!);
+  }
+
+  for (const item of PENDING) {
+    const at = item instanceof State ? ORDER.get(item)! : 0;
+    if (at > own && at < last) PENDING.delete(item);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #339

## Problem

```ts
class Pairing extends State { session = new Session(); }
class HostPairing extends Pairing { session = new HostSession(); }
HostPairing.new();
// warn: Session-xxxx was constructed but never activated.
```

JS runs both initializers. The base `Session` is constructed, replaced by `HostSession` in the same tick, and never adopted. Since #330 the tick deadline warns about it. Still present on 0.84.1 with #336 applied - that PR fixed cross-parent resolution, not this.

## Fix

The pending set is insertion-ordered, so the States constructed after a parent are the entries that follow it. Before a parent activates it snapshots those entries; after activation it drops every one that precedes the last entry that activated. Initializers run synchronously inside the parent's construction, so everything in that window came from them, and anything still pending there was overwritten.

The window is bounded on both sides, so a State constructed *alongside* the parent in the same tick (`new Parent(); new Other(); event(parent)`) sits after the last activated child and still warns. Nested overwrites resolve the same way at each level, since each adopted child prunes its own window when it activates.

No new module state: the pending set already carried the order.

## Tests

Under `activation` in `state.test.ts`: the issue's scenario, the same overwrite one level down inside an adopted child, and an unrelated same-tick State that must still warn. The first two fail on `main`. Coverage stays at 100%; full workspace suite passes.

Changeset: patch for `@expressive/mvc`.