### PR TITLE
test(mvc): cover get() resolving a sibling a subclass initializer replaced

### DIFF
--- a/packages/mvc/src/field/get.test.ts
+++ b/packages/mvc/src/field/get.test.ts
@@ -476,6 +476,39 @@ describe('fetch mode', () => {
       expect(parent.a.peer).toBe(parent.b);
       expect(parent.b.peer).toBe(parent.a);
     });
+
+    it('will resolve a sibling a subclass initializer replaced', () => {
+      class Workspace extends State {
+        git = 'host';
+      }
+      class HarnessWorkspace extends Workspace {
+        git = 'harness';
+      }
+      class Session extends State {
+        workspace = get(Workspace);
+      }
+      class HarnessSession extends Session {}
+      class Pairing extends State {
+        session = new Session();
+        workspace = new Workspace();
+      }
+      class HarnessPairing extends Pairing {
+        session = new HarnessSession();
+        workspace = new HarnessWorkspace();
+      }
+
+      const p1 = HarnessPairing.new();
+      const p2 = HarnessPairing.new();
+
+      p1.set(null);
+
+      const p3 = HarnessPairing.new();
+
+      for (const p of [p2, p3]) {
+        expect(p.session.workspace).toBe(p.workspace);
+        expect(p.session.workspace.git).toBe('harness');
+      }
+    });
   });
 
   it('will not register upstream into own context', () => {


### PR DESCRIPTION
Closes #342

## Finding

The scenario in #342 does not reproduce on `main` (0.84.2). Upstream `get()` binds at the subject's activation, not its construction, and a child activates only when its parent adopts it after the most-derived constructor has finished. By then the parent's store already holds the subclass instance, so the overwritten base child is never seen by any sibling.

Verified three ways:

- The issue's snippet, in both field orders, with a second live parent and after destroying one - `p.session.workspace` is the `HarnessWorkspace` on `p.workspace` every time.
- agent-concentrate at the pre-workaround commit (#133 reverse-applied, `restart.test.ts` rewritten back to field initializers) against a build of `main`: no `never activated` warnings, no `Open a folder first`, 7 of 8 restart tests pass.
- Every `get()` on the harness pairing's session, workspace and review children resolves to its own sibling across three sequential `Room`s with one destroyed in between.

The one failing restart test (`the running chat parked behind another tab is still running`) times out identically on exact 0.84.0 with the consumer's own `parts()` shape, so it is unrelated to mvc's version or to how children are declared.

The report's mechanism - `get()` binding the base child before the subclass overwrites it - matches 0.84.0/0.84.1 symptoms through root-context cross-talk (#335, #336) plus the orphan warning (#340), all of which shipped in 0.84.2.

## Change

One test under `siblings` in `field/get.test.ts` pinning the scenario: subclass redeclares both the consumer and the sibling it looks up, checked across a live second parent and after a destroyed one. Passes on `main`; kept as a regression guard. No changeset.