### PR TITLE
fix(mvc): do not warn for a base child a subclass instruction replaced

### DIFF
--- a/.changeset/orphan-instruction-overwrite.md
+++ b/.changeset/orphan-instruction-overwrite.md
@@ -1,0 +1,5 @@
+---
+"@expressive/mvc": patch
+---
+
+A child State a base-class initializer constructed no longer warns that it was never activated when a subclass initializer replaces it with an instruction (`get`, `ref`, `set`). An instruction records the States pending when it was created; applying it drops those constructed after its owner, which came from the owner's own initializers.

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -19,6 +19,7 @@ declare namespace def {
 }
 
 const APPLY = new Map<symbol, def.Factory | null>();
+const TRACE = new Map<symbol, State[]>();
 const RESET = () => APPLY.clear();
 
 function def<T>(arg1: def.Factory<T>) {
@@ -32,6 +33,7 @@ function def<T>(arg1: def.Factory<T>) {
   const token = Symbol('field-' + uid());
 
   APPLY.set(token, arg1);
+  TRACE.set(token, [...PENDING].filter((x) => x instanceof State) as State[]);
 
   return token as T extends void ? unknown : T;
 }
@@ -51,6 +53,7 @@ State.on((self) => {
     if (!instruction) continue;
 
     APPLY.set(property.value, null);
+    discard(self, property.value);
     delete (self as any)[key];
 
     const output = instruction.call(self, key, self, store);
@@ -64,5 +67,19 @@ State.on((self) => {
     apply(self, key, desc, true);
   }
 });
+
+/**
+ * Drop pending States constructed after `self` and before the instruction -
+ * products of its own initializers, discarded when this token replaced them.
+ */
+function discard(self: State, token: symbol) {
+  let seen = false;
+
+  for (const item of TRACE.get(token)!)
+    if (!seen) seen = item === self;
+    else PENDING.delete(item);
+
+  TRACE.delete(token);
+}
 
 export { def };

--- a/packages/mvc/src/field/def.ts
+++ b/packages/mvc/src/field/def.ts
@@ -18,8 +18,7 @@ declare namespace def {
   }
 }
 
-const APPLY = new Map<symbol, def.Factory | null>();
-const TRACE = new Map<symbol, State[]>();
+const APPLY = new Map<symbol, [def.Factory, State[]] | null>();
 const RESET = () => APPLY.clear();
 
 function def<T>(arg1: def.Factory<T>) {
@@ -32,8 +31,7 @@ function def<T>(arg1: def.Factory<T>) {
 
   const token = Symbol('field-' + uid());
 
-  APPLY.set(token, arg1);
-  TRACE.set(token, [...PENDING].filter((x) => x instanceof State) as State[]);
+  APPLY.set(token, [arg1, [...PENDING].filter((x) => x instanceof State) as State[]]);
 
   return token as T extends void ? unknown : T;
 }
@@ -43,17 +41,19 @@ State.on((self) => {
 
   for (const key in self) {
     const property: PropertyDescriptor = Object.getOwnPropertyDescriptor(self, key) || {};
-    const instruction = APPLY.get(property.value);
+    const entry = APPLY.get(property.value);
 
-    if (instruction === null)
+    if (entry === null)
       throw new Error(
         `${self}.${key} has an instruction applied to another State.`
       );
 
-    if (!instruction) continue;
+    if (!entry) continue;
+
+    const [instruction, pending] = entry;
 
     APPLY.set(property.value, null);
-    discard(self, property.value);
+    discard(self, pending);
     delete (self as any)[key];
 
     const output = instruction.call(self, key, self, store);
@@ -72,14 +72,12 @@ State.on((self) => {
  * Drop pending States constructed after `self` and before the instruction -
  * products of its own initializers, discarded when this token replaced them.
  */
-function discard(self: State, token: symbol) {
+function discard(self: State, pending: State[]) {
   let seen = false;
 
-  for (const item of TRACE.get(token)!)
+  for (const item of pending)
     if (!seen) seen = item === self;
     else PENDING.delete(item);
-
-  TRACE.delete(token);
 }
 
 export { def };

--- a/packages/mvc/src/state.test.ts
+++ b/packages/mvc/src/state.test.ts
@@ -3870,6 +3870,51 @@ describe('activation', () => {
     expect(warn).not.toBeCalled();
   });
 
+  it('will not warn for a child a subclass instruction replaced', async () => {
+    class Child extends State {}
+
+    class Base extends State {
+      child = new Child();
+    }
+
+    class Sub extends Base {
+      child = get(Child) as any;
+    }
+
+    class Root extends State {
+      child = new Child();
+      sub = new Sub();
+    }
+
+    const root = Root.new();
+
+    await flushMicrotasks();
+
+    expect(root.sub.child).toBe(root.child);
+    expect(warn).not.toBeCalled();
+  });
+
+  it('will not warn for a child replaced by ref or set', async () => {
+    class Child extends State {}
+
+    class Base extends State {
+      a = new Child();
+      b = new Child();
+    }
+
+    class Sub extends Base {
+      a = ref<Child>() as any;
+      b = set(() => new Child());
+    }
+
+    const sub = Sub.new();
+
+    await flushMicrotasks();
+
+    expect(sub.b).toBeInstanceOf(Child);
+    expect(warn).not.toBeCalled();
+  });
+
   it('will not warn for overwritten child of an adopted child', async () => {
     class Leaf extends State {}
 


### PR DESCRIPTION
## Problem

#340 stopped the "constructed but never activated" warning for a base-class child a subclass initializer overwrote with another State. The activation window it added is anchored on the last State the parent adopted. When the subclass replaces the child with an instruction instead - `child = get(Child)`, `ref()`, `set(() => ...)` - nothing later is adopted, the window has no anchor, and the discarded base instance still warns.

Probed on `origin/main`:

| Base `child = new Child()`, subclass ... | warns |
|---|---|
| `child = new Child()` | no (#340) |
| `child = get(Child)` | yes |
| `child = ref()` | yes |
| `child = set(() => new Child())` | yes |

## Fix

An instruction's `def()` call runs mid-initializer, so every State pending after the subject at that moment came from the subject's own initializer chain. `def()` now snapshots the pending States when it creates a token. When the token is applied on a State at activation, the snapshot entries that follow that State are dropped from pending - they were constructed inside its chain and this instruction replaced them.

Dropping early is harmless for a child that is later adopted: adoption removes it from pending anyway. The #340 window stays for the State-replaces-State case, which has no instruction to observe.

Not covered: a subclass replacing a child with `null` or a non-State value. There is no hook to observe and the base field should be declared optional instead.

## Tests

- `will not warn for a child a subclass instruction replaced` - `get()` replacement, also asserts the sibling resolves through the root.
- `will not warn for a child replaced by ref or set`.

Both fail on `main`. Full suite green at 100% coverage in every package.